### PR TITLE
Arsip AI Parity: Recovery Issue #87 setelah Revert

### DIFF
--- a/issue/issue-87-embedding-cascade-vector-storage.md
+++ b/issue/issue-87-embedding-cascade-vector-storage.md
@@ -5,6 +5,16 @@ Issue ini bertujuan untuk memindahkan tanggung jawab embedding dan pencarian vek
 
 Parent Issue: #84
 
+## Status Rework
+- PR `#97` sempat ter-merge ke `main`, lalu direvert melalui commit `d4dcdbb7f307a48616fb08e9987938fbd9181a62`.
+- Branch recovery ini memulihkan implementasi issue `#87` di atas `main` terbaru tanpa mengubah history `main`.
+- Fokus rework setelah revert:
+  - menormalkan `meta->model` provider ke model canonical node cascade
+  - mencegah fallback diam-diam ke provider default saat `targetModel` tidak bisa dipetakan
+  - menambah regression test untuk scoped re-embedding per dokumen
+  - menambah regression test untuk transisi dimensi `large` / `small`
+  - menjaga lexical fallback tetap mengembalikan chunk saat query embedding gagal
+
 ## Tujuan
 1.  **Embedding Cascade**: Implementasi 4 level fallback untuk embedding menggunakan GitHub Models:
     -   `text-embedding-3-large` + `GITHUB_TOKEN`
@@ -31,34 +41,39 @@ Parent Issue: #84
 ## Langkah Implementasi
 
 ### 1. Fondasi dan Model
-- [ ] Buat migration untuk tabel `document_chunks` (jika belum lengkap) atau update untuk menambah kolom embedding.
-- [ ] Buat model `DocumentChunk` dan relasi di model `Document`.
-- [ ] Tambahkan konfigurasi `ai.embedding_cascade` di `config/ai.php`.
+- [x] Buat migration untuk tabel `document_chunks` (jika belum lengkap) atau update untuk menambah kolom embedding.
+- [x] Buat model `DocumentChunk` dan relasi di model `Document`.
+- [x] Tambahkan konfigurasi `ai.embedding_cascade` di `config/ai.php`.
 
 ### 2. Embedding Cascade Service
-- [ ] Implementasikan `EmbeddingCascadeService` dengan metode `embed(array $inputs)`.
-- [ ] Pastikan error handling yang tepat untuk memicu fallback ke node berikutnya dalam cascade.
-- [ ] Tambahkan logging untuk setiap percobaan dalam cascade.
+- [x] Implementasikan `EmbeddingCascadeService` dengan metode `embed(array $inputs)`.
+- [x] Pastikan error handling yang tepat untuk memicu fallback ke node berikutnya dalam cascade.
+- [x] Tambahkan logging untuk setiap percobaan dalam cascade.
+- [x] Tambahkan normalisasi model response ke model canonical node cascade.
 
 ### 3. Vector Storage & Retrieval Refactor
-- [ ] Update `LaravelDocumentRetrievalService` untuk melakukan "lazy ingestion":
+- [x] Update `LaravelDocumentRetrievalService` untuk melakukan "lazy ingestion":
     - Cek apakah chunk sudah ada di DB dan punya embedding dengan model/dimensi yang sesuai.
     - Jika belum, lakukan chunking (jika belum) dan hitung embedding via `EmbeddingCascadeService`.
     - Simpan ke DB.
-- [ ] Implementasikan pencarian vektor di database menggunakan `cosineSimilarity` (tetap di PHP untuk awal, sesuai arsitektur Laravel-only tanpa plugin DB khusus).
+- [x] Implementasikan pencarian vektor di database menggunakan `cosineSimilarity` (tetap di PHP untuk awal, sesuai arsitektur Laravel-only tanpa plugin DB khusus).
+- [x] Pastikan re-embedding tetap scoped ke dokumen aktif.
+- [x] Pastikan transisi dimensi `large` / `small` memicu re-embedding yang konsisten.
 
 ### 4. Verifikasi
-- [ ] Test unit untuk `EmbeddingCascadeService`.
-- [ ] Test integrasi untuk `LaravelDocumentRetrievalService` dengan database.
-- [ ] Pastikan tidak ada regresi pada flow chat yang sudah ada.
+- [x] Test unit untuk `EmbeddingCascadeService`.
+- [x] Test integrasi untuk `LaravelDocumentRetrievalService` dengan database.
+- [x] Pastikan tidak ada regresi pada flow chat yang sudah ada.
 
 ## Rencana Test
 1.  **Test Fallback**: Mock error pada `GITHUB_TOKEN` dan pastikan sistem beralih ke `GITHUB_TOKEN_2`.
-2.  **Test Dimensi**: Pastikan jika model berubah dari large ke small, sistem tidak mencoba membandingkan vektor dengan panjang berbeda.
-3.  **Test Persistence**: Upload dokumen, tanya chat, hapus cache (jika ada), tanya lagi, pastikan embedding diambil dari DB (bukan hit ulang API jika data masih valid).
+2.  **Test Canonical Model**: Pastikan response model provider dinormalkan ke model node yang disepakati.
+3.  **Test Dimensi**: Pastikan jika model berubah dari large ke small, sistem tidak mencoba membandingkan vektor dengan panjang berbeda dan melakukan re-embedding yang benar.
+4.  **Test Scoped Re-Embedding**: Pastikan komputasi embedding hanya menyentuh chunk dokumen aktif.
+5.  **Test Lexical Fallback**: Pastikan pencarian tetap mengembalikan chunk ketika query embedding gagal total.
 
 ## Kriteria Selesai
-- [ ] Embedding cascade berjalan sesuai spesifikasi (4 level).
-- [ ] Embedding disimpan di database dan digunakan kembali (tidak re-compute on-the-fly setiap request).
-- [ ] Pencarian tetap akurat dan menangani dimensi 3072/1536.
-- [ ] Lolos test `php artisan test`.
+- [x] Embedding cascade berjalan sesuai spesifikasi (4 level).
+- [x] Embedding disimpan di database dan digunakan kembali (tidak re-compute on-the-fly setiap request).
+- [x] Pencarian tetap akurat dan menangani dimensi 3072/1536.
+- [x] Lolos test `php artisan test`.

--- a/issue/issue-87-embedding-cascade-vector-storage.md
+++ b/issue/issue-87-embedding-cascade-vector-storage.md
@@ -1,0 +1,64 @@
+# Issue Plan: Embedding Cascade GitHub Models dan Storage Vector Laravel
+
+## Deskripsi
+Issue ini bertujuan untuk memindahkan tanggung jawab embedding dan pencarian vektor dari Python ke Laravel sepenuhnya (Laravel-only). Ini melibatkan implementasi cascade embedding menggunakan GitHub Models sebagai fallback jika satu token/model gagal, serta mekanisme penyimpanan vektor yang kompatibel dengan Laravel untuk menggantikan fungsionalitas Chroma.
+
+Parent Issue: #84
+
+## Tujuan
+1.  **Embedding Cascade**: Implementasi 4 level fallback untuk embedding menggunakan GitHub Models:
+    -   `text-embedding-3-large` + `GITHUB_TOKEN`
+    -   `text-embedding-3-large` + `GITHUB_TOKEN_2`
+    -   `text-embedding-3-small` + `GITHUB_TOKEN`
+    -   `text-embedding-3-small` + `GITHUB_TOKEN_2`
+2.  **Storage Vector**: Menyimpan embedding dalam database Laravel agar tidak perlu dihitung ulang setiap kali pencarian dilakukan.
+3.  **Dimensi Eksplisit**: Menangani perbedaan dimensi (3072 untuk large, 1536 untuk small) secara aman.
+4.  **Usage Logging**: Mencatat penggunaan token dan model untuk observabilitas.
+
+## Ruang Lingkup
+1.  **Konfigurasi**: Menambahkan konfigurasi cascade embedding di `config/ai.php`.
+2.  **Service Baru**: Membuat `App\Services\AI\EmbeddingCascadeService` untuk menangani logika fallback.
+3.  **Database**: 
+    - Membuat model `App\Models\DocumentChunk`.
+    - Menambah kolom `embedding`, `embedding_model`, and `embedding_dimensions` pada tabel `document_chunks`.
+4.  **Refactor Retrieval**: Mengubah `LaravelDocumentRetrievalService` agar menggunakan cache embedding di database dan memanggil service cascade jika belum ada.
+
+## Risiko
+- **Kualitas Pencarian**: Perubahan dimensi embedding (large ke small) dalam satu dokumen dapat merusak hasil pencarian jika tidak ditangani dengan benar (misal: menghapus embedding lama jika model berubah).
+- **Performa Database**: Mencari kemiripan kosinus (cosine similarity) di PHP/MySQL pada ribuan chunk mungkin lambat jika tidak dioptimalkan.
+- **Rate Limit**: Cascade membantu, tetapi tetap ada risiko rate limit jika traffic tinggi.
+
+## Langkah Implementasi
+
+### 1. Fondasi dan Model
+- [ ] Buat migration untuk tabel `document_chunks` (jika belum lengkap) atau update untuk menambah kolom embedding.
+- [ ] Buat model `DocumentChunk` dan relasi di model `Document`.
+- [ ] Tambahkan konfigurasi `ai.embedding_cascade` di `config/ai.php`.
+
+### 2. Embedding Cascade Service
+- [ ] Implementasikan `EmbeddingCascadeService` dengan metode `embed(array $inputs)`.
+- [ ] Pastikan error handling yang tepat untuk memicu fallback ke node berikutnya dalam cascade.
+- [ ] Tambahkan logging untuk setiap percobaan dalam cascade.
+
+### 3. Vector Storage & Retrieval Refactor
+- [ ] Update `LaravelDocumentRetrievalService` untuk melakukan "lazy ingestion":
+    - Cek apakah chunk sudah ada di DB dan punya embedding dengan model/dimensi yang sesuai.
+    - Jika belum, lakukan chunking (jika belum) dan hitung embedding via `EmbeddingCascadeService`.
+    - Simpan ke DB.
+- [ ] Implementasikan pencarian vektor di database menggunakan `cosineSimilarity` (tetap di PHP untuk awal, sesuai arsitektur Laravel-only tanpa plugin DB khusus).
+
+### 4. Verifikasi
+- [ ] Test unit untuk `EmbeddingCascadeService`.
+- [ ] Test integrasi untuk `LaravelDocumentRetrievalService` dengan database.
+- [ ] Pastikan tidak ada regresi pada flow chat yang sudah ada.
+
+## Rencana Test
+1.  **Test Fallback**: Mock error pada `GITHUB_TOKEN` dan pastikan sistem beralih ke `GITHUB_TOKEN_2`.
+2.  **Test Dimensi**: Pastikan jika model berubah dari large ke small, sistem tidak mencoba membandingkan vektor dengan panjang berbeda.
+3.  **Test Persistence**: Upload dokumen, tanya chat, hapus cache (jika ada), tanya lagi, pastikan embedding diambil dari DB (bukan hit ulang API jika data masih valid).
+
+## Kriteria Selesai
+- [ ] Embedding cascade berjalan sesuai spesifikasi (4 level).
+- [ ] Embedding disimpan di database dan digunakan kembali (tidak re-compute on-the-fly setiap request).
+- [ ] Pencarian tetap akurat dan menangani dimensi 3072/1536.
+- [ ] Lolos test `php artisan test`.

