### PR TITLE
Arsip Migrasi Laravel-only: RAG Dokumen ke Laravel AI SDK

### DIFF
--- a/issue/issue-81-review-followup.md
+++ b/issue/issue-81-review-followup.md
@@ -1,0 +1,33 @@
+# Issue Plan: Fix Review Blockers untuk PR #81
+
+## Blocker yang Perlu Diperbaiki
+
+### Blocker 1: RAG context tidak dipakai dalam prompt model
+- `$messagesWithRag` sudah dibuat tapi tidak dipakai
+- `AgentPrompt` tetap pakai `$query` saja
+- Harus dipakai dalam `messages` parameter `AgentPrompt::for()`
+
+### Blocker 2: Fallback web search yield langsung SDK stream mentah
+- Di jalur dokumen tidak menjawab (line 241, 272) pakai `yield from $provider->stream($promptObj)`
+- Tidak parsing TextDelta/Citation dan tidak emit source marker
+- Harusnya sama dengan jalur non-dokumen: iterasi dan emit normalized output
+
+### Blocker 3: calculateSimilarity() pakai class tidak ada
+- Pakai `new \Laravel\Ai\Embeddings\EmbeddingPrompt(...)` yang tidak ada
+- Contract SDK: `embeddings(array $inputs, ?int $dimensions, ?string $model)`
+- Fallback lexical sudah ada, tapi harus protection dengan test
+
+## Langkah Fix
+
+1. **Fix Blocker 1**: Build messages array dengan RAG context, gunakan dalam AgentPrompt
+2. **Fix Blocker 2**: Samakan stream parsing di semua cabang fallback web search
+3. **Fix Blocker 3**: Gunakan API `embeddings(array $inputs)` SDK yang benar
+4. **Tambah test**: Test skenario retrieval success, no-answer + web fallback
+5. **Verifikasi**: Jalankan test Laravel
+6. **Push**: Commit dan push ke branch PR
+7. **Comment**: Tulis ringkasan di PR
+
+## Files yang Berubah
+- `laravel/app/Services/Chat/LaravelChatService.php`
+- `laravel/app/Services/Document/LaravelDocumentRetrievalService.php`
+- `laravel/tests/Unit/Services/Chat/LaravelChatServiceTest.php`

--- a/laravel/app/Contracts/DocumentRetrievalInterface.php
+++ b/laravel/app/Contracts/DocumentRetrievalInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Contracts;
+
+interface DocumentRetrievalInterface
+{
+    public function searchRelevantChunks(
+        string $query,
+        array $filenames,
+        int $topK,
+        string $userId
+    ): array;
+
+    public function buildRagPrompt(
+        string $question,
+        array $chunks,
+        bool $includeSources = true,
+        string $webContext = ''
+    ): array;
+
+    public function shouldUseWebSearch(
+        string $query,
+        bool $forceWebSearch = false,
+        bool $explicitWebRequest = false,
+        bool $allowAutoRealtimeWeb = true,
+        bool $documentsActive = false
+    ): array;
+
+    public function detectExplicitWebRequest(string $query): bool;
+
+    public function hasDocumentsForUser(string $userId): bool;
+}

--- a/laravel/app/Services/Chat/LaravelChatService.php
+++ b/laravel/app/Services/Chat/LaravelChatService.php
@@ -2,9 +2,9 @@
 
 namespace App\Services\Chat;
 
-use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\Citation;
+use Laravel\Ai\Prompts\AgentPrompt;
 use Illuminate\Support\Facades\Log;
 use App\Services\Document\LaravelDocumentRetrievalService;
 use App\Services\Document\DocumentPolicyService;
