### PR TITLE
Refactor Tahap 5: Login Blade dan Boundary OTP

### DIFF
--- a/issue/issue-refactor-login-blade-laravel.md
+++ b/issue/issue-refactor-login-blade-laravel.md
@@ -1,0 +1,90 @@
+# Issue Plan: Refactor Bertahap Prioritas 4 - Optimasi Login Blade Laravel
+
+## Latar Belakang
+Area auth Laravel masih menyisakan satu file view yang terlalu padat, yaitu [`login.blade.php`](</Users/macbookair/Magang-Istana/laravel/resources/views/livewire/pages/auth/login.blade.php:19>) dengan ukuran sekitar 583 baris. File ini bukan hanya template login, tetapi juga memegang class Volt, orkestrasi login, register, forgot password, pending registration berbasis cache, rate limit OTP, verifikasi OTP, modal OTP, dan shell UI auth dalam satu tempat.
+
+Sebagian struktur memang sudah mulai dipisah ke partial seperti [`login-form.blade.php`](</Users/macbookair/Magang-Istana/laravel/resources/views/livewire/pages/auth/partials/login-form.blade.php:1>), [`register-form.blade.php`](</Users/macbookair/Magang-Istana/laravel/resources/views/livewire/pages/auth/partials/register-form.blade.php:1>), dan [`forgot-password-form.blade.php`](</Users/macbookair/Magang-Istana/laravel/resources/views/livewire/pages/auth/partials/forgot-password-form.blade.php:1>). Namun concern terbesar masih terkumpul di page Volt utama. Akibatnya, perubahan kecil di auth berisiko menyentuh banyak area sekaligus dan memperbesar biaya review, debugging, serta pengembangan lanjutan.
+
+Prioritas refactor ini perlu dibatasi dengan ketat: merapikan boundary dan memecah concern `login.blade.php` tanpa mengubah route, UX auth, atau perilaku OTP yang sudah berjalan.
+
+## Tujuan
+- Mengurangi kepadatan `login.blade.php` dengan memecah concern yang saat ini menumpuk di satu file.
+- Memisahkan tanggung jawab antara shell UI auth, flow state page, dan orkestrasi OTP/pending registration.
+- Menjaga perilaku user-facing tetap sama untuk login, register, forgot password, resend OTP, cancel OTP, dan verify OTP.
+- Memperjelas boundary agar perubahan auth berikutnya tidak harus mengedit satu file besar yang sensitif.
+- Menambah atau menyesuaikan test pada flow auth yang paling rawan regresi.
+
+## Ruang Lingkup
+- Mempertahankan route auth yang ada, terutama [`/login`](</Users/macbookair/Magang-Istana/laravel/routes/auth.php:11>) yang mengarah ke `pages.auth.login`.
+- Merapikan `pages.auth.login` agar tidak lagi menjadi gabungan class Volt + orchestration OTP + modal + shell UI dalam satu file besar.
+- Mengekstrak bagian visual/presentasional yang masih besar dari [`login.blade.php`](</Users/macbookair/Magang-Istana/laravel/resources/views/livewire/pages/auth/login.blade.php:415>) ke partial yang lebih fokus.
+- Mengekstrak atau memindahkan helper/orchestration pending registration dan OTP dari page Volt ke boundary yang lebih jelas bila diperlukan, misalnya helper/service/trait/action yang tetap kompatibel dengan Volt.
+- Menjaga integrasi dengan [`LoginForm`](</Users/macbookair/Magang-Istana/laravel/app/Livewire/Forms/LoginForm.php:1>) dan mail [`VerificationCodeMail`](</Users/macbookair/Magang-Istana/laravel/app/Mail/VerificationCodeMail.php:1>) tetap stabil.
+- Menambah atau memperluas test Laravel untuk flow auth yang disentuh refactor.
+
+## Di Luar Scope
+- Mendesain ulang tampilan halaman login atau mengganti visual direction auth.
+- Mengubah copy UX auth secara besar-besaran.
+- Mengubah route auth, redirect utama, atau middleware guest/auth.
+- Mengganti mekanisme OTP, cache key, TTL, rate limit policy, atau strategi verifikasi email.
+- Mengubah schema database user atau auth.
+- Merombak halaman auth lain seperti `reset-password`, `verify-email`, atau `confirm-password` di tahap ini kecuali ada penyesuaian kecil yang benar-benar dibutuhkan.
+
+## Area / File Terkait
+- Page Volt utama:
+  - [`/Users/macbookair/Magang-Istana/laravel/resources/views/livewire/pages/auth/login.blade.php`](/Users/macbookair/Magang-Istana/laravel/resources/views/livewire/pages/auth/login.blade.php)
+- Partial yang sudah ada:
+  - [`/Users/macbookair/Magang-Istana/laravel/resources/views/livewire/pages/auth/partials/login-form.blade.php`](/Users/macbookair/Magang-Istana/laravel/resources/views/livewire/pages/auth/partials/login-form.blade.php)
+  - [`/Users/macbookair/Magang-Istana/laravel/resources/views/livewire/pages/auth/partials/register-form.blade.php`](/Users/macbookair/Magang-Istana/laravel/resources/views/livewire/pages/auth/partials/register-form.blade.php)
+  - [`/Users/macbookair/Magang-Istana/laravel/resources/views/livewire/pages/auth/partials/forgot-password-form.blade.php`](/Users/macbookair/Magang-Istana/laravel/resources/views/livewire/pages/auth/partials/forgot-password-form.blade.php)
+- Boundary auth pendukung:
+  - [`/Users/macbookair/Magang-Istana/laravel/app/Livewire/Forms/LoginForm.php`](/Users/macbookair/Magang-Istana/laravel/app/Livewire/Forms/LoginForm.php)
+  - [`/Users/macbookair/Magang-Istana/laravel/app/Mail/VerificationCodeMail.php`](/Users/macbookair/Magang-Istana/laravel/app/Mail/VerificationCodeMail.php)
+  - [`/Users/macbookair/Magang-Istana/laravel/routes/auth.php`](/Users/macbookair/Magang-Istana/laravel/routes/auth.php)
+- Test yang relevan:
+  - [`/Users/macbookair/Magang-Istana/laravel/tests/Feature/Auth/AuthenticationTest.php`](/Users/macbookair/Magang-Istana/laravel/tests/Feature/Auth/AuthenticationTest.php)
+  - [`/Users/macbookair/Magang-Istana/laravel/tests/Feature/Auth/RegistrationTest.php`](/Users/macbookair/Magang-Istana/laravel/tests/Feature/Auth/RegistrationTest.php)
+  - [`/Users/macbookair/Magang-Istana/laravel/tests/Feature/Auth/PasswordResetTest.php`](/Users/macbookair/Magang-Istana/laravel/tests/Feature/Auth/PasswordResetTest.php)
+
+## Risiko
+- Auth adalah area user-facing dan kritikal; regresi kecil bisa memutus login atau registrasi.
+- Karena `pages.auth.login` saat ini memegang beberapa mode view sekaligus (`login`, `register`, `forgot-password`, modal OTP), pemecahan yang tidak hati-hati bisa menimbulkan kebocoran state antar-mode.
+- Orkestrasi OTP saat ini bergantung pada cache key, TTL, rate limiting, dan email side effect; boundary baru harus menjaga perilaku ini tetap identik.
+- Refactor yang terlalu agresif berisiko berubah dari perapihan struktur menjadi redesign auth, padahal itu bukan tujuan issue ini.
+
+## Langkah Implementasi
+1. Tetapkan boundary refactor untuk page login.
+   - Putuskan concern mana yang tetap berada di page Volt, dan mana yang dipindah ke partial/helper/service.
+   - Jaga agar entry point `pages.auth.login` tetap menjadi pintu masuk route yang sama.
+2. Pisahkan shell UI auth dari logic yang berat.
+   - Keluarkan blok presentasional besar seperti wrapper page, branding, footer, dan modal OTP ke partial yang lebih fokus.
+   - Tujuannya agar file utama lebih berperan sebagai composer, bukan file template raksasa.
+3. Rapikan orchestration state auth.
+   - Kurangi helper pendukung yang sekarang menumpuk di satu class Volt, terutama pending registration key, OTP resend/verify/cancel, dan state reset antar-view.
+   - Jika perlu, pindahkan logic yang bukan tanggung jawab view ke helper/service/action yang jelas dan tetap mudah dipanggil dari Volt.
+4. Jaga flow auth tetap identik.
+   - Login tetap melalui [`LoginForm`](</Users/macbookair/Magang-Istana/laravel/app/Livewire/Forms/LoginForm.php:1>).
+   - Register tetap masuk ke fase verifikasi OTP sebelum membuat akun aktif.
+   - Forgot password, resend OTP, cancel verification, dan verify OTP tetap berperilaku sama seperti sebelum refactor.
+5. Tambahkan safety net test bila ada gap.
+   - Prioritaskan test yang mengunci flow auth kritikal daripada test struktur file.
+
+## Rencana Test
+- Jalankan full test Laravel:
+  - `cd laravel && php artisan test`
+- Pastikan suite auth tetap hijau, terutama:
+  - render login screen
+  - login sukses dan gagal
+  - register membuka fase OTP tanpa langsung membuat akun aktif
+  - OTP valid menyelesaikan registrasi dan login
+  - cancel verification menjaga email tetap reusable
+  - rate limit OTP verify dan resend tetap berjalan
+  - forgot password flow tetap bekerja
+- Tambahkan test baru hanya jika refactor membuka gap yang belum tercakup pada `AuthenticationTest`, `RegistrationTest`, atau `PasswordResetTest`.
+
+## Kriteria Selesai
+- `login.blade.php` jauh lebih ringan dan tidak lagi menjadi titik kumpul utama semua concern auth.
+- Shell UI auth, modal OTP, dan orchestration pendukung punya boundary yang lebih jelas.
+- Route dan UX user-facing tetap sama.
+- Flow login/register/forgot-password/OTP tetap berjalan tanpa perubahan perilaku yang tidak direncanakan.
+- Test Laravel yang relevan sudah dijalankan, dan test tambahan dibuat bila memang diperlukan untuk menjaga perilaku yang disentuh.