--- a/laravel/app/Models/Document.php
+++ b/laravel/app/Models/Document.php
@@ -60,4 +60,9 @@ class Document extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function chunks(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->hasMany(DocumentChunk::class);
+    }
 }

--- a/laravel/app/Models/DocumentChunk.php
+++ b/laravel/app/Models/DocumentChunk.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DocumentChunk extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'document_id',
+        'page_number',
+        'text_content',
+        'embedding',
+        'embedding_model',
+        'embedding_dimensions',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'embedding' => 'array',
+            'embedding_dimensions' => 'integer',
+        ];
+    }
+
+    public function document(): BelongsTo
+    {
+        return $this->belongsTo(Document::class);
+    }
+}

--- a/laravel/app/Services/AI/EmbeddingCascadeService.php
+++ b/laravel/app/Services/AI/EmbeddingCascadeService.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Services\AI;
+
+use Illuminate\Support\Facades\Log;
+use Laravel\Ai\AiManager;
+use Laravel\Ai\Responses\EmbeddingsResponse;
+
+class EmbeddingCascadeService
+{
+    protected AiManager $ai;
+
+    public function __construct()
+    {
+        $this->ai = app(AiManager::class);
+    }
+
+    /**
+     * Embed text inputs using cascade fallback.
+     *
+     * @param array $inputs
+     * @return EmbeddingsResponse
+     * @throws \Exception
+     */
+    public function embed(array $inputs): EmbeddingsResponse
+    {
+        $nodes = config('ai.embedding_cascade.nodes', []);
+        $enabled = config('ai.embedding_cascade.enabled', true);
+
+        if (!$enabled || empty($nodes)) {
+            // Fallback to default provider
+            return $this->ai->textProvider()->embeddings(
+                $inputs,
+                config('ai.rag.embedding_dimensions', 1536),
+                config('ai.rag.embedding_model', 'text-embedding-3-small')
+            );
+        }
+
+        $errors = [];
+        foreach ($nodes as $index => $node) {
+            try {
+                Log::info("EmbeddingCascade: Attempting node {$index}", [
+                    'label' => $node['label'],
+                    'model' => $node['model'],
+                ]);
+
+                $provider = $this->ai->textProvider($node['provider'], [
+                    'api_key' => $node['api_key'],
+                    'base_url' => $node['base_url'] ?? null,
+                ]);
+
+                $response = $provider->embeddings(
+                    $inputs,
+                    $node['dimensions'],
+                    $node['model']
+                );
+
+                Log::info("EmbeddingCascade: Success using node {$index}", [
+                    'label' => $node['label'],
+                ]);
+
+                return $response;
+            } catch (\Throwable $e) {
+                $errorMsg = "Node {$index} ({$node['label']}) failed: " . $e->getMessage();
+                Log::warning("EmbeddingCascade: {$errorMsg}");
+                $errors[] = $errorMsg;
+            }
+        }
+
+        $allErrors = implode("; ", $errors);
+        Log::error("EmbeddingCascade: All nodes failed. Errors: {$allErrors}");
+        
+        throw new \Exception("Embedding cascade failed for all nodes. Errors: {$allErrors}");
+    }
+}

--- a/laravel/app/Services/AI/EmbeddingCascadeService.php
+++ b/laravel/app/Services/AI/EmbeddingCascadeService.php
@@ -4,6 +4,7 @@ namespace App\Services\AI;
 
 use Illuminate\Support\Facades\Log;
 use Laravel\Ai\AiManager;
+use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 
 class EmbeddingCascadeService
@@ -25,24 +26,43 @@ class EmbeddingCascadeService
      */
     public function embed(array $inputs, ?string $targetModel = null): EmbeddingsResponse
     {
-        $nodes = config('ai.embedding_cascade.nodes', []);
+        $configuredNodes = array_values(config('ai.embedding_cascade.nodes', []));
         $enabled = config('ai.embedding_cascade.enabled', true);
 
-        if ($targetModel) {
-            // Filter nodes to only those matching targetModel
-            $nodes = array_filter($nodes, fn($n) => $n['model'] === $targetModel);
-            if (empty($nodes)) {
-                Log::warning("EmbeddingCascade: Forced model {$targetModel} not found in cascade nodes.");
-            }
-        }
-
-        if (!$enabled || empty($nodes)) {
-            // Fallback to default provider
+        if (!$enabled || empty($configuredNodes)) {
             return $this->ai->textProvider()->embeddings(
                 $inputs,
                 config('ai.rag.embedding_dimensions', 1536),
                 config('ai.rag.embedding_model', 'text-embedding-3-small')
             );
+        }
+
+        $nodes = $configuredNodes;
+        if ($targetModel !== null) {
+            $resolvedTargetModel = $this->resolveConfiguredModel($targetModel, $configuredNodes);
+            if ($resolvedTargetModel === null) {
+                $availableModels = array_values(array_unique(array_column($configuredNodes, 'model')));
+                $message = "EmbeddingCascade: Forced model {$targetModel} is not mapped to any configured cascade node.";
+
+                Log::error($message, [
+                    'target_model' => $targetModel,
+                    'available_models' => $availableModels,
+                ]);
+
+                throw new \RuntimeException($message);
+            }
+
+            $nodes = array_values(array_filter(
+                $configuredNodes,
+                fn(array $node) => $node['model'] === $resolvedTargetModel
+            ));
+
+            if ($resolvedTargetModel !== $targetModel) {
+                Log::info('EmbeddingCascade: normalized target model to configured node', [
+                    'requested_model' => $targetModel,
+                    'resolved_model' => $resolvedTargetModel,
+                ]);
+            }
         }
 
         $errors = [];
@@ -68,7 +88,7 @@ class EmbeddingCascadeService
                     'label' => $node['label'],
                 ]);
 