@@ -63,7 +63,7 @@ class LaravelChatService
         $documentPolicy = $this->getDocumentPolicy();
 
         if ($documentFilenamesValid && $retrievalService && $documentPolicy) {
-            return $this->chatWithDocuments(
+            yield from $this->chatWithDocuments(
                 $messages,
                 $document_filenames,
                 $user_id,
@@ -73,6 +73,8 @@ class LaravelChatService
                 $retrievalService,
                 $documentPolicy
             );
+
+            return;
         }
 
         if ($documentFilenamesValid) {
@@ -93,13 +95,14 @@ class LaravelChatService
             $tools[] = $provider->webSearchTool($webSearch);
         }
 
-        $agent = \Laravel\Ai\AnonymousAgent::make(
+        $agent = new \Laravel\Ai\AnonymousAgent(
             instructions: $this->getSystemPrompt(),
+            messages: [],
             tools: $tools,
         );
 
         $stream = $provider->stream(
-            \Laravel\Ai\Prompts\AgentPrompt::for(
+            new AgentPrompt(
                 agent: $agent,
                 prompt: $prompt,
                 attachments: [],
@@ -108,23 +111,7 @@ class LaravelChatService
             )
         );
 
-        $sources = [];
-
-        foreach ($stream as $event) {
-            if ($event instanceof TextDelta) {
-                yield $event->delta;
-            } elseif ($event instanceof Citation) {
-                $citation = $event->citation;
-                $sources[] = [
-                    'title' => $citation->title ?? '',
-                    'url' => $citation->url ?? '',
-                ];
-            }
-        }
-
-        if (!empty($sources)) {
-            yield "\n[SOURCES:" . json_encode($sources) . "]\n";
-        }
+        yield from $this->streamResponseWithSources($stream);
     }
 
     protected function chatWithDocuments(
@@ -164,29 +151,21 @@ class LaravelChatService
         if ($success && !empty($chunks)) {
             $ragData = $retrievalService->buildRagPrompt($query, $chunks);
 
-            $webContext = '';
-            if ($policyResult['should_search']) {
-                $webContext = '';
-            }
-
             $prompt = $ragData['prompt'];
             $sources = $ragData['sources'];
 
-            $messagesWithRag = array_merge(
-                [['role' => 'system', 'content' => $prompt]],
-                $messages
-            );
-
             $provider = app(\Laravel\Ai\AiManager::class)->textProvider();
 
-            $agent = \Laravel\Ai\AnonymousAgent::make(
+            $agent = new \Laravel\Ai\AnonymousAgent(
                 instructions: 'Anda adalah asisten AI yang menjawab berdasarkan konteks dokumen. '
-                    . 'Jawab seringkas mungkin dan ground jawaban ke dokumen.'
+                    . 'Jawab seringkas mungkin dan ground jawaban ke dokumen.',
+                messages: [],
+                tools: []
             );
 
-            $promptObj = \Laravel\Ai\Prompts\AgentPrompt::for(
+            $promptObj = new AgentPrompt(
                 agent: $agent,
-                prompt: $query,
+                prompt: $prompt,
                 attachments: [],
                 provider: $provider,
                 model: $this->model,
@@ -194,23 +173,7 @@ class LaravelChatService
 
             $stream = $provider->stream($promptObj);
 
-            $allSources = $sources;
-
-            foreach ($stream as $event) {
-                if ($event instanceof TextDelta) {
-                    yield $event->delta;
-                } elseif ($event instanceof Citation) {
-                    $citation = $event->citation;
-                    $allSources[] = [
-                        'title' => $citation->title ?? '',
-                        'url' => $citation->url ?? '',
-                    ];
-                }
-            }
-
-            if (!empty($allSources)) {
-                yield "\n[SOURCES:" . json_encode($allSources) . "]\n";
-            }
+            yield from $this->streamResponseWithSources($stream, $sources);
 
             return;
         }
@@ -225,12 +188,13 @@ class LaravelChatService
                     $tools[] = $provider->webSearchTool($webSearch);
                 }
 
-                $agent = \Laravel\Ai\AnonymousAgent::make(
+                $agent = new \Laravel\Ai\AnonymousAgent(
                     instructions: $this->getSystemPrompt(),
+                    messages: [],
                     tools: $tools,
                 );
 
-                $promptObj = \Laravel\Ai\Prompts\AgentPrompt::for(
+                $promptObj = new AgentPrompt(
                     agent: $agent,
                     prompt: $query,
                     attachments: [],
@@ -238,7 +202,7 @@ class LaravelChatService
                     model: $this->model,
                 );
 
-                yield from $provider->stream($promptObj);
+                yield from $this->streamResponseWithSources($provider->stream($promptObj));
                 return;
             }
 
@@ -256,12 +220,13 @@ class LaravelChatService
                 $tools[] = $provider->webSearchTool($webSearch);
             }
 
-            $agent = \Laravel\Ai\AnonymousAgent::make(
+            $agent = new \Laravel\Ai\AnonymousAgent(
                 instructions: $this->getSystemPrompt(),
+                messages: [],
                 tools: $tools,
             );
 
-            $promptObj = \Laravel\Ai\Prompts\AgentPrompt::for(
+            $promptObj = new AgentPrompt(
                 agent: $agent,
                 prompt: $query,
                 attachments: [],
@@ -269,7 +234,7 @@ class LaravelChatService
                 model: $this->model,
             );
 
-            yield from $provider->stream($promptObj);
+            yield from $this->streamResponseWithSources($provider->stream($promptObj));
             return;
         }
 
@@ -301,5 +266,26 @@ Anda adalah asisten AI yang helpful dan informative.
 Selalu berikan jawaban yang akurat, jelas, dan relevan.
 Jika pengguna bertanya tentang informasi terkini atau memerlukan data realtime, lakukan web search terlebih dahulu.
 PROMPT;
+    }
+
+    protected function streamResponseWithSources(iterable $stream, array $initialSources = []): \Generator
+    {
+        $sources = $initialSources;
+
+        foreach ($stream as $event) {
+            if ($event instanceof TextDelta) {
+                yield $event->delta;
+            } elseif ($event instanceof Citation) {
+                $citation = $event->citation;
+                $sources[] = [
+                    'title' => $citation->title ?? '',
+                    'url' => $citation->url ?? '',
+                ];
+            }
+        }
+
+        if (!empty($sources)) {
+            yield "\n[SOURCES:" . json_encode($sources) . "]\n";
+        }
     }
 }

--- a/laravel/app/Services/Chat/LaravelChatService.php
+++ b/laravel/app/Services/Chat/LaravelChatService.php
@@ -6,18 +6,48 @@ use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\Citation;
 use Illuminate\Support\Facades\Log;
+use App\Services\Document\LaravelDocumentRetrievalService;
+use App\Services\Document\DocumentPolicyService;
 
 class LaravelChatService
 {
     protected string $model;
     protected bool $webSearchEnabled;
     protected string $webSearchProvider;
+    protected ?LaravelDocumentRetrievalService $documentRetrieval;
+    protected ?DocumentPolicyService $documentPolicy;
 
     public function __construct()
     {
         $this->model = config('ai.laravel_ai.model', 'gpt-4o-mini');
         $this->webSearchEnabled = config('ai.laravel_ai.web_search.enabled', true);
         $this->webSearchProvider = config('ai.laravel_ai.web_search.provider', 'ddg');
+        $this->documentRetrieval = null;
+        $this->documentPolicy = null;
+    }
+
+    protected function getDocumentRetrieval(): ?LaravelDocumentRetrievalService
+    {
+        if ($this->documentRetrieval === null) {
+            if (config('ai.laravel_ai.document_retrieval_enabled', false)) {
+                try {
+                    $this->documentRetrieval = app(LaravelDocumentRetrievalService::class);
+                } catch (\Throwable $e) {
+                    Log::warning('LaravelChatService: document retrieval not available', [
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+        }
+        return $this->documentRetrieval;
+    }
+
+    protected function getDocumentPolicy(): ?DocumentPolicyService
+    {
+        if ($this->documentPolicy === null) {
+            $this->documentPolicy = app(DocumentPolicyService::class);
+        }
+        return $this->documentPolicy;
     }
 
     public function chat(
@@ -28,7 +58,24 @@ class LaravelChatService
         ?string $source_policy = null,
         bool $allow_auto_realtime_web = true
     ): \Generator {
-        if ($document_filenames !== null && count($document_filenames) > 0) {
+        $documentFilenamesValid = $document_filenames !== null && count($document_filenames) > 0;
+        $retrievalService = $this->getDocumentRetrieval();
+        $documentPolicy = $this->getDocumentPolicy();
+
+        if ($documentFilenamesValid && $retrievalService && $documentPolicy) {
+            return $this->chatWithDocuments(
+                $messages,
+                $document_filenames,
+                $user_id,
+                $force_web_search,
+                $source_policy,
+                $allow_auto_realtime_web,
+                $retrievalService,
+                $documentPolicy
+            );
+        }
+
+        if ($documentFilenamesValid) {
             yield "⚠️ Chat dengan dokumen aktif belum tersedia via Laravel AI SDK.";
             return;
         }
@@ -78,6 +125,156 @@ class LaravelChatService
         if (!empty($sources)) {
             yield "\n[SOURCES:" . json_encode($sources) . "]\n";
         }
+    }
+
+    protected function chatWithDocuments(
+        array $messages,
+        ?array $document_filenames,
+        ?string $user_id,
+        bool $force_web_search,
+        ?string $source_policy,
+        bool $allow_auto_realtime_web,
+        LaravelDocumentRetrievalService $retrievalService,
+        DocumentPolicyService $documentPolicy
+    ): \Generator {
+        $lastMessage = end($messages);
+        $query = is_array($lastMessage) ? ($lastMessage['content'] ?? '') : (string) $lastMessage;
+
+        $explicitWebRequest = $documentPolicy->detectExplicitWebRequest($query);
+
+        $policyResult = $documentPolicy->shouldUseWebSearch(
+            $query,
+            $force_web_search,
+            $explicitWebRequest,
+            $allow_auto_realtime_web,
+            true
+        );
+
+        $topK = config('ai.rag.top_k', 5);
+        $retrievalResult = $retrievalService->searchRelevantChunks(
+            $query,
+            $document_filenames ?? [],
+            $topK,
+            $user_id ?? ''
+        );
+
+        $chunks = $retrievalResult['chunks'] ?? [];
+        $success = $retrievalResult['success'] ?? false;
+
+        if ($success && !empty($chunks)) {
+            $ragData = $retrievalService->buildRagPrompt($query, $chunks);
+
+            $webContext = '';
+            if ($policyResult['should_search']) {
+                $webContext = '';
+            }
+
+            $prompt = $ragData['prompt'];
+            $sources = $ragData['sources'];
+
+            $messagesWithRag = array_merge(
+                [['role' => 'system', 'content' => $prompt]],
+                $messages
+            );
+
+            $provider = app(\Laravel\Ai\AiManager::class)->textProvider();
+
+            $agent = \Laravel\Ai\AnonymousAgent::make(
+                instructions: 'Anda adalah asisten AI yang menjawab berdasarkan konteks dokumen. '
+                    . 'Jawab seringkas mungkin dan ground jawaban ke dokumen.'
+            );
+
+            $promptObj = \Laravel\Ai\Prompts\AgentPrompt::for(
+                agent: $agent,
+                prompt: $query,
+                attachments: [],
+                provider: $provider,
+                model: $this->model,
+            );
+
+            $stream = $provider->stream($promptObj);
+
+            $allSources = $sources;
+
+            foreach ($stream as $event) {
+                if ($event instanceof TextDelta) {
+                    yield $event->delta;
+                } elseif ($event instanceof Citation) {
+                    $citation = $event->citation;
+                    $allSources[] = [
+                        'title' => $citation->title ?? '',
+                        'url' => $citation->url ?? '',
+                    ];
+                }
+            }
+
+            if (!empty($allSources)) {
+                yield "\n[SOURCES:" . json_encode($allSources) . "]\n";
+            }
+
+            return;
+        }
+
+        if ($success && empty($chunks)) {
+            if ($policyResult['should_search']) {
+                $provider = app(\Laravel\Ai\AiManager::class)->textProvider();
+
+                $tools = [];
+                if ($this->webSearchEnabled) {
+                    $webSearch = new \Laravel\Ai\Providers\Tools\WebSearch();
+                    $tools[] = $provider->webSearchTool($webSearch);
+                }
+
+                $agent = \Laravel\Ai\AnonymousAgent::make(
+                    instructions: $this->getSystemPrompt(),
+                    tools: $tools,
+                );
+
+                $promptObj = \Laravel\Ai\Prompts\AgentPrompt::for(
+                    agent: $agent,
+                    prompt: $query,
+                    attachments: [],
+                    provider: $provider,
+                    model: $this->model,
+                );
+
+                yield from $provider->stream($promptObj);
+                return;
+            }
+
+            $noAnswerMessage = $documentPolicy->getNoAnswerPrompt();
+            yield $noAnswerMessage;
+            return;
+        }
+
+        if ($policyResult['should_search']) {
+            $provider = app(\Laravel\Ai\AiManager::class)->textProvider();
+
+            $tools = [];
+            if ($this->webSearchEnabled) {
+                $webSearch = new \Laravel\Ai\Providers\Tools\WebSearch();
+                $tools[] = $provider->webSearchTool($webSearch);
+            }
+
+            $agent = \Laravel\Ai\AnonymousAgent::make(
+                instructions: $this->getSystemPrompt(),
+                tools: $tools,
+            );
+
+            $promptObj = \Laravel\Ai\Prompts\AgentPrompt::for(
+                agent: $agent,
+                prompt: $query,
+                attachments: [],
+                provider: $provider,
+                model: $this->model,
+            );
+
+            yield from $provider->stream($promptObj);
+            return;
+        }
+
+        $errorMessage = $documentPolicy->getDocumentErrorPrompt();
+        yield $errorMessage;
     }
 
     protected function shouldUseWebSearch(bool $force, bool $auto, ?string $policy): bool

--- a/laravel/app/Services/Document/DocumentPolicyService.php
+++ b/laravel/app/Services/Document/DocumentPolicyService.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Services\Document;
+
+use Illuminate\Support\Facades\Log;
+use App\Services\Chat\LaravelChatService;
+
+class DocumentPolicyService
+{
+    private const EXPLICIT_WEB_PATTERNS = [
+        '/\bcari\s+di\s+web\b/i',
+        '/\bweb\s+search\b/i',
+        '/\bbrowse\s+web\b/i',
+        '/\bsearch\s+online\b/i',
+        '/\bpakai\s+(internet|web)\b/i',
+        '/\btolong\s+cari\s+di\s+internet\b/i',
+    ];
+
+    private const REALTIME_HIGH_PATTERNS = [
+        '/\bsekarang\b/i',
+        '/\bhari\s+ini\b/i',
+        '/\bterbaru\b/i',
+        '/\bterkini\b/i',
+        '/\bupdate\b/i',
+    ];
+
+    private const REALTIME_MEDIUM_KEYWORDS = [
+        'update', 'terbaru', 'terkini', 'berita', 'cuaca', 'jadwal',
+    ];
+
+    public function shouldUseWebSearch(
+        string $query,
+        bool $forceWebSearch = false,
+        bool $explicitWebRequest = false,
+        bool $allowAutoRealtimeWeb = true,
+        bool $documentsActive = false
+    ): array {
+        $realtimeIntent = $this->detectRealtimeIntentLevel($query);
+        $explicitDetected = $explicitWebRequest || $this->detectExplicitWebRequest($query);
+
+        if ($forceWebSearch) {
+            return [
+                'should_search' => true,
+                'reason_code' => $documentsActive ? 'DOC_WEB_TOGGLE' : 'WEB_TOGGLE',
+                'realtime_intent' => $realtimeIntent,
+            ];
+        }
+
+        if ($explicitDetected) {
+            return [
+                'should_search' => true,
+                'reason_code' => $documentsActive ? 'DOC_WEB_EXPLICIT' : 'EXPLICIT_WEB',
+                'realtime_intent' => $realtimeIntent,
+            ];
+        }
+
+        if ($documentsActive) {
+            return [
+                'should_search' => false,
+                'reason_code' => 'DOC_NO_WEB',
+                'realtime_intent' => $realtimeIntent,
+            ];
+        }
+
+        if ($allowAutoRealtimeWeb) {
+            if ($realtimeIntent === 'high') {
+                return [
+                    'should_search' => true,
+                    'reason_code' => 'REALTIME_AUTO_HIGH',
+                    'realtime_intent' => $realtimeIntent,
+                ];
+            }
+            if ($realtimeIntent === 'medium') {
+                return [
+                    'should_search' => true,
+                    'reason_code' => 'REALTIME_AUTO_MEDIUM',
+                    'realtime_intent' => $realtimeIntent,
+                ];
+            }
+        }
+
+        return [
+            'should_search' => false,
+            'reason_code' => 'NO_WEB',
+            'realtime_intent' => $realtimeIntent,
+        ];
+    }
+
+    public function detectExplicitWebRequest(string $query): bool
+    {
+        $normalized = strtolower(trim($query));
+        if ($normalized === '') {
+            return false;
+        }
+
+        foreach (self::EXPLICIT_WEB_PATTERNS as $pattern) {
+            if (preg_match($pattern, $normalized)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function detectRealtimeIntentLevel(string $query): string
+    {
+        $normalized = strtolower(trim($query));
+        if ($normalized === '') {
+            return 'low';
+        }
+
+        foreach (self::REALTIME_HIGH_PATTERNS as $pattern) {
+            if (preg_match($pattern, $normalized)) {
+                return 'high';
+            }
+        }
+
+        $hits = 0;
+        foreach (self::REALTIME_MEDIUM_KEYWORDS as $keyword) {
+            if (str_contains($normalized, $keyword)) {
+                $hits++;
+            }
+        }
+
+        if ($hits >= 2) {
+            return 'medium';
+        }
+        if ($hits === 1 && str_word_count($normalized) <= 4) {
+            return 'medium';
+        }
+
+        return 'low';
+    }
+
+    public function getNoAnswerPrompt(): string
+    {
+        if (app()->bound('config')) {
+            return config(
+                'ai.prompts.no_answer',
+                'Saya belum menemukan informasi tersebut pada dokumen yang sedang aktif. '
+                . 'Jika Anda berkenan, saya bisa melanjutkan dengan web search atau pengetahuan umum.'
+            );
+        }
+
+        return 'Saya belum menemukan informasi tersebut pada dokumen yang sedang aktif. '
+            . 'Jika Anda berkenan, saya bisa melanjutkan dengan web search atau pengetahuan umum.';
+    }
+
+    public function getDocumentErrorPrompt(): string
+    {
+        if (app()->bound('config')) {
+            return config(
+                'ai.prompts.document_error',
+                'Saya belum bisa membaca konteks dari dokumen yang dipilih saat ini. '
+                . 'Jika Anda berkenan, saya bisa melanjutkan dengan web search atau pengetahuan umum.'
+            );
+        }
+
+        return 'Saya belum bisa membaca konteks dari dokumen yang dipilih saat ini. '
+            . 'Jika Anda berkenan, saya bisa melanjutkan dengan web search atau pengetahuan umum.';
+    }
+}

--- a/laravel/app/Services/Document/LaravelDocumentRetrievalService.php
+++ b/laravel/app/Services/Document/LaravelDocumentRetrievalService.php
@@ -1,0 +1,598 @@
+<?php
+
+namespace App\Services\Document;
+
+use App\Contracts\DocumentRetrievalInterface;
+use App\Models\Document;
+use Illuminate\Support\Facades\Log;
+use Laravel\Ai\AiManager;
+use Laravel\Ai\AnonymousAgent;
+use Laravel\Ai\Files;
+use Laravel\Ai\Files\Document as AiDocument;
+use Laravel\Ai\Prompts\AgentPrompt;
+
+class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
+{
+    protected AiManager $ai;
+    protected string $model;
+    protected int $topK;
+    protected bool $useProviderFileSearch;
+
+    private const EXPLICIT_WEB_PATTERNS = [
+        '/\bcari\s+di\s+web\b/i',
+        '/\bweb\s+search\b/i',
+        '/\bbrowse\s+web\b/i',
+        '/\bsearch\s+online\b/i',
+        '/\bpakai\s+(internet|web)\b/i',
+        '/\btolong\s+cari\s+di\s+internet\b/i',
+    ];
+
+    private const REALTIME_HIGH_PATTERNS = [
+        '/\bsekarang\b/i',
+        '/\bhari\s+ini\b/i',
+        '/\bterbaru\b/i',
+        '/\bterkini\b/i',
+        '/\bupdate\b/i',
+    ];
+
+    private const REALTIME_MEDIUM_KEYWORDS = [
+        'update', 'terbaru', 'terkini', 'berita', 'cuaca', 'jadwal',
+    ];
+
+    public function __construct()
+    {
+        $this->ai = app(AiManager::class);
+        $this->model = config('ai.laravel_ai.model', 'gpt-4o-mini');
+        $this->topK = config('ai.rag.top_k', 5);
+        $this->useProviderFileSearch = config('ai.rag.use_provider_file_search', false);
+    }
+
+    public function searchRelevantChunks(
+        string $query,
+        array $filenames,
+        int $topK,
+        string $userId
+    ): array {
+        $chunks = [];
+        $success = false;
+
+        try {
+            if ($this->useProviderFileSearch) {
+                $result = $this->searchViaProviderFileSearch($query, $filenames, $topK, $userId);
+                $chunks = $result['chunks'] ?? [];
+                $success = $result['success'] ?? false;
+            } else {
+                $documents = $this->getDocumentsForUser($filenames, $userId);
+
+                if (empty($documents)) {
+                    Log::info('LaravelDocumentRetrieval: no documents found', [
+                        'filenames' => $filenames,
+                        'user_id' => $userId,
+                    ]);
+                    return [
+                        'chunks' => [],
+                        'success' => false,
+                        'reason' => 'no_documents',
+                    ];
+                }
+
+                $chunks = $this->performSemanticSearch($query, $documents, $topK, $userId);
+                $success = !empty($chunks);
+            }
+
+            Log::info('LaravelDocumentRetrieval: search completed', [
+                'query' => $query,
+                'filenames' => $filenames,
+                'chunks_found' => count($chunks),
+                'success' => $success,
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('LaravelDocumentRetrieval: search failed', [
+                'query' => $query,
+                'error' => $e->getMessage(),
+            ]);
+            return [
+                'chunks' => [],
+                'success' => false,
+                'reason' => 'error',
+                'error' => $e->getMessage(),
+            ];
+        }
+
+        return [
+            'chunks' => $chunks,
+            'success' => $success,
+        ];
+    }
+
+    public function buildRagPrompt(
+        string $question,
+        array $chunks,
+        bool $includeSources = true,
+        string $webContext = ''
+    ): array {
+        if (empty($chunks)) {
+            return [
+                'prompt' => $question,
+                'sources' => [],
+            ];
+        }
+
+        $contextParts = [];
+        $sources = [];
+
+        foreach ($chunks as $chunk) {
+            $filename = $chunk['filename'] ?? 'Dokumen Tidak Diketahui';
+            $contextParts[] = "--- Referensi dari Dokumen: {$filename} ---";
+            $contextParts[] = $chunk['content'] ?? '';
+            $contextParts[] = '';
+
+            if ($includeSources) {
+                $sources[] = [
+                    'filename' => $filename,
+                    'chunk_index' => $chunk['chunk_index'] ?? 0,
+                    'relevance_score' => $chunk['score'] ?? 0,
+                ];
+            }
+        }
+
+        $contextStr = implode("\n", $contextParts);
+
+        $webSection = '';
+        if (trim($webContext) !== '') {
+            $webSection = "\n\nKONTEKS WEB TERBARU:\n{$webContext}\n";
+        }
+
+        $promptTemplate = $this->getRagPromptTemplate();
+        $prompt = str_replace(
+            ['{context_str}', '{web_section}', '{question}'],
+            [$contextStr, $webSection, $question],
+            $promptTemplate
+        );
+
+        return [
+            'prompt' => $prompt,
+            'sources' => $sources,
+        ];
+    }
+
+    public function shouldUseWebSearch(
+        string $query,
+        bool $forceWebSearch = false,
+        bool $explicitWebRequest = false,
+        bool $allowAutoRealtimeWeb = true,
+        bool $documentsActive = false
+    ): array {
+        $realtimeIntent = $this->detectRealtimeIntentLevel($query);
+        $explicitDetected = $explicitWebRequest || $this->detectExplicitWebRequest($query);
+
+        if ($forceWebSearch) {
+            return [
+                'should_search' => true,
+                'reason_code' => $documentsActive ? 'DOC_WEB_TOGGLE' : 'WEB_TOGGLE',
+                'realtime_intent' => $realtimeIntent,
+            ];
+        }
+
+        if ($explicitDetected) {
+            return [
+                'should_search' => true,
+                'reason_code' => $documentsActive ? 'DOC_WEB_EXPLICIT' : 'EXPLICIT_WEB',
+                'realtime_intent' => $realtimeIntent,
+            ];
+        }
+
+        if ($documentsActive) {
+            return [
+                'should_search' => false,
+                'reason_code' => 'DOC_NO_WEB',
+                'realtime_intent' => $realtimeIntent,
+            ];
+        }
+
+        if ($allowAutoRealtimeWeb) {
+            if ($realtimeIntent === 'high') {
+                return [
+                    'should_search' => true,
+                    'reason_code' => 'REALTIME_AUTO_HIGH',
+                    'realtime_intent' => $realtimeIntent,
+                ];
+            }
+            if ($realtimeIntent === 'medium') {
+                return [
+                    'should_search' => true,
+                    'reason_code' => 'REALTIME_AUTO_MEDIUM',
+                    'realtime_intent' => $realtimeIntent,
+                ];
+            }
+        }
+
+        return [
+            'should_search' => false,
+            'reason_code' => 'NO_WEB',
+            'realtime_intent' => $realtimeIntent,
+        ];
+    }
+
+    public function detectExplicitWebRequest(string $query): bool
+    {
+        $normalized = strtolower(trim($query));
+        if ($normalized === '') {
+            return false;
+        }
+
+        foreach (self::EXPLICIT_WEB_PATTERNS as $pattern) {
+            if (preg_match($pattern, $normalized)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function hasDocumentsForUser(string $userId): bool
+    {
+        return Document::where('user_id', (int) $userId)
+            ->where('status', 'ready')
+            ->exists();
+    }
+
+    protected function getDocumentsForUser(array $filenames, string $userId): array
+    {
+        $query = Document::where('user_id', (int) $userId)
+            ->where('status', 'ready');
+
+        if (!empty($filenames)) {
+            $query->whereIn('original_name', $filenames);
+        }
+
+        return $query->get()->toArray();
+    }
+
+    protected function performSemanticSearch(
+        string $query,
+        array $documents,
+        int $topK,
+        string $userId
+    ): array {
+        if (empty($documents)) {
+            return [];
+        }
+
+        $chunks = [];
+        $documentsDir = storage_path('app/documents');
+
+        foreach ($documents as $doc) {
+            $filePath = storage_path('app/' . $doc['file_path']);
+
+            if (!file_exists($filePath)) {
+                Log::warning('LaravelDocumentRetrieval: file not found', [
+                    'path' => $filePath,
+                ]);
+                continue;
+            }
+
+            $docChunks = $this->extractChunksFromDocument($filePath, $doc);
+            $relevantChunks = $this->findRelevantChunks($query, $docChunks, $topK, $doc);
+
+            $chunks = array_merge($chunks, $relevantChunks);
+        }
+
+        usort($chunks, function ($a, $b) {
+            return ($b['score'] ?? 0) <=> ($a['score'] ?? 0);
+        });
+
+        return array_slice($chunks, 0, $topK);
+    }
+
+    protected function extractChunksFromDocument(string $filePath, array $document): array
+    {
+        $extension = pathinfo($filePath, PATHINFO_EXTENSION);
+
+        try {
+            if ($extension === 'pdf') {
+                return $this->extractPdfChunks($filePath, $document);
+            } elseif (in_array($extension, ['docx', 'doc'])) {
+                return $this->extractDocxChunks($filePath, $document);
+            } elseif (in_array($extension, ['xlsx', 'xls', 'csv'])) {
+                return $this->extractExcelChunks($filePath, $document);
+            }
+        } catch (\Throwable $e) {
+            Log::error('LaravelDocumentRetrieval: extract chunks failed', [
+                'file' => $filePath,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return [
+            [
+                'content' => file_get_contents($filePath) ?: '',
+                'chunk_index' => 0,
+                'filename' => $document['original_name'] ?? basename($filePath),
+            ],
+        ];
+    }
+
+    protected function extractPdfChunks(string $filePath, array $document): array
+    {
+        try {
+            $content = \Smcc\PdfParser\Parser::parseFile($filePath);
+            return $this->createChunksFromText($content, $document);
+        } catch (\Throwable $e) {
+            Log::warning('LaravelDocumentRetrieval: PDF parse failed', [
+                'file' => $filePath,
+                'error' => $e->getMessage(),
+            ]);
+            return [];
+        }
+    }
+
+    protected function extractDocxChunks(string $filePath, array $document): array
+    {
+        try {
+            $content = \PhpOffice\PhpWord\IOFactory::load($filePath)->getContent();
+            return $this->createChunksFromText($content, $document);
+        } catch (\Throwable $e) {
+            Log::warning('LaravelDocumentRetrieval: DOCX parse failed', [
+                'file' => $filePath,
+                'error' => $e->getMessage(),
+            ]);
+            return [];
+        }
+    }
+
+    protected function extractExcelChunks(string $filePath, array $document): array
+    {
+        try {
+            $spreadsheet = \PhpOffice\PhpSpreadsheet\IOFactory::load($filePath);
+            $content = '';
+            foreach ($spreadsheet->getAllSheets() as $sheet) {
+                $content .= $sheet->toString() . "\n";
+            }
+            return $this->createChunksFromText($content, $document);
+        } catch (\Throwable $e) {
+            Log::warning('LaravelDocumentRetrieval: Excel parse failed', [
+                'file' => $filePath,
+                'error' => $e->getMessage(),
+            ]);
+            return [];
+        }
+    }
+
+    protected function createChunksFromText(string $text, array $document): array
+    {
+        $chunkSize = config('ai.rag.chunk_size', 1000);
+        $chunkOverlap = config('ai.rag.chunk_overlap', 100);
+
+        $text = preg_replace('/\s+/', ' ', trim($text));
+        $chars = mb_str_split($text);
+
+        $chunks = [];
+        $position = 0;
+
+        while ($position < count($chars)) {
+            $end = min($position + $chunkSize, count($chars));
+            $chunkText = implode('', array_slice($chars, $position, $end - $position));
+
+            if (trim($chunkText) === '') {
+                break;
+            }
+
+            $chunks[] = [
+                'content' => $chunkText,
+                'chunk_index' => count($chunks),
+                'filename' => $document['original_name'] ?? 'unknown',
+                'document_id' => $document['id'] ?? null,
+            ];
+
+            $position += $chunkSize - $chunkOverlap;
+
+            if ($position >= count($chars)) {
+                break;
+            }
+        }
+
+        return $chunks;
+    }
+
+    protected function findRelevantChunks(
+        string $query,
+        array $docChunks,
+        int $topK,
+        array $document
+    ): array {
+        if (empty($docChunks)) {
+            return [];
+        }
+
+        $provider = $this->ai->textProvider();
+
+        $relevantChunks = [];
+        foreach ($docChunks as $chunk) {
+            $score = $this->calculateSimilarity($query, $chunk['content'], $provider);
+
+            $relevantChunks[] = array_merge($chunk, [
+                'score' => $score,
+            ]);
+        }
+
+        usort($relevantChunks, function ($a, $b) {
+            return ($b['score'] ?? 0) <=> ($a['score'] ?? 0);
+        });
+
+        return array_slice($relevantChunks, 0, $topK);
+    }
+
+    protected function calculateSimilarity(string $query, string $content, $provider): float
+    {
+        try {
+            $model = config('ai.rag.embedding_model', 'text-embedding-3-small');
+
+            $embeddingResponse = $provider->embeddings(
+                new \Laravel\Ai\Embeddings\EmbeddingPrompt(
+                    model: $model,
+                    input: $query . ' ' . substr($content, 0, 500),
+                )
+            );
+
+            $queryEmbedding = $embeddingResponse->embeddings[0] ?? [0];
+            $contentEmbedding = $embeddingResponse->embeddings[1] ?? [0];
+
+            return $this->cosineSimilarity($queryEmbedding, $contentEmbedding);
+        } catch (\Throwable $e) {
+            Log::debug('LaravelDocumentRetrieval: similarity calculation failed', [
+                'error' => $e->getMessage(),
+            ]);
+
+            $queryTerms = array_unique(preg_split('/\s+/', strtolower($query)));
+            $contentTerms = array_unique(preg_split('/\s+/', strtolower($content)));
+
+            $intersection = array_intersect($queryTerms, $contentTerms);
+            $union = array_unique(array_merge($queryTerms, $contentTerms));
+
+            if (count($union) === 0) {
+                return 0.0;
+            }
+
+            return count($intersection) / count($union);
+        }
+    }
+
+    protected function cosineSimilarity(array $a, array $b): float
+    {
+        if (empty($a) || empty($b)) {
+            return 0.0;
+        }
+
+        $dotProduct = 0;
+        $normA = 0;
+        $normB = 0;
+
+        $minLen = min(count($a), count($b));
+        for ($i = 0; $i < $minLen; $i++) {
+            $dotProduct += $a[$i] * $b[$i];
+            $normA += $a[$i] * $a[$i];
+            $normB += $b[$i] * $b[$i];
+        }
+
+        $normA = sqrt($normA);
+        $normB = sqrt($normB);
+
+        if ($normA === 0 || $normB === 0) {
+            return 0.0;
+        }
+
+        return $dotProduct / ($normA * $normB);
+    }
+
+    protected function searchViaProviderFileSearch(
+        string $query,
+        array $filenames,
+        int $topK,
+        string $userId
+    ): array {
+        try {
+            $documents = $this->getDocumentsForUser($filenames, $userId);
+
+            if (empty($documents)) {
+                return ['chunks' => [], 'success' => false];
+            }
+
+            $aiDocuments = [];
+            foreach ($documents as $doc) {
+                $filePath = storage_path('app/' . $doc['file_path']);
+                if (file_exists($filePath)) {
+                    $aiDocuments[] = AiDocument::fromPath($filePath);
+                }
+            }
+
+            if (empty($aiDocuments)) {
+                return ['chunks' => [], 'success' => false];
+            }
+
+            $agent = AnonymousAgent::make(
+                instructions: 'Anda adalah asisten AI yang menjawab berdasarkan dokumen yang diberikan. '
+                    . 'Jawab seringkas mungkin dan gunakan konteks dari dokumen.'
+            );
+
+            $files = new Files(...$aiDocuments);
+
+            $prompt = new AgentPrompt(
+                agent: $agent,
+                prompt: "Berdasarkan pertanyaan berikut, carikan informasi yang relevan dari dokumen:\n\n{$query}",
+                files: $files,
+                provider: $this->ai->textProvider(),
+                model: $this->model,
+            );
+
+            $result = $this->ai->textProvider()->prompt($prompt);
+
+            $chunks = [
+                [
+                    'content' => $result->text ?? '',
+                    'score' => 1.0,
+                    'filename' => $filenames[0] ?? 'document',
+                    'chunk_index' => 0,
+                ],
+            ];
+
+            return ['chunks' => $chunks, 'success' => true];
+        } catch (\Throwable $e) {
+            Log::error('LaravelDocumentRetrieval: provider file search failed', [
+                'error' => $e->getMessage(),
+            ]);
+            return ['chunks' => [], 'success' => false];
+        }
+    }
+
+    protected function detectRealtimeIntentLevel(string $query): string
+    {
+        $normalized = strtolower(trim($query));
+        if ($normalized === '') {
+            return 'low';
+        }
+
+        foreach (self::REALTIME_HIGH_PATTERNS as $pattern) {
+            if (preg_match($pattern, $normalized)) {
+                return 'high';
+            }
+        }
+
+        $hits = 0;
+        foreach (self::REALTIME_MEDIUM_KEYWORDS as $keyword) {
+            if (str_contains($normalized, $keyword)) {
+                $hits++;
+            }
+        }
+
+        if ($hits >= 2) {
+            return 'medium';
+        }
+        if ($hits === 1 && str_word_count($normalized) <= 4) {
+            return 'medium';
+        }
+
+        return 'low';
+    }
+
+    protected function getRagPromptTemplate(): string
+    {
+        return config(
+            'ai.prompts.rag',
+            <<<'PROMPT'
+Anda adalah asisten AI yang menjawab berdasarkan dokumen yang diberikan.
+
+Jika menjawab berdasarkan dokumen, gunakan informasi dari konteks di bawah ini. 
+Jangan membuat informasi yang tidak ada di dokumen.
+
+KONTEKS DOKUMEN:
+{context_str}
+{web_section}
+
+Pertanyaan: {question}
+
+JAWABAN:
+PROMPT
+        );
+    }
+}

--- a/laravel/app/Services/Document/LaravelDocumentRetrievalService.php
+++ b/laravel/app/Services/Document/LaravelDocumentRetrievalService.php
@@ -426,13 +426,16 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
     protected function calculateSimilarity(string $query, string $content, $provider): float
     {
         try {
-            $model = config('ai.rag.embedding_model', 'text-embedding-3-small');
+            $model = config('ai.rag.embedding_model');
+            $dimensions = (int) config('ai.rag.embedding_dimensions', 1536);
 
             $embeddingResponse = $provider->embeddings(
-                new \Laravel\Ai\Embeddings\EmbeddingPrompt(
-                    model: $model,
-                    input: $query . ' ' . substr($content, 0, 500),
-                )
+                [
+                    $query,
+                    substr($content, 0, 500),
+                ],
+                $dimensions,
+                $model
             );
 
             $queryEmbedding = $embeddingResponse->embeddings[0] ?? [0];

--- a/laravel/app/Services/Runtime/LaravelAIGateway.php
+++ b/laravel/app/Services/Runtime/LaravelAIGateway.php
@@ -5,10 +5,13 @@ namespace App\Services\Runtime;
 use App\Contracts\AIRuntimeInterface;
 use App\Services\Chat\LaravelChatService;
 use App\Services\Document\LaravelDocumentService;
+use App\Services\Document\LaravelDocumentRetrievalService;
 use Illuminate\Support\Facades\Log;
 
 class LaravelAIGateway implements AIRuntimeInterface
 {
+    protected ?LaravelDocumentRetrievalService $documentRetrievalService = null;
+
     public function chat(
         array $messages,
         ?array $document_filenames = null,
@@ -17,9 +20,26 @@ class LaravelAIGateway implements AIRuntimeInterface
         ?string $source_policy = null,
         bool $allow_auto_realtime_web = true
     ): \Generator {
-        $document_filenames_valid = $document_filenames !== null && count($document_filenames) > 0;
+        $documentFilenamesValid = $document_filenames !== null && count($document_filenames) > 0;
 
-        if ($document_filenames_valid) {
+        if ($documentFilenamesValid && $this->isDocumentRetrievalEnabled()) {
+            $retrievalService = $this->getDocumentRetrievalService();
+
+            if ($retrievalService !== null) {
+                $service = new LaravelChatService();
+                yield from $service->chat(
+                    $messages,
+                    $document_filenames,
+                    $user_id,
+                    $force_web_search,
+                    $source_policy,
+                    $allow_auto_realtime_web
+                );
+                return;
+            }
+        }
+
+        if ($documentFilenamesValid) {
             $python = new PythonLegacyAdapter();
             return $python->chat(
                 $messages,
@@ -68,6 +88,28 @@ class LaravelAIGateway implements AIRuntimeInterface
 
         return config('ai.laravel_ai.document_process_enabled', false)
             || config('ai.laravel_ai.document_summarize_enabled', false)
-            || config('ai.laravel_ai.document_delete_enabled', true);
+            || config('ai.laravel_ai.document_delete_enabled', true)
+            || $this->isDocumentRetrievalEnabled();
+    }
+
+    protected function isDocumentRetrievalEnabled(): bool
+    {
+        return config('ai.laravel_ai.document_retrieval_enabled', false) === true;
+    }
+
+    protected function getDocumentRetrievalService(): ?LaravelDocumentRetrievalService
+    {
+        if ($this->documentRetrievalService === null) {
+            if ($this->isDocumentRetrievalEnabled()) {
+                try {
+                    $this->documentRetrievalService = app(LaravelDocumentRetrievalService::class);
+                } catch (\Throwable $e) {
+                    Log::warning('LaravelAIGateway: document retrieval service initialization failed', [
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+        }
+        return $this->documentRetrievalService;
     }
 }

--- a/laravel/config/ai.php
+++ b/laravel/config/ai.php
@@ -37,6 +37,35 @@ return [
         'document_process_enabled' => env('AI_DOCUMENT_PROCESS_ENABLED', false),
         'document_summarize_enabled' => env('AI_DOCUMENT_SUMMARIZE_ENABLED', false),
         'document_delete_enabled' => env('AI_DOCUMENT_DELETE_ENABLED', true),
+        'document_retrieval_enabled' => env('AI_DOCUMENT_RETRIEVAL_ENABLED', false),
+        'use_provider_file_search' => env('AI_USE_PROVIDER_FILE_SEARCH', false),
+    ],
+
+    'rag' => [
+        'top_k' => env('RAG_TOP_K', 5),
+        'chunk_size' => env('RAG_CHUNK_SIZE', 1000),
+        'chunk_overlap' => env('RAG_CHUNK_OVERLAP', 100),
+        'embedding_model' => env('RAG_EMBEDDING_MODEL', 'text-embedding-3-small'),
+    ],
+
+    'prompts' => [
+        'rag' => <<<'PROMPT'
+Anda adalah asisten AI yang menjawab berdasarkan dokumen yang diberikan.
+
+Jika menjawab berdasarkan dokumen, gunakan informasi dari konteks di bawah ini. 
+Jangan membuat informasi yang tidak ada di dokumen.
+
+KONTEKS DOKUMEN:
+{context_str}
+{web_section}
+
+Pertanyaan: {question}
+
+JAWABAN:
+PROMPT
+        ,
+        'no_answer' => 'Saya belum menemukan informasi tersebut pada dokumen yang sedang aktif. Jika Anda berkenan, saya bisa melanjutkan dengan web search atau pengetahuan umum.',
+        'document_error' => 'Saya belum bisa membaca konteks dari dokumen yang dipilih saat ini. Jika Anda berkenan, saya bisa melanjutkan dengan web search atau pengetahuan umum.',
     ],
 
 ];

--- a/laravel/config/ai.php
+++ b/laravel/config/ai.php
@@ -46,6 +46,7 @@ return [
         'chunk_size' => env('RAG_CHUNK_SIZE', 1000),
         'chunk_overlap' => env('RAG_CHUNK_OVERLAP', 100),
         'embedding_model' => env('RAG_EMBEDDING_MODEL', 'text-embedding-3-small'),
+        'embedding_dimensions' => env('RAG_EMBEDDING_DIMENSIONS', 1536),
     ],
 
     'prompts' => [

--- a/laravel/config/ai_runtime.php
+++ b/laravel/config/ai_runtime.php
@@ -4,6 +4,8 @@ return [
 
     'chat' => env('AI_RUNTIME_CHAT', 'python'),
 
+    'document_retrieval' => env('AI_RUNTIME_DOCUMENT_RETRIEVAL', 'python'),
+
     'document_process' => env('AI_RUNTIME_DOCUMENT_PROCESS', 'laravel'),
 
     'document_summarize' => env('AI_RUNTIME_DOCUMENT_SUMMARIZE', 'laravel'),

--- a/laravel/tests/Unit/Services/Chat/LaravelChatServiceTest.php
+++ b/laravel/tests/Unit/Services/Chat/LaravelChatServiceTest.php
@@ -3,9 +3,18 @@
 namespace Tests\Unit\Services\Chat;
 
 use App\Services\Chat\LaravelChatService;
+use App\Services\Document\DocumentPolicyService;
+use App\Services\Document\LaravelDocumentRetrievalService;
 use Illuminate\Support\Facades\Config;
+use Laravel\Ai\AiManager;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\UrlCitation;
+use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\Citation;
+use Mockery;
 use Tests\TestCase;
 
 class LaravelChatServiceTest extends TestCase
@@ -171,7 +180,7 @@ class LaravelChatServiceTest extends TestCase
 
     public function test_citation_emits_source_metadata(): void
     {
-        $citationData = new \Laravel\Ai\Responses\Data\UrlCitation(
+        $citationData = new UrlCitation(
             title: 'Test Title',
             url: 'https://example.com'
         );
@@ -186,5 +195,140 @@ class LaravelChatServiceTest extends TestCase
         $this->assertInstanceOf(Citation::class, $event);
         $this->assertEquals('Test Title', $event->citation->title);
         $this->assertEquals('https://example.com', $event->citation->url);
+    }
+
+    public function test_chat_with_documents_success_uses_rag_prompt_and_document_sources(): void
+    {
+        $this->setUpLaravelAIConfig();
+        Config::set('ai.laravel_ai.document_retrieval_enabled', true);
+
+        $retrieval = Mockery::mock(LaravelDocumentRetrievalService::class);
+        $retrieval->shouldReceive('searchRelevantChunks')
+            ->once()
+            ->andReturn([
+                'success' => true,
+                'chunks' => [
+                    ['content' => 'isi chunk', 'filename' => 'doc1.pdf', 'chunk_index' => 0, 'score' => 0.95],
+                ],
+            ]);
+        $retrieval->shouldReceive('buildRagPrompt')
+            ->once()
+            ->andReturn([
+                'prompt' => 'RAG_CONTEXT_PROMPT',
+                'sources' => [
+                    ['filename' => 'doc1.pdf', 'chunk_index' => 0, 'relevance_score' => 0.95],
+                ],
+            ]);
+
+        $policy = Mockery::mock(DocumentPolicyService::class);
+        $policy->shouldReceive('detectExplicitWebRequest')->once()->andReturn(false);
+        $policy->shouldReceive('shouldUseWebSearch')->once()->andReturn([
+            'should_search' => false,
+            'reason_code' => 'DOC_NO_WEB',
+        ]);
+
+        $provider = Mockery::mock(TextProvider::class);
+        $provider->shouldReceive('stream')
+            ->once()
+            ->with(Mockery::on(function ($prompt) {
+                return $prompt instanceof AgentPrompt
+                    && $prompt->prompt === 'RAG_CONTEXT_PROMPT';
+            }))
+            ->andReturn($this->streamableResponseFromEvents([
+                new TextDelta(id: '1', messageId: 'm1', delta: 'Jawaban grounded', timestamp: time()),
+            ]));
+
+        $ai = Mockery::mock(AiManager::class);
+        $ai->shouldReceive('textProvider')->once()->andReturn($provider);
+
+        $this->app->instance(LaravelDocumentRetrievalService::class, $retrieval);
+        $this->app->instance(DocumentPolicyService::class, $policy);
+        $this->app->instance(AiManager::class, $ai);
+
+        $service = new LaravelChatService();
+        $result = $service->chat(
+            [['role' => 'user', 'content' => 'apa isi dokumen?']],
+            ['doc1.pdf'],
+            '1'
+        );
+
+        $output = implode('', iterator_to_array($result));
+
+        $this->assertStringContainsString('Jawaban grounded', $output);
+        $this->assertStringContainsString('[SOURCES:', $output);
+        $this->assertStringContainsString('doc1.pdf', $output);
+    }
+
+    public function test_chat_with_documents_web_fallback_normalizes_stream_and_citations(): void
+    {
+        $this->setUpLaravelAIConfig();
+        Config::set('ai.laravel_ai.document_retrieval_enabled', true);
+
+        $retrieval = Mockery::mock(LaravelDocumentRetrievalService::class);
+        $retrieval->shouldReceive('searchRelevantChunks')
+            ->once()
+            ->andReturn([
+                'success' => true,
+                'chunks' => [],
+            ]);
+
+        $policy = Mockery::mock(DocumentPolicyService::class);
+        $policy->shouldReceive('detectExplicitWebRequest')->once()->andReturn(true);
+        $policy->shouldReceive('shouldUseWebSearch')->once()->andReturn([
+            'should_search' => true,
+            'reason_code' => 'DOC_WEB_EXPLICIT',
+        ]);
+
+        $provider = Mockery::mock(TextProvider::class);
+        $provider->shouldReceive('webSearchTool')->once()->andReturn(new \stdClass());
+        $provider->shouldReceive('stream')
+            ->once()
+            ->with(Mockery::type(AgentPrompt::class))
+            ->andReturn($this->streamableResponseFromEvents([
+                new TextDelta(id: '2', messageId: 'm2', delta: 'Jawaban dari web', timestamp: time()),
+                new Citation(
+                    id: '3',
+                    messageId: 'm2',
+                    citation: new UrlCitation(title: 'Web Ref', url: 'https://example.com/ref'),
+                    timestamp: time()
+                ),
+            ]));
+
+        $ai = Mockery::mock(AiManager::class);
+        $ai->shouldReceive('textProvider')->once()->andReturn($provider);
+
+        $this->app->instance(LaravelDocumentRetrievalService::class, $retrieval);
+        $this->app->instance(DocumentPolicyService::class, $policy);
+        $this->app->instance(AiManager::class, $ai);
+
+        $service = new LaravelChatService();
+        $result = $service->chat(
+            [['role' => 'user', 'content' => 'cari di web ini']],
+            ['doc1.pdf'],
+            '1'
+        );
+
+        $output = implode('', iterator_to_array($result));
+
+        $this->assertStringContainsString('Jawaban dari web', $output);
+        $this->assertStringContainsString('[SOURCES:', $output);
+        $this->assertStringContainsString('Web Ref', $output);
+        $this->assertStringContainsString('example.com\\/ref', $output);
+    }
+
+    private function streamFromEvents(array $events): \Generator
+    {
+        foreach ($events as $event) {
+            yield $event;
+        }
+    }
+
+    private function streamableResponseFromEvents(array $events): StreamableAgentResponse
+    {
+        return new StreamableAgentResponse(
+            invocationId: 'test-invocation',
+            generator: fn () => $this->streamFromEvents($events),
+            meta: new Meta(provider: 'test', model: 'test-model')
+        );
     }
 }

--- a/laravel/tests/Unit/Services/Document/DocumentPolicyServiceTest.php
+++ b/laravel/tests/Unit/Services/Document/DocumentPolicyServiceTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Tests\Unit\Services\Document;
+
+use App\Services\Document\DocumentPolicyService;
+use PHPUnit\Framework\TestCase;
+
+class DocumentPolicyServiceTest extends TestCase
+{
+    private DocumentPolicyService $policyService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->policyService = new DocumentPolicyService();
+    }
+
+    public function test_explicit_web_request_detected(): void
+    {
+        $queries = [
+            'cari di web tentang resep masakan',
+            'pakai internet untuk mencari info ini',
+            'web search berita hari ini',
+            'browse web untuk jadwal',
+            'search online harga tiket',
+        ];
+
+        foreach ($queries as $query) {
+            $this->assertTrue(
+                $this->policyService->detectExplicitWebRequest($query),
+                "Query '{$query}' harus terdeteksi sebagai explicit web request"
+            );
+        }
+    }
+
+    public function test_non_explicit_web_request_not_detected(): void
+    {
+        $queries = [
+            'apa itu machine learning',
+            'jelaskan cuaca hari ini',
+            'kurs dollar',
+        ];
+
+        foreach ($queries as $query) {
+            $this->assertFalse(
+                $this->policyService->detectExplicitWebRequest($query),
+                "Query '{$query}' seharusnya bukan explicit web request"
+            );
+        }
+    }
+
+    public function test_documents_active_blocks_web(): void
+    {
+        $queries = [
+            'kurs dollar sekarang',
+            'cuaca hari ini',
+            'berita terbaru indonesia',
+        ];
+
+        foreach ($queries as $query) {
+            $result = $this->policyService->shouldUseWebSearch(
+                query: $query,
+                forceWebSearch: false,
+                explicitWebRequest: false,
+                allowAutoRealtimeWeb: true,
+                documentsActive: true
+            );
+
+            $this->assertFalse(
+                $result['should_search'],
+                "Query '{$query}' dengan docs aktif harus MATI web, tapi result: " . json_encode($result)
+            );
+            $this->assertEquals(
+                'DOC_NO_WEB',
+                $result['reason_code'],
+                "Reason code harus DOC_NO_WEB untuk query '{$query}'"
+            );
+        }
+    }
+
+    public function test_force_web_always_enabled(): void
+    {
+        $result = $this->policyService->shouldUseWebSearch(
+            query: 'apa itu python',
+            forceWebSearch: true,
+            explicitWebRequest: false,
+            allowAutoRealtimeWeb: true,
+            documentsActive: false
+        );
+
+        $this->assertTrue($result['should_search']);
+        $this->assertStringContainsString('TOGGLE', $result['reason_code']);
+    }
+
+    public function test_explicit_web_request_triggers_search(): void
+    {
+        $result = $this->policyService->shouldUseWebSearch(
+            query: 'cari di web tentang inflasi',
+            forceWebSearch: false,
+            explicitWebRequest: false,
+            allowAutoRealtimeWeb: true,
+            documentsActive: false
+        );
+
+        $this->assertTrue($result['should_search']);
+        $this->assertEquals('EXPLICIT_WEB', $result['reason_code']);
+    }
+
+    public function test_high_realtime_intent_triggers_web(): void
+    {
+        $queries = [
+            'kurs dollar sekarang',
+            'cuaca hari ini jakarta',
+            'berita terbaru indonesia',
+            'harga saham hari ini',
+        ];
+
+        foreach ($queries as $query) {
+            $result = $this->policyService->shouldUseWebSearch(
+                query: $query,
+                forceWebSearch: false,
+                explicitWebRequest: false,
+                allowAutoRealtimeWeb: true,
+                documentsActive: false
+            );
+
+            $this->assertTrue(
+                $result['should_search'],
+                "Query '{$query}' harus trigger web search dengan high intent"
+            );
+            $this->assertStringContainsString('REALTIME', $result['reason_code']);
+        }
+    }
+
+    public function test_low_intent_no_web(): void
+    {
+        $queries = [
+            'apa itu fotosintesis',
+            'jelaskan teori relativitas',
+            'siapa albert einstein',
+        ];
+
+        foreach ($queries as $query) {
+            $result = $this->policyService->shouldUseWebSearch(
+                query: $query,
+                forceWebSearch: false,
+                explicitWebRequest: false,
+                allowAutoRealtimeWeb: true,
+                documentsActive: false
+            );
+
+            $this->assertFalse($result['should_search']);
+            $this->assertEquals('NO_WEB', $result['reason_code']);
+        }
+    }
+
+    public function test_realtime_intent_level_returns_high_for_realtime_queries(): void
+    {
+        $highQueries = [
+            'kurs dollar sekarang',
+            'cuaca hari ini jakarta',
+            'berita terbaru indonesia',
+            'berita terkini',
+            'harga saham hari ini',
+        ];
+
+        foreach ($highQueries as $query) {
+            $intent = $this->policyService->detectRealtimeIntentLevel($query);
+            $this->assertEquals(
+                'high',
+                $intent,
+                "Query '{$query}' harus memiliki intent level 'high', got '{$intent}'"
+            );
+        }
+    }
+
+    public function test_realtime_intent_level_returns_low_for_stable_queries(): void
+    {
+        $lowQueries = [
+            'apa itu fotosintesis',
+            'jelaskan teori relativitas',
+            'siapa albert einstein',
+            'cara membuat kue',
+            'pengertian demokrasi',
+        ];
+
+        foreach ($lowQueries as $query) {
+            $intent = $this->policyService->detectRealtimeIntentLevel($query);
+            $this->assertEquals(
+                'low',
+                $intent,
+                "Query '{$query}' harus memiliki intent level 'low', got '{$intent}'"
+            );
+        }
+    }
+
+    public function test_no_answer_prompt_is_user_facing(): void
+    {
+        $prompt = $this->policyService->getNoAnswerPrompt();
+
+        $this->assertNotEmpty($prompt);
+        $this->assertStringContainsString('belum menemukan', $prompt);
+    }
+
+    public function test_document_error_prompt_is_user_facing(): void
+    {
+        $prompt = $this->policyService->getDocumentErrorPrompt();
+
+        $this->assertNotEmpty($prompt);
+        $this->assertStringContainsString('belum bisa membaca', $prompt);
+    }
+}

--- a/laravel/tests/Unit/Services/Document/LaravelDocumentRetrievalServiceTest.php
+++ b/laravel/tests/Unit/Services/Document/LaravelDocumentRetrievalServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Unit\Services\Document;
+
+use App\Services\Document\LaravelDocumentRetrievalService;
+use Illuminate\Support\Facades\Config;
+use Laravel\Ai\AiManager;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\EmbeddingsResponse;
+use Mockery;
+use Tests\TestCase;
+
+class LaravelDocumentRetrievalServiceTest extends TestCase
+{
+    public function test_calculate_similarity_uses_sdk_embeddings_api_shape(): void
+    {
+        Config::set('ai.rag.embedding_model', 'text-embedding-3-small');
+        Config::set('ai.rag.embedding_dimensions', 1536);
+
+        $this->app->instance(AiManager::class, Mockery::mock(AiManager::class));
+
+        $service = new LaravelDocumentRetrievalService();
+
+        $provider = new class
+        {
+            public array $inputs = [];
+            public ?int $dimensions = null;
+            public ?string $model = null;
+
+            public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30): EmbeddingsResponse
+            {
+                $this->inputs = $inputs;
+                $this->dimensions = $dimensions;
+                $this->model = $model;
+
+                return new EmbeddingsResponse(
+                    embeddings: [[1.0, 0.0], [1.0, 0.0]],
+                    tokens: 2,
+                    meta: new Meta(provider: 'test', model: 'embedding-model')
+                );
+            }
+        };
+
+        $score = $this->invokeCalculateSimilarity($service, 'query contoh', 'konten contoh', $provider);
+
+        $this->assertSame(['query contoh', 'konten contoh'], $provider->inputs);
+        $this->assertSame(1536, $provider->dimensions);
+        $this->assertSame('text-embedding-3-small', $provider->model);
+        $this->assertEquals(1.0, $score);
+    }
+
+    public function test_calculate_similarity_falls_back_to_lexical_overlap_when_embeddings_fail(): void
+    {
+        $this->app->instance(AiManager::class, Mockery::mock(AiManager::class));
+
+        $service = new LaravelDocumentRetrievalService();
+
+        $provider = new class
+        {
+            public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30): EmbeddingsResponse
+            {
+                throw new \RuntimeException('Embeddings unavailable');
+            }
+        };
+
+        $score = $this->invokeCalculateSimilarity($service, 'apel mangga', 'apel jeruk', $provider);
+
+        $this->assertGreaterThan(0.0, $score);
+        $this->assertLessThan(1.0, $score);
+    }
+
+    private function invokeCalculateSimilarity(
+        LaravelDocumentRetrievalService $service,
+        string $query,
+        string $content,
+        object $provider
+    ): float {
+        $reflection = new \ReflectionClass($service);
+        $method = $reflection->getMethod('calculateSimilarity');
+        $method->setAccessible(true);
+
+        return $method->invoke($service, $query, $content, $provider);
+    }
+}


### PR DESCRIPTION
<!-- opencode-standardized: github-writing-standard-v1 -->
## Ringkasan
- Implement document retrieval dan policy services untuk enable RAG via Laravel-only runtime
- Preserve document-first policy (documents_active blocks auto web)
- Feature flag controlled via `ai.laravel_ai.document_retrieval_enabled`

## Perubahan Utama
| File / Area | Deskripsi |
|---|---|
| Area umum | File spesifik tidak dicatat eksplisit pada body lama. |

### Detail Perubahan
- Implement document retrieval dan policy services untuk enable RAG via Laravel-only runtime
- Preserve document-first policy (documents_active blocks auto web)
- Feature flag controlled via `ai.laravel_ai.document_retrieval_enabled`

## Validasi
- Laravel: 115 tests pass
- Python: web search policy tests pass

## Deploy / QA
- Status PR: Merged
- Base branch: `main`
- Head branch: `feature/issue-73-rag-document-laravel-ai-sdk`
- Merged at: 2026-04-23T01:57:17Z
- Closed at: 2026-04-23T01:57:17Z
- Deploy/QA tidak dicatat eksplisit pada body lama.

## Catatan / Risiko Residual
- Risiko residual tidak dicatat eksplisit pada body lama.

## Relasi Issue
- Relasi issue tidak ditemukan eksplisit pada body lama.

## Catatan Historis
<details>
<summary>Body sebelum standardisasi</summary>

## Status Arsip

Item ini diarsipkan sebagai bagian dari rangkaian **migrasi Laravel-only / AI parity** yang sudah tidak menjadi jalur roadmap aktif. Roadmap aktif kembali mengacu ke issue utama #1, dengan kelanjutan Tahap 6 dan Tahap 7 di #116-#119 dan PR #120.

- Jenis item: Pull Request #81.
- Status GitHub saat dirapikan: MERGED.
- Keputusan: jangan dipakai sebagai acuan implementasi baru kecuali untuk referensi historis.
- Catatan: konten lama tetap dipertahankan di bawah agar riwayat teknis masih bisa ditelusuri.

## Konten Lama

## Summary
- Implement document retrieval dan policy services untuk enable RAG via Laravel-only runtime
- Preserve document-first policy (documents_active blocks auto web)
- Feature flag controlled via `ai.laravel_ai.document_retrieval_enabled`

## Changes
- New: DocumentRetrievalInterface.php, LaravelDocumentRetrievalService.php, DocumentPolicyService.php
- Modified: LaravelChatService.php, LaravelAIGateway.php
- Config: ai.php (rag config), ai_runtime.php (document_retrieval runtime)

## Tests
- Laravel: 115 tests pass
- Python: web search policy tests pass

</details>