--- a/laravel/app/Services/Auth/PendingRegistrationService.php
+++ b/laravel/app/Services/Auth/PendingRegistrationService.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Services\Auth;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
+
+class PendingRegistrationService
+{
+    public function pendingRegistrationKey(string $token): string
+    {
+        return 'pending_registration:'.$token;
+    }
+
+    public function pendingRegistrationEmailKey(string $email): string
+    {
+        return 'pending_registration_email:'.Str::lower($email);
+    }
+
+    public function otpRateLimitKey(string $token, string $ipAddress): string
+    {
+        return 'otp_registration:'.$token.'|'.$ipAddress;
+    }
+
+    public function otpResendRateLimitKey(string $token, string $ipAddress): string
+    {
+        return 'otp_registration_resend:'.$token.'|'.$ipAddress;
+    }
+
+    public function pendingRegistrationTtlMinutes(): int
+    {
+        return max(1, (int) config('auth.otp_registration.ttl_minutes', 60));
+    }
+
+    public function otpMaxAttempts(): int
+    {
+        return max(1, (int) config('auth.otp_registration.max_attempts', 3));
+    }
+
+    public function otpDecaySeconds(): int
+    {
+        return max(1, (int) config('auth.otp_registration.decay_seconds', 600));
+    }
+
+    public function otpResendCooldownSeconds(): int
+    {
+        return max(1, (int) config('auth.otp_registration.resend_cooldown_seconds', 60));
+    }
+
+    public function pendingTokenByEmail(string $email): ?string
+    {
+        $token = Cache::get($this->pendingRegistrationEmailKey($email));
+
+        return is_string($token) && $token !== '' ? $token : null;
+    }
+
+    public function getPendingRegistration(string $token): ?array
+    {
+        $pending = Cache::get($this->pendingRegistrationKey($token));
+
+        return is_array($pending) ? $pending : null;
+    }
+
+    public function createPendingRegistration(string $name, string $email, string $hashedPassword): array
+    {
+        $plainCode = sprintf('%06d', random_int(0, 999999));
+        $pendingToken = (string) Str::uuid();
+
+        $this->storePendingRegistration($pendingToken, [
+            'name' => $name,
+            'email' => Str::lower($email),
+            'password' => $hashedPassword,
+            'code_hash' => hash('sha256', $plainCode),
+        ]);
+
+        return [$pendingToken, $plainCode];
+    }
+
+    public function storePendingRegistration(string $token, array $payload): void
+    {
+        $ttlMinutes = $this->pendingRegistrationTtlMinutes();
+        $email = Str::lower((string) ($payload['email'] ?? ''));
+
+        Cache::put($this->pendingRegistrationKey($token), [
+            'name' => (string) ($payload['name'] ?? ''),
+            'email' => $email,
+            'password' => (string) ($payload['password'] ?? ''),
+            'code_hash' => (string) ($payload['code_hash'] ?? ''),
+            'expires_at' => now()->addMinutes($ttlMinutes)->getTimestamp(),
+        ], now()->addMinutes($ttlMinutes));
+
+        Cache::put(
+            $this->pendingRegistrationEmailKey($email),
+            $token,
+            now()->addMinutes($ttlMinutes)
+        );
+    }
+
+    public function clearPendingRegistration(?string $token = null, ?string $email = null, ?string $ipAddress = null): void
+    {
+        if ($token) {
+            Cache::forget($this->pendingRegistrationKey($token));
+
+            if ($ipAddress) {
+                RateLimiter::clear($this->otpRateLimitKey($token, $ipAddress));
+                RateLimiter::clear($this->otpResendRateLimitKey($token, $ipAddress));
+            }
+        }
+
+        if ($email) {
+            Cache::forget($this->pendingRegistrationEmailKey($email));
+        }
+    }
+}