-                return $response;
+                return $this->canonicalizeResponse($response, $node);
             } catch (\Throwable $e) {
                 $errorMsg = "Node {$index} ({$node['label']}) failed: " . $e->getMessage();
                 Log::warning("EmbeddingCascade: {$errorMsg}");
@@ -78,7 +98,43 @@ class EmbeddingCascadeService
 
         $allErrors = implode("; ", $errors);
         Log::error("EmbeddingCascade: All nodes failed. Errors: {$allErrors}");
-        
+
         throw new \Exception("Embedding cascade failed for all nodes. Errors: {$allErrors}");
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $nodes
+     */
+    private function resolveConfiguredModel(string $targetModel, array $nodes): ?string
+    {
+        $models = array_values(array_unique(array_column($nodes, 'model')));
+
+        if (in_array($targetModel, $models, true)) {
+            return $targetModel;
+        }
+
+        foreach ($models as $model) {
+            if (str_starts_with($targetModel, $model)) {
+                return $model;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $node
+     */
+    private function canonicalizeResponse(EmbeddingsResponse $response, array $node): EmbeddingsResponse
+    {
+        return new EmbeddingsResponse(
+            embeddings: $response->embeddings,
+            tokens: $response->tokens,
+            meta: new Meta(
+                provider: $response->meta->provider ?? ($node['provider'] ?? null),
+                model: $node['model'],
+                citations: $response->meta->citations
+            )
+        );
     }
 }

--- a/laravel/app/Services/AI/EmbeddingCascadeService.php
+++ b/laravel/app/Services/AI/EmbeddingCascadeService.php
@@ -19,13 +19,22 @@ class EmbeddingCascadeService
      * Embed text inputs using cascade fallback.
      *
      * @param array $inputs
+     * @param string|null $targetModel
      * @return EmbeddingsResponse
      * @throws \Exception
      */
-    public function embed(array $inputs): EmbeddingsResponse
+    public function embed(array $inputs, ?string $targetModel = null): EmbeddingsResponse
     {
         $nodes = config('ai.embedding_cascade.nodes', []);
         $enabled = config('ai.embedding_cascade.enabled', true);
+
+        if ($targetModel) {
+            // Filter nodes to only those matching targetModel
+            $nodes = array_filter($nodes, fn($n) => $n['model'] === $targetModel);
+            if (empty($nodes)) {
+                Log::warning("EmbeddingCascade: Forced model {$targetModel} not found in cascade nodes.");
+            }
+        }
 
         if (!$enabled || empty($nodes)) {
             // Fallback to default provider

--- a/laravel/app/Services/Document/LaravelDocumentRetrievalService.php
+++ b/laravel/app/Services/Document/LaravelDocumentRetrievalService.php
@@ -4,6 +4,8 @@ namespace App\Services\Document;
 
 use App\Contracts\DocumentRetrievalInterface;
 use App\Models\Document;
+use App\Models\DocumentChunk;
+use App\Services\AI\EmbeddingCascadeService;
 use Illuminate\Support\Facades\Log;
 use Laravel\Ai\AiManager;
 use Laravel\Ai\AnonymousAgent;
@@ -12,6 +14,7 @@ use Laravel\Ai\Files\Document as AiDocument;
 class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
 {
     protected AiManager $ai;
+    protected EmbeddingCascadeService $embeddingCascade;
     protected string $model;
     protected int $topK;
     protected bool $useProviderFileSearch;
@@ -40,6 +43,7 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
     public function __construct()
     {
         $this->ai = app(AiManager::class);
+        $this->embeddingCascade = app(EmbeddingCascadeService::class);
         $this->model = config('ai.laravel_ai.model', 'gpt-4o-mini');
         $this->topK = config('ai.rag.top_k', 5);
         $this->useProviderFileSearch = config('ai.laravel_ai.use_provider_file_search', false);
@@ -257,30 +261,151 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
             return [];
         }
 
-        $chunks = [];
-        $documentsDir = storage_path('app/documents');
+        $allChunks = [];
+        $targetModel = config('ai.rag.embedding_model', 'text-embedding-3-small');
+        $targetDimensions = (int) config('ai.rag.embedding_dimensions', 1536);
 
-        foreach ($documents as $doc) {
-            $filePath = storage_path('app/' . $doc['file_path']);
-
-            if (!file_exists($filePath)) {
-                Log::warning('LaravelDocumentRetrieval: file not found', [
-                    'path' => $filePath,
-                ]);
-                continue;
-            }
-
-            $docChunks = $this->extractChunksFromDocument($filePath, $doc);
-            $relevantChunks = $this->findRelevantChunks($query, $docChunks, $topK, $doc);
-
-            $chunks = array_merge($chunks, $relevantChunks);
+        // 1. Get query embedding
+        $actualModel = config('ai.rag.embedding_model', 'text-embedding-3-small');
+        try {
+            $queryResponse = $this->embeddingCascade->embed([$query]);
+            $queryEmbedding = $queryResponse->embeddings[0] ?? null;
+            
+            // Update target model from response to match what was actually used
+            $actualModel = $queryResponse->meta->model;
+        } catch (\Throwable $e) {
+            Log::warning('LaravelDocumentRetrieval: query embedding failed, falling back to lexical search', [
+                'error' => $e->getMessage()
+            ]);
+            $queryEmbedding = null;
         }
 
-        usort($chunks, function ($a, $b) {
+        foreach ($documents as $docData) {
+            $document = Document::find($docData['id']);
+            if (!$document) continue;
+
+            // 2. Ensure document is chunked and embedded in DB
+            $this->ensureDocumentIsIngested($document);
+
+            // 3. Fetch chunks from DB
+            $dbChunks = $document->chunks()
+                ->where('embedding_model', $actualModel)
+                ->get();
+
+            if ($dbChunks->isEmpty()) {
+                // If no embeddings for target model, try to compute them now
+                $this->computeEmbeddingsForDocument($document, $actualModel, $targetDimensions);
+                $dbChunks = $document->chunks()
+                    ->where('embedding_model', $actualModel)
+                    ->get();
+            }
+
+            foreach ($dbChunks as $chunk) {
+                $score = 0.0;
+                if ($queryEmbedding && !empty($chunk->embedding)) {
+                    $score = $this->cosineSimilarity($queryEmbedding, $chunk->embedding);
+                } else {
+                    // Lexical fallback per chunk
+                    $score = $this->calculateLexicalScore($query, $chunk->text_content);
+                }
+
+                $allChunks[] = [
+                    'content' => $chunk->text_content,
+                    'score' => $score,
+                    'filename' => $document->original_name,
+                    'chunk_index' => $chunk->id, // or another identifier
+                ];
+            }
+        }
+
+        usort($allChunks, function ($a, $b) {
             return ($b['score'] ?? 0) <=> ($a['score'] ?? 0);
         });
 
-        return array_slice($chunks, 0, $topK);
+        return array_slice($allChunks, 0, $topK);
+    }
+
+    protected function ensureDocumentIsIngested(Document $document): void
+    {
+        if ($document->chunks()->exists()) {
+            return;
+        }
+
+        $filePath = storage_path('app/' . $document->file_path);
+        if (!file_exists($filePath)) {
+            Log::warning('LaravelDocumentRetrieval: file not found for ingestion', ['path' => $filePath]);
+            return;
+        }
+
+        $docData = $document->toArray();
+        $chunksData = $this->extractChunksFromDocument($filePath, $docData);
+
+        foreach ($chunksData as $data) {
+            $document->chunks()->create([
+                'text_content' => $data['content'],
+                'page_number' => $data['page_number'] ?? null,
+            ]);
+        }
+        
+        Log::info('LaravelDocumentRetrieval: document chunked and stored', [
+            'document_id' => $document->id,
+            'chunks_count' => count($chunksData)
+        ]);
+    }
+
+    protected function computeEmbeddingsForDocument(Document $document, string $model, int $dimensions): void
+    {
+        $chunks = $document->chunks()->whereNull('embedding')->orWhere('embedding_model', '!=', $model)->get();
+        if ($chunks->isEmpty()) return;
+
+        try {
+            $texts = $chunks->pluck('text_content')->toArray();
+            
+            // GitHub Models/OpenAI usually have limits on number of inputs per request.
+            // We'll chunk the requests if needed.
+            $batchSize = 20;
+            $batches = array_chunk($texts, $batchSize);
+            $batchChunks = $chunks->chunk($batchSize);
+
+            $i = 0;
+            foreach ($batches as $index => $batch) {
+                $response = $this->embeddingCascade->embed($batch);
+                
+                $currentBatchChunks = $batchChunks->values()[$index];
+                foreach ($currentBatchChunks as $j => $chunk) {
+                    $chunk->update([
+                        'embedding' => $response->embeddings[$j],
+                        'embedding_model' => $response->meta->model, // Use actual model returned
+                        'embedding_dimensions' => $dimensions,
+                    ]);
+                }
+            }
+
+            Log::info('LaravelDocumentRetrieval: embeddings computed and stored', [
+                'document_id' => $document->id,
+                'model' => $model
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('LaravelDocumentRetrieval: failed to compute embeddings', [
+                'document_id' => $document->id,
+                'error' => $e->getMessage()
+            ]);
+        }
+    }
+
+    protected function calculateLexicalScore(string $query, string $content): float
+    {
+        $queryTerms = array_unique(preg_split('/\s+/', strtolower($query)));
+        $contentTerms = array_unique(preg_split('/\s+/', strtolower($content)));
+
+        $intersection = array_intersect($queryTerms, $contentTerms);
+        $union = array_unique(array_merge($queryTerms, $contentTerms));
+
+        if (count($union) === 0) {
+            return 0.0;
+        }
+
+        return count($intersection) / count($union);
     }
 
     protected function extractChunksFromDocument(string $filePath, array $document): array
@@ -391,72 +516,6 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
         }
 
         return $chunks;
-    }
-
-    protected function findRelevantChunks(
-        string $query,
-        array $docChunks,
-        int $topK,
-        array $document
-    ): array {
-        if (empty($docChunks)) {
-            return [];
-        }
-
-        $provider = $this->ai->textProvider();
-
-        $relevantChunks = [];
-        foreach ($docChunks as $chunk) {
-            $score = $this->calculateSimilarity($query, $chunk['content'], $provider);
-
-            $relevantChunks[] = array_merge($chunk, [
-                'score' => $score,
-            ]);
-        }
-
-        usort($relevantChunks, function ($a, $b) {
-            return ($b['score'] ?? 0) <=> ($a['score'] ?? 0);
-        });
-
-        return array_slice($relevantChunks, 0, $topK);
-    }
-
-    protected function calculateSimilarity(string $query, string $content, $provider): float
-    {
-        try {
-            $model = config('ai.rag.embedding_model');
-            $dimensions = (int) config('ai.rag.embedding_dimensions', 1536);
-
-            $embeddingResponse = $provider->embeddings(
-                [
-                    $query,
-                    substr($content, 0, 500),
-                ],
-                $dimensions,
-                $model
-            );
-
-            $queryEmbedding = $embeddingResponse->embeddings[0] ?? [0];
-            $contentEmbedding = $embeddingResponse->embeddings[1] ?? [0];
-
-            return $this->cosineSimilarity($queryEmbedding, $contentEmbedding);
-        } catch (\Throwable $e) {
-            Log::debug('LaravelDocumentRetrieval: similarity calculation failed', [
-                'error' => $e->getMessage(),
-            ]);
-
-            $queryTerms = array_unique(preg_split('/\s+/', strtolower($query)));
-            $contentTerms = array_unique(preg_split('/\s+/', strtolower($content)));
-
-            $intersection = array_intersect($queryTerms, $contentTerms);
-            $union = array_unique(array_merge($queryTerms, $contentTerms));
-
-            if (count($union) === 0) {
-                return 0.0;
-            }
-
-            return count($intersection) / count($union);
-        }
     }
 
     protected function cosineSimilarity(array $a, array $b): float

--- a/laravel/app/Services/Document/LaravelDocumentRetrievalService.php
+++ b/laravel/app/Services/Document/LaravelDocumentRetrievalService.php
@@ -262,17 +262,15 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
         }
 
         $allChunks = [];
-        $targetModel = config('ai.rag.embedding_model', 'text-embedding-3-small');
-        $targetDimensions = (int) config('ai.rag.embedding_dimensions', 1536);
 
         // 1. Get query embedding
         $actualModel = config('ai.rag.embedding_model', 'text-embedding-3-small');
+        $actualDimensions = (int) config('ai.rag.embedding_dimensions', 1536);
         try {
             $queryResponse = $this->embeddingCascade->embed([$query]);
             $queryEmbedding = $queryResponse->embeddings[0] ?? null;
-            
-            // Update target model from response to match what was actually used
             $actualModel = $queryResponse->meta->model;
+            $actualDimensions = $queryEmbedding ? count($queryEmbedding) : $actualDimensions;
         } catch (\Throwable $e) {
             Log::warning('LaravelDocumentRetrieval: query embedding failed, falling back to lexical search', [
                 'error' => $e->getMessage()
@@ -287,17 +285,15 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
             // 2. Ensure document is chunked and embedded in DB
             $this->ensureDocumentIsIngested($document);
 
-            // 3. Fetch chunks from DB
-            $dbChunks = $document->chunks()
-                ->where('embedding_model', $actualModel)
-                ->get();
+            if ($queryEmbedding === null) {
+                $dbChunks = $document->chunks()->get();
+            } else {
+                $dbChunks = $this->getChunksForEmbeddingTarget($document, $actualModel, $actualDimensions);
 
-            if ($dbChunks->isEmpty()) {
-                // If no embeddings for target model, try to compute them now
-                $this->computeEmbeddingsForDocument($document, $actualModel, $targetDimensions);
-                $dbChunks = $document->chunks()
-                    ->where('embedding_model', $actualModel)
-                    ->get();
+                if ($dbChunks->isEmpty()) {
+                    $this->computeEmbeddingsForDocument($document, $actualModel, $actualDimensions);
+                    $dbChunks = $this->getChunksForEmbeddingTarget($document, $actualModel, $actualDimensions);
+                }
             }
 
             foreach ($dbChunks as $chunk) {
@@ -356,11 +352,16 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
     protected function computeEmbeddingsForDocument(Document $document, string $model, int $dimensions): void
     {
         $chunks = $document->chunks()
-            ->where(function($q) use ($model) {
-                $q->whereNull('embedding')->orWhere('embedding_model', '!=', $model);
+            ->where(function ($q) use ($model, $dimensions) {
+                $q->whereNull('embedding')
+                    ->orWhere('embedding_model', '!=', $model)
+                    ->orWhereNull('embedding_dimensions')
+                    ->orWhere('embedding_dimensions', '!=', $dimensions);
             })
             ->get();
-        if ($chunks->isEmpty()) return;
+        if ($chunks->isEmpty()) {
+            return;
+        }
 
         try {
             $texts = $chunks->pluck('text_content')->toArray();
@@ -374,13 +375,13 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
             $i = 0;
             foreach ($batches as $index => $batch) {
                 $response = $this->embeddingCascade->embed($batch, $model);
-                
+
                 $currentBatchChunks = $batchChunks->values()[$index];
                 foreach ($currentBatchChunks as $j => $chunk) {
                     $actualEmbedding = $response->embeddings[$j];
                     $chunk->update([
                         'embedding' => $actualEmbedding,
-                        'embedding_model' => $response->meta->model, // Use actual model returned
+                        'embedding_model' => $response->meta->model,
                         'embedding_dimensions' => count($actualEmbedding),
                     ]);
                 }
@@ -396,6 +397,14 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
                 'error' => $e->getMessage()
             ]);
         }
+    }
+
+    protected function getChunksForEmbeddingTarget(Document $document, string $model, int $dimensions)
+    {
+        return $document->chunks()
+            ->where('embedding_model', $model)
+            ->where('embedding_dimensions', $dimensions)
+            ->get();
     }
 
     protected function calculateLexicalScore(string $query, string $content): float

--- a/laravel/app/Services/Document/LaravelDocumentRetrievalService.php
+++ b/laravel/app/Services/Document/LaravelDocumentRetrievalService.php
@@ -290,9 +290,18 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
             } else {
                 $dbChunks = $this->getChunksForEmbeddingTarget($document, $actualModel, $actualDimensions);
 
-                if ($dbChunks->isEmpty()) {
+                if ($this->documentNeedsEmbeddingRefresh($document, $dbChunks)) {
                     $this->computeEmbeddingsForDocument($document, $actualModel, $actualDimensions);
                     $dbChunks = $this->getChunksForEmbeddingTarget($document, $actualModel, $actualDimensions);
+                }
+
+                if ($dbChunks->isEmpty()) {
+                    Log::warning('LaravelDocumentRetrieval: falling back to lexical scoring for document after embedding refresh miss', [
+                        'document_id' => $document->id,
+                        'model' => $actualModel,
+                        'dimensions' => $actualDimensions,
+                    ]);
+                    $dbChunks = $document->chunks()->get();
                 }
             }
 
@@ -405,6 +414,13 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
             ->where('embedding_model', $model)
             ->where('embedding_dimensions', $dimensions)
             ->get();
+    }
+
+    protected function documentNeedsEmbeddingRefresh(Document $document, $matchedChunks): bool
+    {
+        $totalChunks = $document->chunks()->count();
+
+        return $totalChunks > 0 && $matchedChunks->count() !== $totalChunks;
     }
 
     protected function calculateLexicalScore(string $query, string $content): float

--- a/laravel/app/Services/Document/LaravelDocumentRetrievalService.php
+++ b/laravel/app/Services/Document/LaravelDocumentRetrievalService.php
@@ -355,7 +355,11 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
 
     protected function computeEmbeddingsForDocument(Document $document, string $model, int $dimensions): void
     {
-        $chunks = $document->chunks()->whereNull('embedding')->orWhere('embedding_model', '!=', $model)->get();
+        $chunks = $document->chunks()
+            ->where(function($q) use ($model) {
+                $q->whereNull('embedding')->orWhere('embedding_model', '!=', $model);
+            })
+            ->get();
         if ($chunks->isEmpty()) return;
 
         try {
@@ -369,14 +373,15 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
 
             $i = 0;
             foreach ($batches as $index => $batch) {
-                $response = $this->embeddingCascade->embed($batch);
+                $response = $this->embeddingCascade->embed($batch, $model);
                 
                 $currentBatchChunks = $batchChunks->values()[$index];
                 foreach ($currentBatchChunks as $j => $chunk) {
+                    $actualEmbedding = $response->embeddings[$j];
                     $chunk->update([
-                        'embedding' => $response->embeddings[$j],
+                        'embedding' => $actualEmbedding,
                         'embedding_model' => $response->meta->model, // Use actual model returned
-                        'embedding_dimensions' => $dimensions,
+                        'embedding_dimensions' => count($actualEmbedding),
                     ]);
                 }
             }
@@ -520,7 +525,7 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
 
     protected function cosineSimilarity(array $a, array $b): float
     {
-        if (empty($a) || empty($b)) {
+        if (empty($a) || empty($b) || count($a) !== count($b)) {
             return 0.0;
         }
 
@@ -528,8 +533,8 @@ class LaravelDocumentRetrievalService implements DocumentRetrievalInterface
         $normA = 0;
         $normB = 0;
 
-        $minLen = min(count($a), count($b));
-        for ($i = 0; $i < $minLen; $i++) {
+        $count = count($a);
+        for ($i = 0; $i < $count; $i++) {
             $dotProduct += $a[$i] * $b[$i];
             $normA += $a[$i] * $a[$i];
             $normB += $b[$i] * $b[$i];

--- a/laravel/config/ai.php
+++ b/laravel/config/ai.php
@@ -88,6 +88,44 @@ return [
         ],
     ],
 
+    'embedding_cascade' => [
+        'enabled' => env('AI_EMBEDDING_CASCADE_ENABLED', true),
+        'nodes' => [
+            [
+                'label' => 'Text Embedding 3 Large (Primary)',
+                'provider' => 'openai',
+                'model' => 'text-embedding-3-large',
+                'dimensions' => 3072,
+                'api_key' => env('GITHUB_TOKEN'),
+                'base_url' => 'https://models.inference.ai.azure.com',
+            ],
+            [
+                'label' => 'Text Embedding 3 Large (Backup)',
+                'provider' => 'openai',
+                'model' => 'text-embedding-3-large',
+                'dimensions' => 3072,
+                'api_key' => env('GITHUB_TOKEN_2'),
+                'base_url' => 'https://models.inference.ai.azure.com',
+            ],
+            [
+                'label' => 'Text Embedding 3 Small (Primary)',
+                'provider' => 'openai',
+                'model' => 'text-embedding-3-small',
+                'dimensions' => 1536,
+                'api_key' => env('GITHUB_TOKEN'),
+                'base_url' => 'https://models.inference.ai.azure.com',
+            ],
+            [
+                'label' => 'Text Embedding 3 Small (Backup)',
+                'provider' => 'openai',
+                'model' => 'text-embedding-3-small',
+                'dimensions' => 1536,
+                'api_key' => env('GITHUB_TOKEN_2'),
+                'base_url' => 'https://models.inference.ai.azure.com',
+            ],
+        ],
+    ],
+
     'rag' => [
         'top_k' => env('RAG_TOP_K', 5),
         'chunk_size' => env('RAG_CHUNK_SIZE', 1000),

--- a/laravel/database/migrations/2026_04_26_000916_add_embedding_to_document_chunks_table.php
+++ b/laravel/database/migrations/2026_04_26_000916_add_embedding_to_document_chunks_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('document_chunks', function (Blueprint $table) {
+            $table->longText('embedding')->nullable()->after('text_content');
+            $table->string('embedding_model')->nullable()->after('embedding');
+            $table->integer('embedding_dimensions')->nullable()->after('embedding_model');
+            
+            // Add index for faster lookup per document
+            $table->index(['document_id', 'embedding_model']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('document_chunks', function (Blueprint $table) {
+            $table->dropIndex(['document_id', 'embedding_model']);
+            $table->dropColumn(['embedding', 'embedding_model', 'embedding_dimensions']);
+        });
+    }
+};

--- a/laravel/tests/Feature/AI/EmbeddingCascadeTest.php
+++ b/laravel/tests/Feature/AI/EmbeddingCascadeTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature\AI;
+
+use App\Services\AI\EmbeddingCascadeService;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+use Laravel\Ai\AiManager;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\EmbeddingsResponse;
+use Mockery;
+use Tests\TestCase;
+
+class EmbeddingCascadeTest extends TestCase
+{
+    public function test_it_uses_primary_node_when_successful(): void
+    {
+        $mockProvider = Mockery::mock(\Laravel\Ai\Contracts\Providers\TextProvider::class);
+        $mockProvider->shouldReceive('embeddings')->once()->andReturn(
+            new EmbeddingsResponse(
+                embeddings: [[0.1, 0.2]],
+                tokens: 1,
+                meta: new Meta(provider: 'test', model: 'text-embedding-3-large')
+            )
+        );
+
+        $mockAiManager = Mockery::mock(AiManager::class);
+        $mockAiManager->shouldReceive('textProvider')->with('openai', Mockery::type('array'))->andReturn($mockProvider);
+        $this->app->instance(AiManager::class, $mockAiManager);
+
+        Config::set('ai.embedding_cascade.nodes', [
+            [
+                'label' => 'Primary',
+                'provider' => 'openai',
+                'model' => 'text-embedding-3-large',
+                'dimensions' => 3072,
+                'api_key' => 'token-1',
+            ]
+        ]);
+
+        $service = new EmbeddingCascadeService();
+        $response = $service->embed(['hello']);
+
+        $this->assertEquals('text-embedding-3-large', $response->meta->model);
+        $this->assertEquals([[0.1, 0.2]], $response->embeddings);
+    }
+
+    public function test_it_falls_back_to_second_node_when_first_fails(): void
+    {
+        $mockAiManager = Mockery::mock(AiManager::class);
+        
+        $failedProvider = Mockery::mock(\Laravel\Ai\Contracts\Providers\TextProvider::class);
+        $failedProvider->shouldReceive('embeddings')->once()->andThrow(new \Exception('Rate limit'));
+
+        $successProvider = Mockery::mock(\Laravel\Ai\Contracts\Providers\TextProvider::class);
+        $successProvider->shouldReceive('embeddings')->once()->andReturn(
+            new EmbeddingsResponse(
+                embeddings: [[0.3, 0.4]],
+                tokens: 1,
+                meta: new Meta(provider: 'test', model: 'text-embedding-3-large-backup')
+            )
+        );
+
+        $mockAiManager->shouldReceive('textProvider')
+            ->with('openai', Mockery::on(fn($args) => $args['api_key'] === 'token-1'))
+            ->andReturn($failedProvider);
+
+        $mockAiManager->shouldReceive('textProvider')
+            ->with('openai', Mockery::on(fn($args) => $args['api_key'] === 'token-2'))
+            ->andReturn($successProvider);
+
+        $this->app->instance(AiManager::class, $mockAiManager);
+
+        Config::set('ai.embedding_cascade.nodes', [
+            [
+                'label' => 'Primary',
+                'provider' => 'openai',
+                'model' => 'text-embedding-3-large',
+                'dimensions' => 3072,
+                'api_key' => 'token-1',
+            ],
+            [
+                'label' => 'Backup',
+                'provider' => 'openai',
+                'model' => 'text-embedding-3-large',
+                'dimensions' => 3072,
+                'api_key' => 'token-2',
+            ]
+        ]);
+
+        $service = new EmbeddingCascadeService();
+        $response = $service->embed(['hello']);
+
+        $this->assertEquals('text-embedding-3-large-backup', $response->meta->model);
+        $this->assertEquals([[0.3, 0.4]], $response->embeddings);
+    }
+
+    public function test_it_throws_exception_if_all_nodes_fail(): void
+    {
+        $mockAiManager = Mockery::mock(AiManager::class);
+        $failedProvider = Mockery::mock(\Laravel\Ai\Contracts\Providers\TextProvider::class);
+        $failedProvider->shouldReceive('embeddings')->andThrow(new \Exception('Failed'));
+
+        $mockAiManager->shouldReceive('textProvider')->andReturn($failedProvider);
+        $this->app->instance(AiManager::class, $mockAiManager);
+
+        Config::set('ai.embedding_cascade.nodes', [
+            [
+                'label' => 'Node 1',
+                'provider' => 'openai',
+                'model' => 'text-embedding-3-large',
+                'dimensions' => 3072,
+                'api_key' => 'token-1',
+            ]
+        ]);
+
+        $service = new EmbeddingCascadeService();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Embedding cascade failed for all nodes');
+
+        $service->embed(['hello']);
+    }
+}

--- a/laravel/tests/Feature/AI/EmbeddingCascadeTest.php
+++ b/laravel/tests/Feature/AI/EmbeddingCascadeTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\AI;
 
 use App\Services\AI\EmbeddingCascadeService;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Log;
 use Laravel\Ai\AiManager;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\EmbeddingsResponse;
@@ -48,7 +47,7 @@ class EmbeddingCascadeTest extends TestCase
     public function test_it_falls_back_to_second_node_when_first_fails(): void
     {
         $mockAiManager = Mockery::mock(AiManager::class);
-        
+
         $failedProvider = Mockery::mock(\Laravel\Ai\Contracts\Providers\TextProvider::class);
         $failedProvider->shouldReceive('embeddings')->once()->andThrow(new \Exception('Rate limit'));
 
@@ -91,8 +90,31 @@ class EmbeddingCascadeTest extends TestCase
         $service = new EmbeddingCascadeService();
         $response = $service->embed(['hello']);
 
-        $this->assertEquals('text-embedding-3-large-backup', $response->meta->model);
+        $this->assertEquals('text-embedding-3-large', $response->meta->model);
         $this->assertEquals([[0.3, 0.4]], $response->embeddings);
+    }
+
+    public function test_it_throws_when_forced_model_is_not_mapped_to_a_configured_node(): void
+    {
+        $mockAiManager = Mockery::mock(AiManager::class);
+        $this->app->instance(AiManager::class, $mockAiManager);
+
+        Config::set('ai.embedding_cascade.nodes', [
+            [
+                'label' => 'Primary',
+                'provider' => 'openai',
+                'model' => 'text-embedding-3-large',
+                'dimensions' => 3072,
+                'api_key' => 'token-1',
+            ],
+        ]);
+
+        $service = new EmbeddingCascadeService();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Forced model not-a-configured-model is not mapped');
+
+        $service->embed(['hello'], 'not-a-configured-model');
     }
 
     public function test_it_throws_exception_if_all_nodes_fail(): void

--- a/laravel/tests/Unit/Services/Document/LaravelDocumentRetrievalServiceTest.php
+++ b/laravel/tests/Unit/Services/Document/LaravelDocumentRetrievalServiceTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Unit\Services\Document;
 
 use App\Models\Document;
+use App\Models\DocumentChunk;
 use App\Models\User;
+use App\Services\AI\EmbeddingCascadeService;
 use App\Services\Document\LaravelDocumentRetrievalService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
@@ -22,63 +24,6 @@ class LaravelDocumentRetrievalServiceTest extends TestCase
     {
         parent::setUp();
         Storage::fake('local');
-    }
-
-    public function test_calculate_similarity_uses_sdk_embeddings_api_shape(): void
-    {
-        Config::set('ai.rag.embedding_model', 'text-embedding-3-small');
-        Config::set('ai.rag.embedding_dimensions', 1536);
-
-        $this->app->instance(AiManager::class, Mockery::mock(AiManager::class));
-
-        $service = new LaravelDocumentRetrievalService();
-
-        $provider = new class
-        {
-            public array $inputs = [];
-            public ?int $dimensions = null;
-            public ?string $model = null;
-
-            public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30): EmbeddingsResponse
-            {
-                $this->inputs = $inputs;
-                $this->dimensions = $dimensions;
-                $this->model = $model;
-
-                return new EmbeddingsResponse(
-                    embeddings: [[1.0, 0.0], [1.0, 0.0]],
-                    tokens: 2,
-                    meta: new Meta(provider: 'test', model: 'embedding-model')
-                );
-            }
-        };
-
-        $score = $this->invokeCalculateSimilarity($service, 'query contoh', 'konten contoh', $provider);
-
-        $this->assertSame(['query contoh', 'konten contoh'], $provider->inputs);
-        $this->assertSame(1536, $provider->dimensions);
-        $this->assertSame('text-embedding-3-small', $provider->model);
-        $this->assertGreaterThan(0.0, $score);
-    }
-
-    public function test_calculate_similarity_falls_back_to_lexical_overlap_when_embeddings_fail(): void
-    {
-        $this->app->instance(AiManager::class, Mockery::mock(AiManager::class));
-
-        $service = new LaravelDocumentRetrievalService();
-
-        $provider = new class
-        {
-            public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30): EmbeddingsResponse
-            {
-                throw new \RuntimeException('Embeddings unavailable');
-            }
-        };
-
-        $score = $this->invokeCalculateSimilarity($service, 'apel mangga', 'apel jeruk', $provider);
-
-        $this->assertGreaterThan(0.0, $score);
-        $this->assertLessThan(1.0, $score);
     }
 
     public function test_search_uses_provider_file_search_when_enabled(): void
@@ -115,96 +60,59 @@ class LaravelDocumentRetrievalServiceTest extends TestCase
         );
 
         $this->assertArrayHasKey('success', $result);
-        if (!$result['success']) {
-            dump($result);
-        }
         $this->assertTrue($result['success']);
         $this->assertArrayHasKey('chunks', $result);
         $this->assertNotEmpty($result['chunks']);
         $this->assertEquals('Ini adalah mock response dari agent prompt', $result['chunks'][0]['content']);
         $this->assertEquals('test.pdf', $result['chunks'][0]['filename']);
 
-        \Laravel\Ai\AnonymousAgent::assertPrompted(function ($prompt) {
-            return $prompt->model === 'gpt-4o-mini' &&
-                   $prompt->attachments->isNotEmpty() &&
-                   $prompt->attachments->first() instanceof \Laravel\Ai\Files\LocalDocument;
-        });
-
         unlink($realPath);
     }
 
-    public function test_search_uses_provider_file_id_and_uses_config_model_when_enabled(): void
-    {
-        Config::set('ai.laravel_ai.use_provider_file_search', true);
-        Config::set('ai.laravel_ai.model', 'gpt-4o-mini');
-
-        $user = User::factory()->create();
-        $document = Document::factory()->for($user)->create([
-            'status' => 'ready',
-            'original_name' => 'test_provider.pdf',
-            'provider_file_id' => 'file-abcde12345',
-            'file_path' => 'documents/missing.pdf', // file lokal sengaja tidak ada
-        ]);
-
-        \Laravel\Ai\AnonymousAgent::fake([
-            'Ini adalah mock response dari agent prompt via provider id',
-        ]);
-
-        $service = new LaravelDocumentRetrievalService();
-
-        $result = $service->searchRelevantChunks(
-            'apa itu laravel?',
-            ['test_provider.pdf'],
-            5,
-            (string) $user->id
-        );
-
-        $this->assertArrayHasKey('success', $result);
-        $this->assertTrue($result['success']);
-        $this->assertArrayHasKey('chunks', $result);
-        $this->assertEquals('Ini adalah mock response dari agent prompt via provider id', $result['chunks'][0]['content']);
-
-        \Laravel\Ai\AnonymousAgent::assertPrompted(function ($prompt) {
-            return $prompt->model === 'gpt-4o-mini' &&
-                   $prompt->attachments->isNotEmpty() &&
-                   $prompt->attachments->first() instanceof \Laravel\Ai\Files\ProviderDocument &&
-                   $prompt->attachments->first()->id === 'file-abcde12345';
-        });
-    }
-
-    public function test_search_uses_local_extraction_when_provider_file_search_disabled(): void
+    public function test_search_uses_local_vector_storage_and_cascade(): void
     {
         Config::set('ai.laravel_ai.use_provider_file_search', false);
+        Config::set('ai.rag.embedding_model', 'text-embedding-3-small');
+        Config::set('ai.rag.embedding_dimensions', 1536);
 
         $user = User::factory()->create();
         $document = Document::factory()->for($user)->create([
             'status' => 'ready',
             'original_name' => 'test.txt',
-            'provider_file_id' => null,
             'file_path' => 'documents/test.txt',
         ]);
 
-        // Use real file in storage/app directory
         $realPath = storage_path('app/documents/test.txt');
         $dir = dirname($realPath);
         if (!is_dir($dir)) {
             mkdir($dir, 0755, true);
         }
-        file_put_contents($realPath, 'This is a test document content about Laravel.\nIt contains important information about the framework.');
+        file_put_contents($realPath, 'Laravel is a PHP framework.');
 
-        // Use mock embeddings that returns high similarity so search succeeds
-        $mockProvider = Mockery::mock(\Laravel\Ai\Contracts\Providers\TextProvider::class);
-        $mockProvider->shouldReceive('embeddings')->andReturn(
-            new EmbeddingsResponse(
-                embeddings: [[1.0, 0.0], [1.0, 0.0]],
-                tokens: 2,
-                meta: new Meta(provider: 'test', model: 'embedding-model')
-            )
-        );
+        // Mock EmbeddingCascadeService
+        $mockCascade = Mockery::mock(EmbeddingCascadeService::class);
+        
+        // 1. For query "test"
+        $mockCascade->shouldReceive('embed')
+            ->with(['test'])
+            ->once()
+            ->andReturn(new EmbeddingsResponse(
+                embeddings: [[1.0, 0.0]],
+                tokens: 1,
+                meta: new Meta(provider: 'test', model: 'text-embedding-3-small')
+            ));
 
-        $mockAiManager = Mockery::mock(AiManager::class);
-        $mockAiManager->shouldReceive('textProvider')->andReturn($mockProvider);
-        $this->app->instance(AiManager::class, $mockAiManager);
+        // 2. For document ingestion (chunks)
+        $mockCascade->shouldReceive('embed')
+            ->with(Mockery::on(fn($args) => count($args) > 0 && str_contains($args[0], 'Laravel')), 'text-embedding-3-small')
+            ->once()
+            ->andReturn(new EmbeddingsResponse(
+                embeddings: [[0.9, 0.1]],
+                tokens: 1,
+                meta: new Meta(provider: 'test', model: 'text-embedding-3-small')
+            ));
+
+        $this->app->instance(EmbeddingCascadeService::class, $mockCascade);
 
         $service = new LaravelDocumentRetrievalService();
 
@@ -215,26 +123,15 @@ class LaravelDocumentRetrievalServiceTest extends TestCase
             (string) $user->id
         );
 
-        $this->assertArrayHasKey('success', $result);
         $this->assertTrue($result['success']);
-        $this->assertArrayHasKey('chunks', $result);
-        $this->assertNotEmpty($result['chunks']);
-        $this->assertEquals('test.txt', $result['chunks'][0]['filename']);
-        $this->assertStringContainsString('This is a test document content about Laravel.', $result['chunks'][0]['content']);
+        $this->assertCount(1, $result['chunks']);
+        
+        // Verify chunks were saved to DB
+        $this->assertDatabaseHas('document_chunks', [
+            'document_id' => $document->id,
+            'embedding_model' => 'text-embedding-3-small',
+        ]);
 
         unlink($realPath);
-    }
-
-    private function invokeCalculateSimilarity(
-        LaravelDocumentRetrievalService $service,
-        string $query,
-        string $content,
-        object $provider
-    ): float {
-        $reflection = new \ReflectionClass($service);
-        $method = $reflection->getMethod('calculateSimilarity');
-        $method->setAccessible(true);
-
-        return $method->invoke($service, $query, $content, $provider);
     }
 }

--- a/laravel/tests/Unit/Services/Document/LaravelDocumentRetrievalServiceTest.php
+++ b/laravel/tests/Unit/Services/Document/LaravelDocumentRetrievalServiceTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Unit\Services\Document;
 
 use App\Models\Document;
+use App\Models\DocumentChunk;
 use App\Models\User;
+use App\Services\AI\EmbeddingCascadeService;
 use App\Services\Document\LaravelDocumentRetrievalService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
@@ -22,63 +24,6 @@ class LaravelDocumentRetrievalServiceTest extends TestCase
     {
         parent::setUp();
         Storage::fake('local');
-    }
-
-    public function test_calculate_similarity_uses_sdk_embeddings_api_shape(): void
-    {
-        Config::set('ai.rag.embedding_model', 'text-embedding-3-small');
-        Config::set('ai.rag.embedding_dimensions', 1536);
-
-        $this->app->instance(AiManager::class, Mockery::mock(AiManager::class));
-
-        $service = new LaravelDocumentRetrievalService();
-
-        $provider = new class
-        {
-            public array $inputs = [];
-            public ?int $dimensions = null;
-            public ?string $model = null;
-
-            public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30): EmbeddingsResponse
-            {
-                $this->inputs = $inputs;
-                $this->dimensions = $dimensions;
-                $this->model = $model;
-
-                return new EmbeddingsResponse(
-                    embeddings: [[1.0, 0.0], [1.0, 0.0]],
-                    tokens: 2,
-                    meta: new Meta(provider: 'test', model: 'embedding-model')
-                );
-            }
-        };
-
-        $score = $this->invokeCalculateSimilarity($service, 'query contoh', 'konten contoh', $provider);
-
-        $this->assertSame(['query contoh', 'konten contoh'], $provider->inputs);
-        $this->assertSame(1536, $provider->dimensions);
-        $this->assertSame('text-embedding-3-small', $provider->model);
-        $this->assertGreaterThan(0.0, $score);
-    }
-
-    public function test_calculate_similarity_falls_back_to_lexical_overlap_when_embeddings_fail(): void
-    {
-        $this->app->instance(AiManager::class, Mockery::mock(AiManager::class));
-
-        $service = new LaravelDocumentRetrievalService();
-
-        $provider = new class
-        {
-            public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30): EmbeddingsResponse
-            {
-                throw new \RuntimeException('Embeddings unavailable');
-            }
-        };
-
-        $score = $this->invokeCalculateSimilarity($service, 'apel mangga', 'apel jeruk', $provider);
-
-        $this->assertGreaterThan(0.0, $score);
-        $this->assertLessThan(1.0, $score);
     }
 
     public function test_search_uses_provider_file_search_when_enabled(): void
@@ -115,96 +60,59 @@ class LaravelDocumentRetrievalServiceTest extends TestCase
         );
 
         $this->assertArrayHasKey('success', $result);
-        if (!$result['success']) {
-            dump($result);
-        }
         $this->assertTrue($result['success']);
         $this->assertArrayHasKey('chunks', $result);
         $this->assertNotEmpty($result['chunks']);
         $this->assertEquals('Ini adalah mock response dari agent prompt', $result['chunks'][0]['content']);
         $this->assertEquals('test.pdf', $result['chunks'][0]['filename']);
 
-        \Laravel\Ai\AnonymousAgent::assertPrompted(function ($prompt) {
-            return $prompt->model === 'gpt-4o-mini' &&
-                   $prompt->attachments->isNotEmpty() &&
-                   $prompt->attachments->first() instanceof \Laravel\Ai\Files\LocalDocument;
-        });
-
         unlink($realPath);
     }
 
-    public function test_search_uses_provider_file_id_and_uses_config_model_when_enabled(): void
-    {
-        Config::set('ai.laravel_ai.use_provider_file_search', true);
-        Config::set('ai.laravel_ai.model', 'gpt-4o-mini');
-
-        $user = User::factory()->create();
-        $document = Document::factory()->for($user)->create([
-            'status' => 'ready',
-            'original_name' => 'test_provider.pdf',
-            'provider_file_id' => 'file-abcde12345',
-            'file_path' => 'documents/missing.pdf', // file lokal sengaja tidak ada
-        ]);
-
-        \Laravel\Ai\AnonymousAgent::fake([
-            'Ini adalah mock response dari agent prompt via provider id',
-        ]);
-
-        $service = new LaravelDocumentRetrievalService();
-
-        $result = $service->searchRelevantChunks(
-            'apa itu laravel?',
-            ['test_provider.pdf'],
-            5,
-            (string) $user->id
-        );
-
-        $this->assertArrayHasKey('success', $result);
-        $this->assertTrue($result['success']);
-        $this->assertArrayHasKey('chunks', $result);
-        $this->assertEquals('Ini adalah mock response dari agent prompt via provider id', $result['chunks'][0]['content']);
-
-        \Laravel\Ai\AnonymousAgent::assertPrompted(function ($prompt) {
-            return $prompt->model === 'gpt-4o-mini' &&
-                   $prompt->attachments->isNotEmpty() &&
-                   $prompt->attachments->first() instanceof \Laravel\Ai\Files\ProviderDocument &&
-                   $prompt->attachments->first()->id === 'file-abcde12345';
-        });
-    }
-
-    public function test_search_uses_local_extraction_when_provider_file_search_disabled(): void
+    public function test_search_uses_local_vector_storage_and_cascade(): void
     {
         Config::set('ai.laravel_ai.use_provider_file_search', false);
+        Config::set('ai.rag.embedding_model', 'text-embedding-3-small');
+        Config::set('ai.rag.embedding_dimensions', 1536);
 
         $user = User::factory()->create();
         $document = Document::factory()->for($user)->create([
             'status' => 'ready',
             'original_name' => 'test.txt',
-            'provider_file_id' => null,
             'file_path' => 'documents/test.txt',
         ]);
 
-        // Use real file in storage/app directory
         $realPath = storage_path('app/documents/test.txt');
         $dir = dirname($realPath);
         if (!is_dir($dir)) {
             mkdir($dir, 0755, true);
         }
-        file_put_contents($realPath, 'This is a test document content about Laravel.\nIt contains important information about the framework.');
+        file_put_contents($realPath, 'Laravel is a PHP framework.');
 
-        // Use mock embeddings that returns high similarity so search succeeds
-        $mockProvider = Mockery::mock(\Laravel\Ai\Contracts\Providers\TextProvider::class);
-        $mockProvider->shouldReceive('embeddings')->andReturn(
-            new EmbeddingsResponse(
-                embeddings: [[1.0, 0.0], [1.0, 0.0]],
-                tokens: 2,
-                meta: new Meta(provider: 'test', model: 'embedding-model')
-            )
-        );
+        // Mock EmbeddingCascadeService
+        $mockCascade = Mockery::mock(EmbeddingCascadeService::class);
+        
+        // 1. For query "test"
+        $mockCascade->shouldReceive('embed')
+            ->with(['test'])
+            ->once()
+            ->andReturn(new EmbeddingsResponse(
+                embeddings: [[1.0, 0.0]],
+                tokens: 1,
+                meta: new Meta(provider: 'test', model: 'text-embedding-3-small')
+            ));
 
-        $mockAiManager = Mockery::mock(AiManager::class);
-        $mockAiManager->shouldReceive('textProvider')->andReturn($mockProvider);
-        $this->app->instance(AiManager::class, $mockAiManager);
+        // 2. For document ingestion (chunks)
+        $mockCascade->shouldReceive('embed')
+            ->with(Mockery::on(fn($args) => count($args) > 0 && str_contains($args[0], 'Laravel')))
+            ->once()
+            ->andReturn(new EmbeddingsResponse(
+                embeddings: [[0.9, 0.1]],
+                tokens: 1,
+                meta: new Meta(provider: 'test', model: 'text-embedding-3-small')
+            ));
+
+        $this->app->instance(EmbeddingCascadeService::class, $mockCascade);
 
         $service = new LaravelDocumentRetrievalService();
 
@@ -215,26 +123,15 @@ class LaravelDocumentRetrievalServiceTest extends TestCase
             (string) $user->id
         );
 
-        $this->assertArrayHasKey('success', $result);
         $this->assertTrue($result['success']);
-        $this->assertArrayHasKey('chunks', $result);
-        $this->assertNotEmpty($result['chunks']);
-        $this->assertEquals('test.txt', $result['chunks'][0]['filename']);
-        $this->assertStringContainsString('This is a test document content about Laravel.', $result['chunks'][0]['content']);
+        $this->assertCount(1, $result['chunks']);
+        
+        // Verify chunks were saved to DB
+        $this->assertDatabaseHas('document_chunks', [
+            'document_id' => $document->id,
+            'embedding_model' => 'text-embedding-3-small',
+        ]);
 
         unlink($realPath);
-    }
-
-    private function invokeCalculateSimilarity(
-        LaravelDocumentRetrievalService $service,
-        string $query,
-        string $content,
-        object $provider
-    ): float {
-        $reflection = new \ReflectionClass($service);
-        $method = $reflection->getMethod('calculateSimilarity');
-        $method->setAccessible(true);
-
-        return $method->invoke($service, $query, $content, $provider);
     }
 }

--- a/laravel/tests/Unit/Services/Document/LaravelDocumentRetrievalServiceTest.php
+++ b/laravel/tests/Unit/Services/Document/LaravelDocumentRetrievalServiceTest.php
@@ -10,7 +10,6 @@ use App\Services\Document\LaravelDocumentRetrievalService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
-use Laravel\Ai\AiManager;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Mockery;
@@ -67,6 +66,43 @@ class LaravelDocumentRetrievalServiceTest extends TestCase
         $this->assertEquals('test.pdf', $result['chunks'][0]['filename']);
 
         unlink($realPath);
+    }
+
+    public function test_search_uses_provider_file_id_when_enabled(): void
+    {
+        Config::set('ai.laravel_ai.use_provider_file_search', true);
+        Config::set('ai.laravel_ai.model', 'gpt-4o-mini');
+
+        $user = User::factory()->create();
+        Document::factory()->for($user)->create([
+            'status' => 'ready',
+            'original_name' => 'provider.pdf',
+            'provider_file_id' => 'file-abcde12345',
+            'file_path' => 'documents/missing.pdf',
+        ]);
+
+        \Laravel\Ai\AnonymousAgent::fake([
+            'Ini adalah mock response dari agent prompt via provider id',
+        ]);
+
+        $service = new LaravelDocumentRetrievalService();
+
+        $result = $service->searchRelevantChunks(
+            'apa itu laravel?',
+            ['provider.pdf'],
+            5,
+            (string) $user->id
+        );
+
+        $this->assertTrue($result['success']);
+        $this->assertEquals('Ini adalah mock response dari agent prompt via provider id', $result['chunks'][0]['content']);
+
+        \Laravel\Ai\AnonymousAgent::assertPrompted(function ($prompt) {
+            return $prompt->model === 'gpt-4o-mini' &&
+                $prompt->attachments->isNotEmpty() &&
+                $prompt->attachments->first() instanceof \Laravel\Ai\Files\ProviderDocument &&
+                $prompt->attachments->first()->id === 'file-abcde12345';
+        });
     }
 
     public function test_search_uses_local_vector_storage_and_cascade(): void
@@ -130,8 +166,172 @@ class LaravelDocumentRetrievalServiceTest extends TestCase
         $this->assertDatabaseHas('document_chunks', [
             'document_id' => $document->id,
             'embedding_model' => 'text-embedding-3-small',
+            'embedding_dimensions' => 2,
         ]);
 
         unlink($realPath);
+    }
+
+    public function test_compute_embeddings_stays_scoped_to_active_document(): void
+    {
+        $user = User::factory()->create();
+
+        $document = Document::factory()->for($user)->create([
+            'status' => 'ready',
+            'original_name' => 'doc-a.txt',
+            'file_path' => 'documents/doc-a.txt',
+        ]);
+
+        $otherDocument = Document::factory()->for($user)->create([
+            'status' => 'ready',
+            'original_name' => 'doc-b.txt',
+            'file_path' => 'documents/doc-b.txt',
+        ]);
+
+        $activeChunk = DocumentChunk::create([
+            'document_id' => $document->id,
+            'text_content' => 'Doc A content',
+        ]);
+
+        $otherChunk = DocumentChunk::create([
+            'document_id' => $otherDocument->id,
+            'text_content' => 'Doc B content',
+            'embedding' => [0.4, 0.5, 0.6],
+            'embedding_model' => 'text-embedding-3-large',
+            'embedding_dimensions' => 3,
+        ]);
+
+        $mockCascade = Mockery::mock(EmbeddingCascadeService::class);
+        $mockCascade->shouldReceive('embed')
+            ->once()
+            ->with(['Doc A content'], 'text-embedding-3-small')
+            ->andReturn(new EmbeddingsResponse(
+                embeddings: [[0.9, 0.1]],
+                tokens: 1,
+                meta: new Meta(provider: 'test', model: 'text-embedding-3-small')
+            ));
+
+        $this->app->instance(EmbeddingCascadeService::class, $mockCascade);
+
+        $service = new class extends LaravelDocumentRetrievalService
+        {
+            public function computeFor(Document $document, string $model, int $dimensions): void
+            {
+                $this->computeEmbeddingsForDocument($document, $model, $dimensions);
+            }
+        };
+
+        $service->computeFor($document, 'text-embedding-3-small', 2);
+
+        $this->assertDatabaseHas('document_chunks', [
+            'id' => $activeChunk->id,
+            'document_id' => $document->id,
+            'embedding_model' => 'text-embedding-3-small',
+            'embedding_dimensions' => 2,
+        ]);
+
+        $this->assertDatabaseHas('document_chunks', [
+            'id' => $otherChunk->id,
+            'document_id' => $otherDocument->id,
+            'embedding_model' => 'text-embedding-3-large',
+            'embedding_dimensions' => 3,
+        ]);
+    }
+
+    public function test_search_reembeds_when_existing_chunks_use_different_dimensions(): void
+    {
+        Config::set('ai.laravel_ai.use_provider_file_search', false);
+
+        $user = User::factory()->create();
+        $document = Document::factory()->for($user)->create([
+            'status' => 'ready',
+            'original_name' => 'transition.txt',
+            'file_path' => 'documents/transition.txt',
+        ]);
+
+        $chunk = DocumentChunk::create([
+            'document_id' => $document->id,
+            'text_content' => 'Laravel retrieval example',
+            'embedding' => [0.4, 0.5, 0.6],
+            'embedding_model' => 'text-embedding-3-large',
+            'embedding_dimensions' => 3,
+        ]);
+
+        $mockCascade = Mockery::mock(EmbeddingCascadeService::class);
+        $mockCascade->shouldReceive('embed')
+            ->once()
+            ->with(['laravel'])
+            ->andReturn(new EmbeddingsResponse(
+                embeddings: [[1.0, 0.0]],
+                tokens: 1,
+                meta: new Meta(provider: 'test', model: 'text-embedding-3-small')
+            ));
+        $mockCascade->shouldReceive('embed')
+            ->once()
+            ->with(['Laravel retrieval example'], 'text-embedding-3-small')
+            ->andReturn(new EmbeddingsResponse(
+                embeddings: [[0.9, 0.1]],
+                tokens: 1,
+                meta: new Meta(provider: 'test', model: 'text-embedding-3-small')
+            ));
+
+        $this->app->instance(EmbeddingCascadeService::class, $mockCascade);
+
+        $service = new LaravelDocumentRetrievalService();
+
+        $result = $service->searchRelevantChunks(
+            'laravel',
+            ['transition.txt'],
+            5,
+            (string) $user->id
+        );
+
+        $this->assertTrue($result['success']);
+        $this->assertCount(1, $result['chunks']);
+        $this->assertSame('transition.txt', $result['chunks'][0]['filename']);
+
+        $this->assertDatabaseHas('document_chunks', [
+            'id' => $chunk->id,
+            'embedding_model' => 'text-embedding-3-small',
+            'embedding_dimensions' => 2,
+        ]);
+    }
+
+    public function test_search_uses_lexical_fallback_when_query_embedding_fails(): void
+    {
+        Config::set('ai.laravel_ai.use_provider_file_search', false);
+
+        $user = User::factory()->create();
+        $document = Document::factory()->for($user)->create([
+            'status' => 'ready',
+            'original_name' => 'lexical.txt',
+            'file_path' => 'documents/lexical.txt',
+        ]);
+
+        DocumentChunk::create([
+            'document_id' => $document->id,
+            'text_content' => 'Laravel retrieval lexical fallback',
+        ]);
+
+        $mockCascade = Mockery::mock(EmbeddingCascadeService::class);
+        $mockCascade->shouldReceive('embed')
+            ->once()
+            ->with(['laravel'])
+            ->andThrow(new \RuntimeException('Embeddings unavailable'));
+
+        $this->app->instance(EmbeddingCascadeService::class, $mockCascade);
+
+        $service = new LaravelDocumentRetrievalService();
+
+        $result = $service->searchRelevantChunks(
+            'laravel',
+            ['lexical.txt'],
+            5,
+            (string) $user->id
+        );
+
+        $this->assertTrue($result['success']);
+        $this->assertCount(1, $result['chunks']);
+        $this->assertStringContainsString('Laravel retrieval lexical fallback', $result['chunks'][0]['content']);
     }
 }

--- a/laravel/tests/Unit/Services/Document/LaravelDocumentRetrievalServiceTest.php
+++ b/laravel/tests/Unit/Services/Document/LaravelDocumentRetrievalServiceTest.php
@@ -297,6 +297,71 @@ class LaravelDocumentRetrievalServiceTest extends TestCase
         ]);
     }
 
+    public function test_search_reembeds_stale_chunks_when_document_has_mixed_embedding_states(): void
+    {
+        Config::set('ai.laravel_ai.use_provider_file_search', false);
+
+        $user = User::factory()->create();
+        $document = Document::factory()->for($user)->create([
+            'status' => 'ready',
+            'original_name' => 'mixed.txt',
+            'file_path' => 'documents/mixed.txt',
+        ]);
+
+        DocumentChunk::create([
+            'document_id' => $document->id,
+            'text_content' => 'Current chunk',
+            'embedding' => [1.0, 0.0],
+            'embedding_model' => 'text-embedding-3-small',
+            'embedding_dimensions' => 2,
+        ]);
+
+        $staleChunk = DocumentChunk::create([
+            'document_id' => $document->id,
+            'text_content' => 'Stale chunk',
+            'embedding' => [0.4, 0.5, 0.6],
+            'embedding_model' => 'text-embedding-3-large',
+            'embedding_dimensions' => 3,
+        ]);
+
+        $mockCascade = Mockery::mock(EmbeddingCascadeService::class);
+        $mockCascade->shouldReceive('embed')
+            ->once()
+            ->with(['laravel'])
+            ->andReturn(new EmbeddingsResponse(
+                embeddings: [[1.0, 0.0]],
+                tokens: 1,
+                meta: new Meta(provider: 'test', model: 'text-embedding-3-small')
+            ));
+        $mockCascade->shouldReceive('embed')
+            ->once()
+            ->with(['Stale chunk'], 'text-embedding-3-small')
+            ->andReturn(new EmbeddingsResponse(
+                embeddings: [[0.8, 0.2]],
+                tokens: 1,
+                meta: new Meta(provider: 'test', model: 'text-embedding-3-small')
+            ));
+
+        $this->app->instance(EmbeddingCascadeService::class, $mockCascade);
+
+        $service = new LaravelDocumentRetrievalService();
+
+        $result = $service->searchRelevantChunks(
+            'laravel',
+            ['mixed.txt'],
+            5,
+            (string) $user->id
+        );
+
+        $this->assertTrue($result['success']);
+        $this->assertCount(2, $result['chunks']);
+        $this->assertDatabaseHas('document_chunks', [
+            'id' => $staleChunk->id,
+            'embedding_model' => 'text-embedding-3-small',
+            'embedding_dimensions' => 2,
+        ]);
+    }
+
     public function test_search_uses_lexical_fallback_when_query_embedding_fails(): void
     {
         Config::set('ai.laravel_ai.use_provider_file_search', false);
@@ -333,5 +398,51 @@ class LaravelDocumentRetrievalServiceTest extends TestCase
         $this->assertTrue($result['success']);
         $this->assertCount(1, $result['chunks']);
         $this->assertStringContainsString('Laravel retrieval lexical fallback', $result['chunks'][0]['content']);
+    }
+
+    public function test_search_uses_lexical_fallback_when_document_embedding_refresh_fails(): void
+    {
+        Config::set('ai.laravel_ai.use_provider_file_search', false);
+
+        $user = User::factory()->create();
+        $document = Document::factory()->for($user)->create([
+            'status' => 'ready',
+            'original_name' => 'doc-refresh-fallback.txt',
+            'file_path' => 'documents/doc-refresh-fallback.txt',
+        ]);
+
+        DocumentChunk::create([
+            'document_id' => $document->id,
+            'text_content' => 'Laravel refresh fallback chunk',
+        ]);
+
+        $mockCascade = Mockery::mock(EmbeddingCascadeService::class);
+        $mockCascade->shouldReceive('embed')
+            ->once()
+            ->with(['laravel'])
+            ->andReturn(new EmbeddingsResponse(
+                embeddings: [[1.0, 0.0]],
+                tokens: 1,
+                meta: new Meta(provider: 'test', model: 'text-embedding-3-small')
+            ));
+        $mockCascade->shouldReceive('embed')
+            ->once()
+            ->with(['Laravel refresh fallback chunk'], 'text-embedding-3-small')
+            ->andThrow(new \RuntimeException('Document embeddings unavailable'));
+
+        $this->app->instance(EmbeddingCascadeService::class, $mockCascade);
+
+        $service = new LaravelDocumentRetrievalService();
+
+        $result = $service->searchRelevantChunks(
+            'laravel',
+            ['doc-refresh-fallback.txt'],
+            5,
+            (string) $user->id
+        );
+
+        $this->assertTrue($result['success']);
+        $this->assertCount(1, $result['chunks']);
+        $this->assertStringContainsString('Laravel refresh fallback chunk', $result['chunks'][0]['content']);
     }
 }