--- a/laravel/resources/views/livewire/pages/auth/login.blade.php
+++ b/laravel/resources/views/livewire/pages/auth/login.blade.php
@@ -3,8 +3,8 @@
 use App\Livewire\Forms\LoginForm;
 use App\Mail\VerificationCodeMail;
 use App\Models\User;
+use App\Services\Auth\PendingRegistrationService;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
@@ -52,77 +52,9 @@ new #[Layout('layouts.auth-canvas')] class extends Component
         }
     }
 
-    protected function pendingRegistrationKey(string $token): string
+    protected function pendingRegistrationService(): PendingRegistrationService
     {
-        return 'pending_registration:'.$token;
-    }
-
-    protected function pendingRegistrationEmailKey(string $email): string
-    {
-        return 'pending_registration_email:'.Str::lower($email);
-    }
-
-    protected function otpRateLimitKey(?string $token = null): ?string
-    {
-        $token ??= $this->pendingRegistrationToken;
-
-        if (! $token) {
-            return null;
-        }
-
-        return 'otp_registration:'.$token.'|'.request()->ip();
-    }
-
-    protected function otpResendRateLimitKey(?string $token = null): ?string
-    {
-        $token ??= $this->pendingRegistrationToken;
-
-        if (! $token) {
-            return null;
-        }
-
-        return 'otp_registration_resend:'.$token.'|'.request()->ip();
-    }
-
-    protected function pendingRegistrationTtlMinutes(): int
-    {
-        return max(1, (int) config('auth.otp_registration.ttl_minutes', 60));
-    }
-
-    protected function otpMaxAttempts(): int
-    {
-        return max(1, (int) config('auth.otp_registration.max_attempts', 3));
-    }
-
-    protected function otpDecaySeconds(): int
-    {
-        return max(1, (int) config('auth.otp_registration.decay_seconds', 600));
-    }
-
-    protected function otpResendCooldownSeconds(): int
-    {
-        return max(1, (int) config('auth.otp_registration.resend_cooldown_seconds', 60));
-    }
-
-    protected function clearPendingRegistration(?string $token = null, ?string $email = null): void
-    {
-        if ($token) {
-            Cache::forget($this->pendingRegistrationKey($token));
-
-            $otpRateLimitKey = $this->otpRateLimitKey($token);
-            if ($otpRateLimitKey) {
-                RateLimiter::clear($otpRateLimitKey);
-            }
-
-            $otpResendRateLimitKey = $this->otpResendRateLimitKey($token);
-            if ($otpResendRateLimitKey) {
-                RateLimiter::clear($otpResendRateLimitKey);
-            }
-        }
-
-        if ($email) {
-            Cache::forget($this->pendingRegistrationEmailKey($email));
-        }
+        return app(PendingRegistrationService::class);
     }
 
     public function setView(string $view): void
@@ -185,6 +117,8 @@ new #[Layout('layouts.auth-canvas')] class extends Component
 
     public function register(): void
     {
+        $pendingRegistrationService = $this->pendingRegistrationService();
+
         $existingUser = User::where('email', $this->register_email)->first();
         if ($existingUser && is_null($existingUser->email_verified_at)) {
             $existingUser->delete();
@@ -207,28 +141,15 @@ new #[Layout('layouts.auth-canvas')] class extends Component
         ]);
 
         $registrationEmail = Str::lower($validated['register_email']);
-        $existingPendingToken = Cache::get($this->pendingRegistrationEmailKey($registrationEmail));
+        $existingPendingToken = $pendingRegistrationService->pendingTokenByEmail($registrationEmail);
         if ($existingPendingToken) {
-            $this->clearPendingRegistration($existingPendingToken, $registrationEmail);
+            $pendingRegistrationService->clearPendingRegistration($existingPendingToken, $registrationEmail, request()->ip());
         }
 
-        $plainCode = sprintf('%06d', random_int(0, 999999));
-        $pendingToken = (string) Str::uuid();
-
-        $ttlMinutes = $this->pendingRegistrationTtlMinutes();
-
-        Cache::put($this->pendingRegistrationKey($pendingToken), [
-            'name' => $validated['name'],
-            'email' => $registrationEmail,
-            'password' => Hash::make($validated['register_password']),
-            'code_hash' => hash('sha256', $plainCode),
-            'expires_at' => now()->addMinutes($ttlMinutes)->getTimestamp(),
-        ], now()->addMinutes($ttlMinutes));
-
-        Cache::put(
-            $this->pendingRegistrationEmailKey($registrationEmail),
-            $pendingToken,
-            now()->addMinutes($ttlMinutes)
+        [$pendingToken, $plainCode] = $pendingRegistrationService->createPendingRegistration(
+            name: $validated['name'],
+            email: $registrationEmail,
+            hashedPassword: Hash::make($validated['register_password']),
         );
 
         Mail::to($registrationEmail)->send(new VerificationCodeMail($plainCode));
@@ -247,7 +168,8 @@ new #[Layout('layouts.auth-canvas')] class extends Component
             return;
         }
 
-        $pending = Cache::get($this->pendingRegistrationKey($this->pendingRegistrationToken));
+        $pendingRegistrationService = $this->pendingRegistrationService();
+        $pending = $pendingRegistrationService->getPendingRegistration($this->pendingRegistrationToken);
 
         if (! is_array($pending)) {
             $this->addError('verification_code_input', 'Sesi pendaftaran sudah berakhir. Silakan daftar ulang.');
@@ -255,9 +177,12 @@ new #[Layout('layouts.auth-canvas')] class extends Component
             return;
         }
 
-        $otpResendRateLimitKey = $this->otpResendRateLimitKey();
+        $otpResendRateLimitKey = $pendingRegistrationService->otpResendRateLimitKey(
+            token: $this->pendingRegistrationToken,
+            ipAddress: request()->ip(),
+        );
 
-        if ($otpResendRateLimitKey && RateLimiter::tooManyAttempts($otpResendRateLimitKey, 1)) {
+        if (RateLimiter::tooManyAttempts($otpResendRateLimitKey, 1)) {
             $seconds = RateLimiter::availableIn($otpResendRateLimitKey);
             $this->addError('verification_code_input', 'Kode OTP sudah dikirim ulang. Coba lagi dalam '.$seconds.' detik.');
 
@@ -265,28 +190,18 @@ new #[Layout('layouts.auth-canvas')] class extends Component
         }
 
         $plainCode = sprintf('%06d', random_int(0, 999999));
-        $ttlMinutes = $this->pendingRegistrationTtlMinutes();
         $email = (string) ($pending['email'] ?? '');
 
-        Cache::put($this->pendingRegistrationKey($this->pendingRegistrationToken), [
+        $pendingRegistrationService->storePendingRegistration($this->pendingRegistrationToken, [
             'name' => (string) ($pending['name'] ?? ''),
             'email' => $email,
             'password' => (string) ($pending['password'] ?? ''),
             'code_hash' => hash('sha256', $plainCode),
-            'expires_at' => now()->addMinutes($ttlMinutes)->getTimestamp(),
-        ], now()->addMinutes($ttlMinutes));
-
-        Cache::put(
-            $this->pendingRegistrationEmailKey($email),
-            $this->pendingRegistrationToken,
-            now()->addMinutes($ttlMinutes)
-        );
+        ]);
 
         Mail::to($email)->send(new VerificationCodeMail($plainCode));
 
-        if ($otpResendRateLimitKey) {
-            RateLimiter::hit($otpResendRateLimitKey, $this->otpResendCooldownSeconds());
-        }
+        RateLimiter::hit($otpResendRateLimitKey, $pendingRegistrationService->otpResendCooldownSeconds());
 
         $this->verification_code_input = '';
         $this->otp_status = 'Kode OTP baru telah dikirim ke email Anda.';
@@ -300,10 +215,11 @@ new #[Layout('layouts.auth-canvas')] class extends Component
             return;
         }
 
-        $pending = Cache::get($this->pendingRegistrationKey($this->pendingRegistrationToken));
+        $pendingRegistrationService = $this->pendingRegistrationService();
+        $pending = $pendingRegistrationService->getPendingRegistration($this->pendingRegistrationToken);
         $pendingEmail = is_array($pending) ? ($pending['email'] ?? null) : null;
 
-        $this->clearPendingRegistration($this->pendingRegistrationToken, $pendingEmail);
+        $pendingRegistrationService->clearPendingRegistration($this->pendingRegistrationToken, $pendingEmail, request()->ip());
 
         $this->pendingRegistrationToken = null;
         $this->verification_code_input = '';