--- a/laravel/tests/Unit/Services/Document/LaravelDocumentRetrievalServiceTest.php
+++ b/laravel/tests/Unit/Services/Document/LaravelDocumentRetrievalServiceTest.php
@@ -3,9 +3,7 @@
 namespace Tests\Unit\Services\Document;
 
 use App\Models\Document;
-use App\Models\DocumentChunk;
 use App\Models\User;
-use App\Services\AI\EmbeddingCascadeService;
 use App\Services\Document\LaravelDocumentRetrievalService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
@@ -24,6 +22,63 @@ class LaravelDocumentRetrievalServiceTest extends TestCase
     {
         parent::setUp();
         Storage::fake('local');
+    }
+
+    public function test_calculate_similarity_uses_sdk_embeddings_api_shape(): void
+    {
+        Config::set('ai.rag.embedding_model', 'text-embedding-3-small');
+        Config::set('ai.rag.embedding_dimensions', 1536);
+
+        $this->app->instance(AiManager::class, Mockery::mock(AiManager::class));
+
+        $service = new LaravelDocumentRetrievalService();
+
+        $provider = new class
+        {
+            public array $inputs = [];
+            public ?int $dimensions = null;
+            public ?string $model = null;
+
+            public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30): EmbeddingsResponse
+            {
+                $this->inputs = $inputs;
+                $this->dimensions = $dimensions;
+                $this->model = $model;
+
+                return new EmbeddingsResponse(
+                    embeddings: [[1.0, 0.0], [1.0, 0.0]],
+                    tokens: 2,
+                    meta: new Meta(provider: 'test', model: 'embedding-model')
+                );
+            }
+        };
+
+        $score = $this->invokeCalculateSimilarity($service, 'query contoh', 'konten contoh', $provider);
+
+        $this->assertSame(['query contoh', 'konten contoh'], $provider->inputs);
+        $this->assertSame(1536, $provider->dimensions);
+        $this->assertSame('text-embedding-3-small', $provider->model);
+        $this->assertGreaterThan(0.0, $score);
+    }
+
+    public function test_calculate_similarity_falls_back_to_lexical_overlap_when_embeddings_fail(): void
+    {
+        $this->app->instance(AiManager::class, Mockery::mock(AiManager::class));
+
+        $service = new LaravelDocumentRetrievalService();
+
+        $provider = new class
+        {
+            public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30): EmbeddingsResponse
+            {
+                throw new \RuntimeException('Embeddings unavailable');
+            }
+        };
+
+        $score = $this->invokeCalculateSimilarity($service, 'apel mangga', 'apel jeruk', $provider);
+
+        $this->assertGreaterThan(0.0, $score);
+        $this->assertLessThan(1.0, $score);
     }
 
     public function test_search_uses_provider_file_search_when_enabled(): void