@@ -313,6 +229,8 @@ new #[Layout('layouts.auth-canvas')] class extends Component
 
     public function verifyOtp(): void
     {
+        $pendingRegistrationService = $this->pendingRegistrationService();
+
         $this->validate([
             'verification_code_input' => ['required', 'digits:6'],
         ], [
@@ -326,15 +244,18 @@ new #[Layout('layouts.auth-canvas')] class extends Component
             return;
         }
 
-        $otpRateLimitKey = $this->otpRateLimitKey();
-        if ($otpRateLimitKey && RateLimiter::tooManyAttempts($otpRateLimitKey, $this->otpMaxAttempts())) {
+        $otpRateLimitKey = $pendingRegistrationService->otpRateLimitKey(
+            token: $this->pendingRegistrationToken,
+            ipAddress: request()->ip(),
+        );
+        if (RateLimiter::tooManyAttempts($otpRateLimitKey, $pendingRegistrationService->otpMaxAttempts())) {
             $seconds = RateLimiter::availableIn($otpRateLimitKey);
             $this->addError('verification_code_input', 'Terlalu banyak percobaan OTP. Coba lagi dalam '.ceil($seconds / 60).' menit.');
 
             return;
         }
 
-        $pending = Cache::get($this->pendingRegistrationKey($this->pendingRegistrationToken));
+        $pending = $pendingRegistrationService->getPendingRegistration($this->pendingRegistrationToken);
 
         if (! is_array($pending)) {
             $this->addError('verification_code_input', 'Sesi pendaftaran sudah berakhir. Silakan daftar ulang.');
@@ -344,7 +265,7 @@ new #[Layout('layouts.auth-canvas')] class extends Component
 
         $expiresAt = (int) ($pending['expires_at'] ?? 0);
         if ($expiresAt < now()->getTimestamp()) {
-            $this->clearPendingRegistration($this->pendingRegistrationToken, $pending['email'] ?? null);
+            $pendingRegistrationService->clearPendingRegistration($this->pendingRegistrationToken, $pending['email'] ?? null, request()->ip());
             $this->addError('verification_code_input', 'Kode verifikasi sudah kedaluwarsa. Silakan daftar ulang.');
 
             return;
@@ -353,9 +274,7 @@ new #[Layout('layouts.auth-canvas')] class extends Component
         $providedCodeHash = hash('sha256', $this->verification_code_input);
 
         if (! hash_equals((string) ($pending['code_hash'] ?? ''), $providedCodeHash)) {
-            if ($otpRateLimitKey) {
-                RateLimiter::hit($otpRateLimitKey, $this->otpDecaySeconds());
-            }
+            RateLimiter::hit($otpRateLimitKey, $pendingRegistrationService->otpDecaySeconds());
 
             $this->addError('verification_code_input', 'Kode verifikasi tidak valid.');
 
@@ -394,15 +313,13 @@ new #[Layout('layouts.auth-canvas')] class extends Component
             return;
         }
 
-        if ($otpRateLimitKey) {
-            RateLimiter::clear($otpRateLimitKey);
-        }
+        RateLimiter::clear($otpRateLimitKey);
 
         Auth::login($user);
 
         Session::regenerate();
 
-        $this->clearPendingRegistration($this->pendingRegistrationToken, $email);
+        $pendingRegistrationService->clearPendingRegistration($this->pendingRegistrationToken, $email, request()->ip());
         $this->pendingRegistrationToken = null;
         $this->verification_code_input = '';
         $this->showVerificationModal = false;
@@ -413,171 +330,11 @@ new #[Layout('layouts.auth-canvas')] class extends Component
 }; ?>
 
 <div class="relative flex min-h-screen w-full items-center justify-center overflow-hidden bg-[#fafaf9]">
-    <div class="absolute inset-0 z-0">
-        <div class="h-full w-full animate-breathe bg-cover bg-center opacity-100" style="background-image: url('/images/ista/login-bg.png');"></div>
-        <div class="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(212,175,55,0.15)_0%,rgba(250,250,249,0.4)_80%)]"></div>
-        <div class="absolute inset-0 bg-gradient-to-t from-ista-gold/20 via-white/5 to-transparent"></div>
-    </div>
+    @include('livewire.pages.auth.partials.auth-background')
 
-    <div class="pointer-events-none absolute inset-0 z-0 overflow-hidden">
-        <div class="animate-float-slow absolute left-1/4 top-1/4 h-64 w-64 cursor-pointer rounded-full bg-yellow-400/20 mix-blend-overlay blur-3xl"></div>
-        <div class="animate-float-reverse absolute bottom-1/4 right-1/4 h-80 w-80 cursor-pointer rounded-full bg-rose-500/10 mix-blend-multiply blur-3xl"></div>
-
-        <div class="animate-twinkle absolute left-20 top-10 h-2 w-2 cursor-pointer rounded-full bg-yellow-500 blur-[1px]" style="animation-delay: 0s"></div>
-        <div class="animate-twinkle absolute bottom-20 right-10 h-3 w-3 cursor-pointer rounded-full bg-rose-400 blur-[2px]" style="animation-delay: 1s"></div>
-        <div class="animate-twinkle absolute left-10 top-1/2 h-1.5 w-1.5 cursor-pointer rounded-full bg-white blur-[1px]" style="animation-delay: 2s"></div>
-        <div class="animate-twinkle absolute right-1/3 top-20 h-2 w-2 cursor-pointer rounded-full bg-yellow-600/60 blur-[1px]" style="animation-delay: 1.5s"></div>
-    </div>
-
-    <div @class([
-        'relative w-full max-w-[640px] p-6 font-sans transition-all duration-500',
-        'opacity-30 blur-sm pointer-events-none' => $showVerificationModal,
-    ]) style="{{ $showVerificationModal ? 'z-index: 0; filter: brightness(0.28) saturate(0.45);' : 'z-index: 10;' }}">
-        <div class="group/card ista-glass-card cursor-pointer">
-            <div class="absolute inset-0 z-0 -translate-x-[200%] bg-gradient-to-tr from-white/0 via-white/40 to-white/0 group-hover/card:animate-[shimmer_1s_ease-out]"></div>
-
-            <div class="animate-enter-1 relative z-20 px-10 pb-6 pt-8 text-center">
-                <div class="group/logo mb-4 inline-flex h-16 w-16 cursor-pointer items-center justify-center rounded-2xl border border-white/40 bg-white/80 shadow-sm transition-transform duration-500 hover:scale-110 hover:rotate-6">
-                    <img src="{{ asset('images/ista/logo.png') }}" class="h-9 w-9 object-contain group-hover/logo:brightness-110" alt="Logo">
-                </div>
-
-                <h1 class="ista-brand-title mb-1 flex items-center justify-center gap-2 cursor-default text-4xl tracking-tight drop-shadow-sm transition-all duration-300 not-italic">
-                    <span class="text-stone-900 not-italic">Login</span> <span class="text-ista-primary not-italic">ISTA <span class="font-light italic text-ista-gold">AI</span></span>
-                </h1>
-                <p class="cursor-default text-[13px] font-medium text-stone-600 opacity-90">Asisten Istana Pintar</p>
-            </div>
-
-            <div class="relative z-20 px-12 pb-10">
-                <x-auth-session-status class="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700" :status="session('status')" />
-
-                @if($view === 'login')
-                    @include('livewire.pages.auth.partials.login-form')
-
-                    <div class="animate-enter-4 mt-6 text-center">
-                        <a href="{{ url('/') }}" class="group inline-flex items-center gap-2 text-xs font-bold text-rose-900 transition-colors hover:text-amber-600">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 cursor-pointer transition-transform duration-300 group-hover:-translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-                            </svg>
-                            <span>Kembali ke Beranda</span>
-                        </a>
-                    </div>
-                @elseif($view === 'register')
-                    @include('livewire.pages.auth.partials.register-form')
-                @elseif($view === 'forgot-password')
-                    @include('livewire.pages.auth.partials.forgot-password-form')
-                @endif
-
-                <div class="animate-enter-4 mt-8 border-t border-rose-900/10 pt-4 text-center">
-                    <p class="inline-block cursor-pointer text-[12px] font-semibold text-rose-950/60 transition-colors hover:scale-105 hover:text-rose-900">
-                        Copyright © 2026 Istana Kepresidenan Yogyakarta, All rights reserved.
-                    </p>
-                </div>
-            </div>
-        </div>
-    </div>
+    @include('livewire.pages.auth.partials.auth-card')
 
     @if($showVerificationModal)
-        <div class="fixed inset-0" style="z-index: 9998; background-color: rgba(0, 0, 0, 0.88); backdrop-filter: blur(8px);"></div>
-
-        <div class="fixed inset-0 z-[9999] flex items-center justify-center p-4">
-            <div class="ista-glass-card relative w-full max-w-md p-8 animate-enter-1 border-white/95 bg-white/80 shadow-[0_0_0_1px_rgba(255,255,255,0.65),0_0_110px_rgba(255,255,255,0.4),0_30px_70px_-15px_rgba(0,0,0,0.58)] hover:translate-y-0 hover:shadow-[0_0_0_1px_rgba(255,255,255,0.65),0_0_110px_rgba(255,255,255,0.4),0_30px_70px_-15px_rgba(0,0,0,0.58)]" style="background: linear-gradient(150deg, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0.78)); backdrop-filter: blur(22px) saturate(135%);">
-                <button wire:click="cancelVerification" class="absolute right-4 top-4 text-stone-500 transition-colors hover:text-stone-700" type="button" aria-label="Tutup popup verifikasi">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                </button>
-
-                <h2 class="mb-2 text-center text-2xl font-bold text-stone-900">Verifikasi Email</h2>
-                <p class="mb-6 text-center text-sm text-stone-600">Kami mengirimkan kode 6 digit ke email Anda. Masukkan kode untuk menyelesaikan pendaftaran.</p>
-
-                @if($otp_status)
-                    <p class="mb-4 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-center text-xs font-medium text-emerald-700">{{ $otp_status }}</p>
-                @endif
-
-                <form wire:submit="verifyOtp">
-                    <div
-                        x-data="{
-                            otp: ['', '', '', '', '', ''],
-                            focusNext(index) {
-                                if (this.otp[index] && index < 5) {
-                                    document.getElementById('otp_' + (index + 1)).focus();
-                                }
-                                $wire.set('verification_code_input', this.otp.join(''));
-                            },
-                            handleBackspace(event, index) {
-                                if ((event.key === 'Backspace' || event.key === 'Delete') && !this.otp[index] && index > 0) {
-                                    const prevInput = document.getElementById('otp_' + (index - 1));
-                                    if (prevInput) {
-                                        prevInput.focus();
-                                        setTimeout(() => prevInput.select(), 10);
-                                    }
-                                }
-                            },
-                            handlePaste(event) {
-                                const pastedData = event.clipboardData.getData('text').slice(0, 6);
-                                if (/^\d+$/.test(pastedData)) {
-                                    for (let i = 0; i < pastedData.length; i++) {
-                                        this.otp[i] = pastedData[i];
-                                    }
-                                    $wire.set('verification_code_input', this.otp.join(''));
-                                    const focusIndex = pastedData.length > 5 ? 5 : pastedData.length;
-                                    document.getElementById('otp_' + focusIndex).focus();
-                                }
-                            }
-                        }"
-                    >
-                        <label class="mb-2 block text-center text-sm font-medium text-stone-700">Kode Verifikasi</label>
-                        <div class="mb-2 flex justify-center gap-2" @paste.prevent="handlePaste">
-                            <template x-for="(digit, index) in otp" :key="index">
-                                <input
-                                    type="text"
-                                    maxlength="1"
-                                    x-model="otp[index]"
-                                    :id="'otp_' + index"
-                                    @input="focusNext(index)"
-                                    @keydown="handleBackspace($event, index)"
-                                    class="h-14 w-12 rounded-xl border border-stone-300 bg-white text-center text-2xl font-bold text-stone-800 shadow-inner transition-all focus:border-ista-primary focus:outline-none focus:ring-4 focus:ring-ista-primary/10"
-                                    required
-                                    autofocus
-                                >
-                            </template>
-                        </div>
-                        @error('verification_code_input')
-                            <span class="mt-1 block text-center text-xs text-rose-600">{{ $message }}</span>
-                        @enderror
-                    </div>
-
-                    <div class="mt-6 pt-2">
-                        <button type="submit" class="ista-login-button group w-full" wire:loading.attr="disabled" wire:target="verifyOtp">
-                            <span class="relative z-10 flex items-center justify-center gap-2 text-[15px] font-semibold text-white transition-all duration-500 ease-out">
-                                <span wire:loading.remove wire:target="verifyOtp">Verifikasi & Login</span>
-                                <span wire:loading.flex wire:target="verifyOtp" class="items-center justify-center gap-2">
-                                    <svg class="h-4 w-4 animate-spin text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                                    </svg>
-                                    Memproses...
-                                </span>
-                                <svg wire:loading.remove wire:target="verifyOtp" class="-ml-4 h-4 w-4 opacity-0 transition-all duration-500 group-hover:ml-0 group-hover:opacity-100" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
-                                </svg>
-                            </span>
-                            <div class="absolute inset-0 z-0 -translate-x-[150%] skew-x-12 bg-gradient-to-r from-transparent via-white/40 to-transparent transition-transform duration-1000 ease-in-out group-hover:translate-x-[150%]"></div>
-                        </button>
-
-                        <button
-                            type="button"
-                            wire:click="resendOtp"
-                            wire:loading.attr="disabled"
-                            wire:target="resendOtp"
-                            class="mt-3 w-full rounded-xl border border-stone-300 bg-white px-4 py-3 text-sm font-semibold text-stone-700 transition-colors hover:border-stone-400 hover:text-stone-900 disabled:cursor-not-allowed disabled:opacity-60"
-                        >
-                            <span wire:loading.remove wire:target="resendOtp">Kirim Ulang OTP</span>
-                            <span wire:loading wire:target="resendOtp">Mengirim ulang...</span>
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
+        @include('livewire.pages.auth.partials.otp-verification-modal')
     @endif
 </div>

--- a/laravel/resources/views/livewire/pages/auth/partials/auth-background.blade.php
+++ b/laravel/resources/views/livewire/pages/auth/partials/auth-background.blade.php
@@ -1,0 +1,15 @@
+<div class="absolute inset-0 z-0">
+    <div class="h-full w-full animate-breathe bg-cover bg-center opacity-100" style="background-image: url('/images/ista/login-bg.png');"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(212,175,55,0.15)_0%,rgba(250,250,249,0.4)_80%)]"></div>
+    <div class="absolute inset-0 bg-gradient-to-t from-ista-gold/20 via-white/5 to-transparent"></div>
+</div>
+
+<div class="pointer-events-none absolute inset-0 z-0 overflow-hidden">
+    <div class="animate-float-slow absolute left-1/4 top-1/4 h-64 w-64 cursor-pointer rounded-full bg-yellow-400/20 mix-blend-overlay blur-3xl"></div>
+    <div class="animate-float-reverse absolute bottom-1/4 right-1/4 h-80 w-80 cursor-pointer rounded-full bg-rose-500/10 mix-blend-multiply blur-3xl"></div>
+
+    <div class="animate-twinkle absolute left-20 top-10 h-2 w-2 cursor-pointer rounded-full bg-yellow-500 blur-[1px]" style="animation-delay: 0s"></div>
+    <div class="animate-twinkle absolute bottom-20 right-10 h-3 w-3 cursor-pointer rounded-full bg-rose-400 blur-[2px]" style="animation-delay: 1s"></div>
+    <div class="animate-twinkle absolute left-10 top-1/2 h-1.5 w-1.5 cursor-pointer rounded-full bg-white blur-[1px]" style="animation-delay: 2s"></div>
+    <div class="animate-twinkle absolute right-1/3 top-20 h-2 w-2 cursor-pointer rounded-full bg-yellow-600/60 blur-[1px]" style="animation-delay: 1.5s"></div>
+</div>

--- a/laravel/resources/views/livewire/pages/auth/partials/auth-card.blade.php
+++ b/laravel/resources/views/livewire/pages/auth/partials/auth-card.blade.php
@@ -1,0 +1,46 @@
+<div @class([
+    'relative w-full max-w-[640px] p-6 font-sans transition-all duration-500',
+    'opacity-30 blur-sm pointer-events-none' => $showVerificationModal,
+]) style="{{ $showVerificationModal ? 'z-index: 0; filter: brightness(0.28) saturate(0.45);' : 'z-index: 10;' }}">
+    <div class="group/card ista-glass-card cursor-pointer">
+        <div class="absolute inset-0 z-0 -translate-x-[200%] bg-gradient-to-tr from-white/0 via-white/40 to-white/0 group-hover/card:animate-[shimmer_1s_ease-out]"></div>
+
+        <div class="animate-enter-1 relative z-20 px-10 pb-6 pt-8 text-center">
+            <div class="group/logo mb-4 inline-flex h-16 w-16 cursor-pointer items-center justify-center rounded-2xl border border-white/40 bg-white/80 shadow-sm transition-transform duration-500 hover:scale-110 hover:rotate-6">
+                <img src="{{ asset('images/ista/logo.png') }}" class="h-9 w-9 object-contain group-hover/logo:brightness-110" alt="Logo">
+            </div>
+
+            <h1 class="ista-brand-title mb-1 flex items-center justify-center gap-2 cursor-default text-4xl tracking-tight drop-shadow-sm transition-all duration-300 not-italic">
+                <span class="text-stone-900 not-italic">Login</span> <span class="text-ista-primary not-italic">ISTA <span class="font-light italic text-ista-gold">AI</span></span>
+            </h1>
+            <p class="cursor-default text-[13px] font-medium text-stone-600 opacity-90">Asisten Istana Pintar</p>
+        </div>
+
+        <div class="relative z-20 px-12 pb-10">
+            <x-auth-session-status class="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700" :status="session('status')" />
+
+            @if($view === 'login')
+                @include('livewire.pages.auth.partials.login-form')
+
+                <div class="animate-enter-4 mt-6 text-center">
+                    <a href="{{ url('/') }}" class="group inline-flex items-center gap-2 text-xs font-bold text-rose-900 transition-colors hover:text-amber-600">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 cursor-pointer transition-transform duration-300 group-hover:-translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                        </svg>
+                        <span>Kembali ke Beranda</span>
+                    </a>
+                </div>
+            @elseif($view === 'register')
+                @include('livewire.pages.auth.partials.register-form')
+            @elseif($view === 'forgot-password')
+                @include('livewire.pages.auth.partials.forgot-password-form')
+            @endif
+
+            <div class="animate-enter-4 mt-8 border-t border-rose-900/10 pt-4 text-center">
+                <p class="inline-block cursor-pointer text-[12px] font-semibold text-rose-950/60 transition-colors hover:scale-105 hover:text-rose-900">
+                    Copyright © 2026 Istana Kepresidenan Yogyakarta, All rights reserved.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/laravel/resources/views/livewire/pages/auth/partials/otp-verification-modal.blade.php
+++ b/laravel/resources/views/livewire/pages/auth/partials/otp-verification-modal.blade.php
@@ -1,0 +1,102 @@
+<div class="fixed inset-0" style="z-index: 9998; background-color: rgba(0, 0, 0, 0.88); backdrop-filter: blur(8px);"></div>
+
+<div class="fixed inset-0 z-[9999] flex items-center justify-center p-4">
+    <div class="ista-glass-card relative w-full max-w-md p-8 animate-enter-1 border-white/95 bg-white/80 shadow-[0_0_0_1px_rgba(255,255,255,0.65),0_0_110px_rgba(255,255,255,0.4),0_30px_70px_-15px_rgba(0,0,0,0.58)] hover:translate-y-0 hover:shadow-[0_0_0_1px_rgba(255,255,255,0.65),0_0_110px_rgba(255,255,255,0.4),0_30px_70px_-15px_rgba(0,0,0,0.58)]" style="background: linear-gradient(150deg, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0.78)); backdrop-filter: blur(22px) saturate(135%);">
+        <button wire:click="cancelVerification" class="absolute right-4 top-4 text-stone-500 transition-colors hover:text-stone-700" type="button" aria-label="Tutup popup verifikasi">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+        </button>
+
+        <h2 class="mb-2 text-center text-2xl font-bold text-stone-900">Verifikasi Email</h2>
+        <p class="mb-6 text-center text-sm text-stone-600">Kami mengirimkan kode 6 digit ke email Anda. Masukkan kode untuk menyelesaikan pendaftaran.</p>
+
+        @if($otp_status)
+            <p class="mb-4 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-center text-xs font-medium text-emerald-700">{{ $otp_status }}</p>
+        @endif
+
+        <form wire:submit="verifyOtp">
+            <div
+                x-data="{
+                    otp: ['', '', '', '', '', ''],
+                    focusNext(index) {
+                        if (this.otp[index] && index < 5) {
+                            document.getElementById('otp_' + (index + 1)).focus();
+                        }
+                        $wire.set('verification_code_input', this.otp.join(''));
+                    },
+                    handleBackspace(event, index) {
+                        if ((event.key === 'Backspace' || event.key === 'Delete') && !this.otp[index] && index > 0) {
+                            const prevInput = document.getElementById('otp_' + (index - 1));
+                            if (prevInput) {
+                                prevInput.focus();
+                                setTimeout(() => prevInput.select(), 10);
+                            }
+                        }
+                    },
+                    handlePaste(event) {
+                        const pastedData = event.clipboardData.getData('text').slice(0, 6);
+                        if (/^\d+$/.test(pastedData)) {
+                            for (let i = 0; i < pastedData.length; i++) {
+                                this.otp[i] = pastedData[i];
+                            }
+                            $wire.set('verification_code_input', this.otp.join(''));
+                            const focusIndex = pastedData.length > 5 ? 5 : pastedData.length;
+                            document.getElementById('otp_' + focusIndex).focus();
+                        }
+                    }
+                }"
+            >
+                <label class="mb-2 block text-center text-sm font-medium text-stone-700">Kode Verifikasi</label>
+                <div class="mb-2 flex justify-center gap-2" @paste.prevent="handlePaste">
+                    <template x-for="(digit, index) in otp" :key="index">
+                        <input
+                            type="text"
+                            maxlength="1"
+                            x-model="otp[index]"
+                            :id="'otp_' + index"
+                            @input="focusNext(index)"
+                            @keydown="handleBackspace($event, index)"
+                            class="h-14 w-12 rounded-xl border border-stone-300 bg-white text-center text-2xl font-bold text-stone-800 shadow-inner transition-all focus:border-ista-primary focus:outline-none focus:ring-4 focus:ring-ista-primary/10"
+                            required
+                            autofocus
+                        >
+                    </template>
+                </div>
+                @error('verification_code_input')
+                    <span class="mt-1 block text-center text-xs text-rose-600">{{ $message }}</span>
+                @enderror
+            </div>
+
+            <div class="mt-6 pt-2">
+                <button type="submit" class="ista-login-button group w-full" wire:loading.attr="disabled" wire:target="verifyOtp">
+                    <span class="relative z-10 flex items-center justify-center gap-2 text-[15px] font-semibold text-white transition-all duration-500 ease-out">
+                        <span wire:loading.remove wire:target="verifyOtp">Verifikasi & Login</span>
+                        <span wire:loading.flex wire:target="verifyOtp" class="items-center justify-center gap-2">
+                            <svg class="h-4 w-4 animate-spin text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                            </svg>
+                            Memproses...
+                        </span>
+                        <svg wire:loading.remove wire:target="verifyOtp" class="-ml-4 h-4 w-4 opacity-0 transition-all duration-500 group-hover:ml-0 group-hover:opacity-100" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
+                        </svg>
+                    </span>
+                    <div class="absolute inset-0 z-0 -translate-x-[150%] skew-x-12 bg-gradient-to-r from-transparent via-white/40 to-transparent transition-transform duration-1000 ease-in-out group-hover:translate-x-[150%]"></div>
+                </button>
+
+                <button
+                    type="button"
+                    wire:click="resendOtp"
+                    wire:loading.attr="disabled"
+                    wire:target="resendOtp"
+                    class="mt-3 w-full rounded-xl border border-stone-300 bg-white px-4 py-3 text-sm font-semibold text-stone-700 transition-colors hover:border-stone-400 hover:text-stone-900 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                    <span wire:loading.remove wire:target="resendOtp">Kirim Ulang OTP</span>
+                    <span wire:loading wire:target="resendOtp">Mengirim ulang...</span>
+                </button>
+            </div>
+        </form>
+    </div>
+</div>