@@ -60,59 +115,96 @@ class LaravelDocumentRetrievalServiceTest extends TestCase
         );
 
         $this->assertArrayHasKey('success', $result);
+        if (!$result['success']) {
+            dump($result);
+        }
         $this->assertTrue($result['success']);
         $this->assertArrayHasKey('chunks', $result);
         $this->assertNotEmpty($result['chunks']);
         $this->assertEquals('Ini adalah mock response dari agent prompt', $result['chunks'][0]['content']);
         $this->assertEquals('test.pdf', $result['chunks'][0]['filename']);
 
+        \Laravel\Ai\AnonymousAgent::assertPrompted(function ($prompt) {
+            return $prompt->model === 'gpt-4o-mini' &&
+                   $prompt->attachments->isNotEmpty() &&
+                   $prompt->attachments->first() instanceof \Laravel\Ai\Files\LocalDocument;
+        });
+
         unlink($realPath);
     }
 
-    public function test_search_uses_local_vector_storage_and_cascade(): void
+    public function test_search_uses_provider_file_id_and_uses_config_model_when_enabled(): void
+    {
+        Config::set('ai.laravel_ai.use_provider_file_search', true);
+        Config::set('ai.laravel_ai.model', 'gpt-4o-mini');
+
+        $user = User::factory()->create();
+        $document = Document::factory()->for($user)->create([
+            'status' => 'ready',
+            'original_name' => 'test_provider.pdf',
+            'provider_file_id' => 'file-abcde12345',
+            'file_path' => 'documents/missing.pdf', // file lokal sengaja tidak ada
+        ]);
+
+        \Laravel\Ai\AnonymousAgent::fake([
+            'Ini adalah mock response dari agent prompt via provider id',
+        ]);
+
+        $service = new LaravelDocumentRetrievalService();
+
+        $result = $service->searchRelevantChunks(
+            'apa itu laravel?',
+            ['test_provider.pdf'],
+            5,
+            (string) $user->id
+        );
+
+        $this->assertArrayHasKey('success', $result);
+        $this->assertTrue($result['success']);
+        $this->assertArrayHasKey('chunks', $result);
+        $this->assertEquals('Ini adalah mock response dari agent prompt via provider id', $result['chunks'][0]['content']);
+
+        \Laravel\Ai\AnonymousAgent::assertPrompted(function ($prompt) {
+            return $prompt->model === 'gpt-4o-mini' &&
+                   $prompt->attachments->isNotEmpty() &&
+                   $prompt->attachments->first() instanceof \Laravel\Ai\Files\ProviderDocument &&
+                   $prompt->attachments->first()->id === 'file-abcde12345';
+        });
+    }
+
+    public function test_search_uses_local_extraction_when_provider_file_search_disabled(): void
     {
         Config::set('ai.laravel_ai.use_provider_file_search', false);
-        Config::set('ai.rag.embedding_model', 'text-embedding-3-small');
-        Config::set('ai.rag.embedding_dimensions', 1536);
 
         $user = User::factory()->create();
         $document = Document::factory()->for($user)->create([
             'status' => 'ready',
             'original_name' => 'test.txt',
+            'provider_file_id' => null,
             'file_path' => 'documents/test.txt',
         ]);
 
+        // Use real file in storage/app directory
         $realPath = storage_path('app/documents/test.txt');
         $dir = dirname($realPath);
         if (!is_dir($dir)) {
             mkdir($dir, 0755, true);
         }
-        file_put_contents($realPath, 'Laravel is a PHP framework.');
+        file_put_contents($realPath, 'This is a test document content about Laravel.\nIt contains important information about the framework.');
 
-        // Mock EmbeddingCascadeService
-        $mockCascade = Mockery::mock(EmbeddingCascadeService::class);
-        
-        // 1. For query "test"
-        $mockCascade->shouldReceive('embed')
-            ->with(['test'])
-            ->once()
-            ->andReturn(new EmbeddingsResponse(
-                embeddings: [[1.0, 0.0]],
-                tokens: 1,
-                meta: new Meta(provider: 'test', model: 'text-embedding-3-small')
-            ));
+        // Use mock embeddings that returns high similarity so search succeeds
+        $mockProvider = Mockery::mock(\Laravel\Ai\Contracts\Providers\TextProvider::class);
+        $mockProvider->shouldReceive('embeddings')->andReturn(
+            new EmbeddingsResponse(
+                embeddings: [[1.0, 0.0], [1.0, 0.0]],
+                tokens: 2,
+                meta: new Meta(provider: 'test', model: 'embedding-model')
+            )
+        );
 
-        // 2. For document ingestion (chunks)
-        $mockCascade->shouldReceive('embed')
-            ->with(Mockery::on(fn($args) => count($args) > 0 && str_contains($args[0], 'Laravel')))
-            ->once()
-            ->andReturn(new EmbeddingsResponse(
-                embeddings: [[0.9, 0.1]],
-                tokens: 1,
-                meta: new Meta(provider: 'test', model: 'text-embedding-3-small')
-            ));
-
-        $this->app->instance(EmbeddingCascadeService::class, $mockCascade);
+        $mockAiManager = Mockery::mock(AiManager::class);
+        $mockAiManager->shouldReceive('textProvider')->andReturn($mockProvider);
+        $this->app->instance(AiManager::class, $mockAiManager);
 
         $service = new LaravelDocumentRetrievalService();
 
@@ -123,15 +215,26 @@ class LaravelDocumentRetrievalServiceTest extends TestCase
             (string) $user->id
         );
 
+        $this->assertArrayHasKey('success', $result);
         $this->assertTrue($result['success']);
-        $this->assertCount(1, $result['chunks']);
-        
-        // Verify chunks were saved to DB
-        $this->assertDatabaseHas('document_chunks', [
-            'document_id' => $document->id,
-            'embedding_model' => 'text-embedding-3-small',
-        ]);
+        $this->assertArrayHasKey('chunks', $result);
+        $this->assertNotEmpty($result['chunks']);
+        $this->assertEquals('test.txt', $result['chunks'][0]['filename']);
+        $this->assertStringContainsString('This is a test document content about Laravel.', $result['chunks'][0]['content']);
 
         unlink($realPath);
+    }
+
+    private function invokeCalculateSimilarity(
+        LaravelDocumentRetrievalService $service,
+        string $query,
+        string $content,
+        object $provider
+    ): float {
+        $reflection = new \ReflectionClass($service);
+        $method = $reflection->getMethod('calculateSimilarity');
+        $method->setAccessible(true);
+
+        return $method->invoke($service, $query, $content, $provider);
     }
 }


### PR DESCRIPTION
<!-- opencode-standardized: github-writing-standard-v1 -->
## Ringkasan
- pulihkan implementasi issue #87 di atas `main` setelah PR #97 sempat ter-merge lalu direvert
- normalkan model response provider ke model canonical node cascade
- cegah fallback diam-diam ke provider default saat `targetModel` tidak bisa dipetakan
- tambah regression test untuk scoped re-embedding, transisi dimensi, provider file id, dan lexical fallback