### PR DESCRIPTION
## Status Roadmap

Bagian dari Tahap 5 roadmap utama #1. Metadata item ini dirapikan pada 2026-04-30 agar daftar issue/PR konsisten dan mudah dipindai.

- Jenis item: Pull Request #64.
- Status GitHub: MERGED.
- Relasi: Issue #63.
- Pola judul: Refactor Tahap 5.

## Ringkasan

Merapikan halaman auth/login dan memindahkan orkestrasi pending registration/OTP ke service boundary yang lebih jelas.

## Verifikasi

Verifikasi mengikuti test yang tercatat pada body lama atau PR terkait.

<details>
<summary>Konten lama sebelum dirapikan</summary>

## Summary
- Refactor `pages.auth.login` so the Volt page acts as a composer, with large presentational sections moved into focused auth partials.
- Extract pending-registration/OTP cache and key orchestration into `PendingRegistrationService` to reduce auth logic density in the Blade Volt class.
- Keep route and behavior unchanged for login, register, resend OTP, cancel verification, verify OTP, and forgot password flows.

## Testing
- `cd laravel && php artisan test tests/Feature/Auth/AuthenticationTest.php tests/Feature/Auth/RegistrationTest.php tests/Feature/Auth/PasswordResetTest.php`
- `cd laravel && php artisan test`
- `cd laravel && php artisan test tests/Feature/Auth/RegistrationTest.php`

Closes #63

</details>