## Perubahan Utama
| File / Area | Deskripsi |
|---|---|
| Area umum | File spesifik tidak dicatat eksplisit pada body lama. |

### Detail Perubahan
- pulihkan implementasi issue #87 di atas `main` setelah PR #97 sempat ter-merge lalu direvert
- normalkan model response provider ke model canonical node cascade
- cegah fallback diam-diam ke provider default saat `targetModel` tidak bisa dipetakan
- tambah regression test untuk scoped re-embedding, transisi dimensi, provider file id, dan lexical fallback

## Validasi
- Body historis tidak mencatat command validasi spesifik.

## Deploy / QA
- Status PR: Merged
- Base branch: `main`
- Head branch: `codex/issue-87-rework`
- Merged at: 2026-04-26T00:44:16Z
- Closed at: 2026-04-26T00:44:16Z
- Deploy/QA tidak dicatat eksplisit pada body lama.

## Catatan / Risiko Residual
- Risiko residual tidak dicatat eksplisit pada body lama.

## Relasi Issue
- Relasi issue tidak ditemukan eksplisit pada body lama.

## Catatan Historis
<details>
<summary>Body sebelum standardisasi</summary>

## Status Arsip

Item ini diarsipkan sebagai bagian dari rangkaian **migrasi Laravel-only / AI parity** yang sudah tidak menjadi jalur roadmap aktif. Roadmap aktif kembali mengacu ke issue utama #1, dengan kelanjutan Tahap 6 dan Tahap 7 di #116-#119 dan PR #120.

- Jenis item: Pull Request #98.
- Status GitHub saat dirapikan: MERGED.
- Keputusan: jangan dipakai sebagai acuan implementasi baru kecuali untuk referensi historis.
- Catatan: konten lama tetap dipertahankan di bawah agar riwayat teknis masih bisa ditelusuri.

## Konten Lama

## Ringkasan
- pulihkan implementasi issue #87 di atas `main` setelah PR #97 sempat ter-merge lalu direvert
- normalkan model response provider ke model canonical node cascade
- cegah fallback diam-diam ke provider default saat `targetModel` tidak bisa dipetakan
- tambah regression test untuk scoped re-embedding, transisi dimensi, provider file id, dan lexical fallback

## Latar Belakang
PR ini menggantikan jalur PR #97 yang sempat masuk ke `main` secara tidak sengaja lalu direvert. Scope tetap mengikuti issue #87, tetapi recovery ini sudah memasukkan perbaikan atas blocker review sebelumnya.

## Verifikasi
- `cd laravel && php artisan test --filter='EmbeddingCascadeTest|LaravelDocumentRetrievalServiceTest'`
- `cd laravel && php artisan test`

</details>
