### PR TITLE
Arsip AI Parity: Follow-up Summarization dan OCR

### DIFF
--- a/issue/issue-113-followup-summarization-runtime-and-observability.md
+++ b/issue/issue-113-followup-summarization-runtime-and-observability.md
@@ -1,0 +1,54 @@
+# Issue Follow-up PR112/PR113: Summarization Runtime, OCR Config, dan Observability Laravel
+
+## Latar Belakang
+
+Setelah merge sampai PR #112, masih ada beberapa gap penting:
+
+1. Fix summarization SDK bypass dari PR #113 belum masuk `main`.
+2. Multi-batch summarization masih memakai prompt parsial secara hardcoded.
+3. `PdfToImageRenderer` masih membaca `image_dpi` / `image_format` dari key config yang salah.
+4. Runtime lokal Laravel pada workspace ini belum membawa kredensial provider yang sekarang dipakai cascade Laravel, sehingga chat jatuh ke 401.
+
+## Tujuan
+
+- Memastikan summarization di `main` tidak lagi bergantung pada endpoint `/responses`.
+- Memperbaiki prompt multi-batch agar partial summary dan final combine memakai template yang benar.
+- Menyamakan pembacaan config OCR image rendering dengan struktur `config/ai.php`.
+- Memulihkan runtime chat lokal Laravel di workspace ini.
+- Mendokumentasikan lokasi log Laravel yang relevan untuk observability runtime.
+
+## Scope Implementasi
+
+### 1. Re-apply fix summarization bypass
+- Cherry-pick / re-apply perubahan setara commit `b744ef5`.
+- Pastikan path summarization memanggil `/chat/completions` langsung, bukan SDK path yang memicu 404 di GitHub Models.
+
+### 2. Fix prompt multi-batch summarization
+- Ubah `buildSummarizationPrompt(...)` agar menerima mode prompt dan nomor bagian.
+- Gunakan template `partial` untuk batch summary.
+- Gunakan template `final` untuk langkah final combine.
+- Pastikan metadata model akhir tetap berasal dari langkah combine terakhir.
+
+### 3. Fix OCR renderer config alignment
+- Ubah `PdfToImageRenderer` agar membaca `image_dpi` dan `image_format` dari `ai.ocr.*`.
+- Pertahankan `max_pages` sesuai jalur OCR yang dipakai renderer.
+
+### 4. Pulihkan runtime lokal
+- Sinkronkan secret provider yang sudah ada di `python-ai/.env` ke `laravel/.env` secara lokal.
+- Langkah ini hanya untuk runtime lokal dan tidak akan di-commit.
+
+### 5. Verifikasi
+- Tambah / perbarui test unit Laravel untuk prompt partial/final dan OCR config.
+- Jalankan test Laravel yang relevan, lalu bila memadai lanjut `php artisan test`.
+- Lakukan smoke check chat lokal singkat setelah secret Laravel tersedia.
+
+## Risiko
+
+- Re-apply fix summarization bisa berbenturan dengan perubahan prompt wiring di PR #112.
+- Verifikasi runtime live chat bergantung pada secret lokal yang valid.
+- Perubahan log/observability harus tetap minimal agar tidak menambah noise berlebihan.
+
+## Catatan
+
+- Temuan embedding 401 belum menjadi fokus fix ini, kecuali menghambat verifikasi chat dasar.
+- Jika ada additional findings lain dari review Devin, catat sebagai tindak lanjut terpisah bila belum bisa direproduksi dari repo lokal.

--- a/issue/issue-113-summarization-sdk-bypass.md
+++ b/issue/issue-113-summarization-sdk-bypass.md
@@ -1,0 +1,42 @@
+# Issue #113 — Summarization cascade SDK bypass (follow-up Devin Review #110)
+
+## Latar belakang
+
+Devin Review pada PR #110 menemukan bahwa `LaravelDocumentService::summarizeWithCascade()` masih memakai SDK `laravel/ai` (`AnonymousAgent` + `AgentPrompt` + `$provider->prompt()`). SDK selalu memanggil endpoint `/responses` (OpenAI Responses API) — endpoint yang **tidak didukung** oleh GitHub Models (`models.inference.ai.azure.com`) yang menjadi target cascade primary.
+
+Ini adalah class bug yang sama dengan yang sudah di-fix PR #107 untuk path chat (`LaravelChatService::streamChatCompletion`), tapi belum di-mirror untuk path summarization. Akibatnya:
+
+- Setiap kali `summarizeDocument` dipanggil di runtime, semua cascade nodes OpenAI-compatible (#1-#4 + #5 Gemini setelah PR #112) gagal dengan HTTP 404 `api_not_supported`.
+- `runSummarizationDefault` fallback juga pakai SDK → ikut gagal.
+- User mendapat pesan error generic, summarization fitur tidak berfungsi end-to-end.
+
+## Scope perubahan
+
+`laravel/app/Services/Document/LaravelDocumentService.php`:
+
+- Ganti `runSummarizationOnNode()` dan `runSummarizationDefault()` dari SDK call ke direct HTTP `POST {base_url}/chat/completions` via `Illuminate\Support\Facades\Http`. Mirror approach `LaravelChatService::streamChatCompletion()` (PR #107) tapi non-streaming (summarization tidak butuh SSE).
+- Tambah helper `callChatCompletion()` yang construct OpenAI-compatible request body, validate response, return content.
+- Tambah helper `getSummarizationInstructions()` yang baca `config('ai.prompts.summarization.instructions')` dengan fallback string lama (back-compat dengan PR #108).
+- Tambah `use Illuminate\Support\Facades\Http;`.
+
+`laravel/tests/Unit/Services/Document/LaravelDocumentServiceTest.php`:
+
+- Tambah test `test_summarize_calls_chat_completions_endpoint_not_responses` yang:
+  1. Stub `Http::fake` untuk `/chat/completions` (200) + `/responses` (404).
+  2. Panggil `summarizeWithCascade()` via anonymous subclass.
+  3. Assert response cocok dengan `/chat/completions` content.
+  4. Assert `Http::assertSent` URL ends with `/chat/completions` (regression guard).
+
+## Acceptance criteria
+
+- [ ] `runSummarizationOnNode` / `runSummarizationDefault` tidak lagi memanggil SDK `$provider->prompt()`.
+- [ ] Test baru lulus dan akan gagal kalau ada regresi (SDK path balik).
+- [ ] Full test suite tetap hijau (15 LaravelDocumentService tests + 5 baru).
+
+## Risiko
+
+Low — perubahan terbatas pada 2 fungsi internal `LaravelDocumentService`. Public API (`summarizeDocument`) tidak berubah. Semua test existing tetap pass karena mereka mock `summarizeWithCascade()` atau `runSummarizationOnNode()` di higher level.
+
+## Dependency
+
+Branch ini di-stack di atas `devin/1777199500-followup-fixes-config-restore` (PR #112) karena sama-sama menyentuh `LaravelDocumentService.php`. Setelah PR #112 merge, PR ini akan auto-rebase clean.

--- a/laravel/app/Services/Chat/LaravelChatService.php
+++ b/laravel/app/Services/Chat/LaravelChatService.php
@@ -404,6 +404,7 @@ PROMPT;
     ): \Generator {
         $baseUrl = rtrim($node['base_url'] ?? 'https://api.openai.com/v1', '/');
         $url = $baseUrl . '/chat/completions';
+        $label = $node['label'] ?? $node['model'] ?? 'unknown';
 
         $body = [
             'model' => $node['model'],
@@ -413,6 +414,13 @@ PROMPT;
             ],
             'stream' => true,
         ];
+
+        Log::info('LaravelChatService: starting stream', [
+            'label' => $label,
+            'model' => $node['model'] ?? null,
+            'base_url' => $baseUrl,
+            'sources_count' => count($initialSources),
+        ]);
 
         $response = Http::withToken((string) ($node['api_key'] ?? ''))
             ->withHeaders(['Accept' => 'text/event-stream'])
@@ -471,6 +479,12 @@ PROMPT;
         if (!empty($sources)) {
             yield "\n[SOURCES:" . json_encode($sources) . "]\n";
         }
+
+        Log::info('LaravelChatService: stream completed', [
+            'label' => $label,
+            'model' => $node['model'] ?? null,
+            'sources_count' => count($sources),
+        ]);
     }
 
     protected function shouldFallback(\Throwable $e): bool

--- a/laravel/app/Services/Document/LaravelDocumentService.php
+++ b/laravel/app/Services/Document/LaravelDocumentService.php
@@ -4,6 +4,7 @@ namespace App\Services\Document;
 
 use App\Models\Document;
 use App\Models\DocumentChunk;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Laravel\Ai\AiManager;
 use Laravel\Ai\AnonymousAgent;
@@ -336,34 +337,88 @@ class LaravelDocumentService
 
     protected function runSummarizationOnNode(array $node, AnonymousAgent $agent, string $content): string
     {
-        $provider = $this->getProviderForNode($node, $agent);
-
-        $prompt = new AgentPrompt(
-            agent: $agent,
-            prompt: $this->buildSummarizationPrompt($content),
-            attachments: [],
-            provider: $provider,
+        return $this->callChatCompletion(
+            baseUrl: $node['base_url'] ?? 'https://api.openai.com/v1',
+            apiKey: $node['api_key'] ?? '',
             model: $node['model'],
+            systemPrompt: $this->getSummarizationInstructions(),
+            userPrompt: $this->buildSummarizationPrompt($content),
         );
-
-        $result = $provider->prompt($prompt);
-
-        return $result->text ?? '';
     }
 
     protected function runSummarizationDefault(AnonymousAgent $agent, string $content): string
     {
-        $defaultProvider = $this->ai->textProvider();
+        $baseUrl = config('ai.laravel_ai.base_url', 'https://api.openai.com/v1');
+        $apiKey = config('ai.laravel_ai.api_key', '');
 
-        $result = $defaultProvider->prompt(new AgentPrompt(
-            agent: $agent,
-            prompt: $this->buildSummarizationPrompt($content),
-            attachments: [],
-            provider: $defaultProvider,
+        return $this->callChatCompletion(
+            baseUrl: $baseUrl,
+            apiKey: $apiKey,
             model: $this->model,
-        ));
+            systemPrompt: $this->getSummarizationInstructions(),
+            userPrompt: $this->buildSummarizationPrompt($content),
+        );
+    }
 
-        return $result->text ?? '';
+    /**
+     * Call provider's `/chat/completions` directly. Bypasses laravel/ai SDK
+     * which always calls `/responses` (Responses API) — unsupported by GitHub
+     * Models endpoint that the cascade targets. Same approach as
+     * LaravelChatService::streamChatCompletion (PR #107) but for non-streaming
+     * summarization use case.
+     */
+    protected function callChatCompletion(
+        string $baseUrl,
+        string $apiKey,
+        string $model,
+        string $systemPrompt,
+        string $userPrompt
+    ): string {
+        $url = rtrim($baseUrl, '/') . '/chat/completions';
+
+        $response = Http::withToken($apiKey)
+            ->acceptJson()
+            ->asJson()
+            ->timeout((int) config('ai.summarization.http_timeout', 120))
+            ->post($url, [
+                'model' => $model,
+                'messages' => [
+                    ['role' => 'system', 'content' => $systemPrompt],
+                    ['role' => 'user', 'content' => $userPrompt],
+                ],
+                'temperature' => (float) config('ai.summarization.temperature', 0.2),
+            ]);
+
+        if (!$response->successful()) {
+            throw new \RuntimeException(sprintf(
+                'Summarization HTTP %d at %s: %s',
+                $response->status(),
+                $url,
+                substr((string) $response->body(), 0, 500)
+            ));
+        }
+
+        $payload = $response->json();
+        $text = $payload['choices'][0]['message']['content'] ?? '';
+
+        if (!is_string($text) || trim($text) === '') {
+            throw new \RuntimeException(
+                'Summarization returned empty content from ' . $url
+            );
+        }
+
+        return $text;
+    }
+
+    protected function getSummarizationInstructions(): string
+    {
+        $instructions = config('ai.prompts.summarization.instructions');
+
+        if (is_string($instructions) && trim($instructions) !== '') {
+            return $instructions;
+        }
+
+        return 'Anda adalah asisten AI yang merangkum dokumen. Berikan ringkasan singkat dan akurat dari bagian dokumen yang diberikan.';
     }
 
     protected function buildSummarizationPrompt(string $content): string

--- a/laravel/app/Services/Document/LaravelDocumentService.php
+++ b/laravel/app/Services/Document/LaravelDocumentService.php
@@ -101,15 +101,21 @@ class LaravelDocumentService
 
             if ($totalTokens <= $this->maxTokensPerBatch) {
                 $content = implode("\n\n", $chunks);
-                $result = $this->summarizeWithCascade($content);
+                $result = $this->summarizeWithCascade($content, 'single');
                 $summary = $result['text'] ?? '';
                 $usedModel = $result['model'] ?? $this->model;
             } else {
                 $batches = $this->createBatches($chunks);
                 $batchSummaries = [];
+                $totalBatches = count($batches);
 
-                foreach ($batches as $batchContent) {
-                    $batchResult = $this->summarizeWithCascade($batchContent);
+                foreach ($batches as $index => $batchContent) {
+                    $batchResult = $this->summarizeWithCascade(
+                        $batchContent,
+                        'partial',
+                        $index + 1,
+                        $totalBatches
+                    );
                     if (!empty($batchResult['text'])) {
                         $batchSummaries[] = $batchResult['text'];
                     }
@@ -125,7 +131,7 @@ class LaravelDocumentService
                 $combinedSummary = implode("\n\n", $batchSummaries);
 
                 if (count($batchSummaries) > 1) {
-                    $finalResult = $this->summarizeWithCascade($combinedSummary);
+                    $finalResult = $this->summarizeWithCascade($combinedSummary, 'final');
                     $summary = $finalResult['text'] ?? $combinedSummary;
                     $usedModel = $finalResult['model'] ?? $this->model;
                 } else {
@@ -296,21 +302,26 @@ class LaravelDocumentService
         return app(\Laravel\Ai\AiManager::class)->textProvider('temp_cascade');
     }
 
-    protected function summarizeWithCascade(string $content): array
+    protected function summarizeWithCascade(
+        string $content,
+        string $promptMode = 'single',
+        int $partNumber = 1,
+        int $totalParts = 1
+    ): array
     {
         $nodes = $this->cascadeEnabled && !empty($this->cascadeNodes)
             ? $this->cascadeNodes
             : [['label' => 'Default', 'provider' => 'openai', 'model' => $this->model, 'api_key' => config('ai.laravel_ai.api_key')]];
 
-        $agent = AnonymousAgent::make(
-            instructions: 'Anda adalah asisten AI yang merangkum dokumen. Berikan ringkasan singkat dan akurat dari bagian dokumen yang diberikan.',
-            messages: [],
-            tools: []
-        );
-
         foreach ($nodes as $node) {
             try {
-                $text = $this->runSummarizationOnNode($node, $agent, $content);
+                $text = $this->runSummarizationOnNode(
+                    $node,
+                    $content,
+                    $promptMode,
+                    $partNumber,
+                    $totalParts
+                );
                 return [
                     'text' => $text,
                     'model' => $node['model'],
@@ -326,7 +337,12 @@ class LaravelDocumentService
             }
         }
 
-        $text = $this->runSummarizationDefault($agent, $content);
+        $text = $this->runSummarizationDefault(
+            $content,
+            $promptMode,
+            $partNumber,
+            $totalParts
+        );
 
         return [
             'text' => $text,
@@ -335,18 +351,29 @@ class LaravelDocumentService
         ];
     }
 
-    protected function runSummarizationOnNode(array $node, AnonymousAgent $agent, string $content): string
+    protected function runSummarizationOnNode(
+        array $node,
+        string $content,
+        string $promptMode = 'single',
+        int $partNumber = 1,
+        int $totalParts = 1
+    ): string
     {
         return $this->callChatCompletion(
             baseUrl: $node['base_url'] ?? 'https://api.openai.com/v1',
             apiKey: $node['api_key'] ?? '',
             model: $node['model'],
             systemPrompt: $this->getSummarizationInstructions(),
-            userPrompt: $this->buildSummarizationPrompt($content),
+            userPrompt: $this->buildSummarizationPrompt($content, $promptMode, $partNumber, $totalParts),
         );
     }
 
-    protected function runSummarizationDefault(AnonymousAgent $agent, string $content): string
+    protected function runSummarizationDefault(
+        string $content,
+        string $promptMode = 'single',
+        int $partNumber = 1,
+        int $totalParts = 1
+    ): string
     {
         $baseUrl = config('ai.laravel_ai.base_url', 'https://api.openai.com/v1');
         $apiKey = config('ai.laravel_ai.api_key', '');
@@ -356,7 +383,7 @@ class LaravelDocumentService
             apiKey: $apiKey,
             model: $this->model,
             systemPrompt: $this->getSummarizationInstructions(),
-            userPrompt: $this->buildSummarizationPrompt($content),
+            userPrompt: $this->buildSummarizationPrompt($content, $promptMode, $partNumber, $totalParts),
         );
     }
 
@@ -421,18 +448,41 @@ class LaravelDocumentService
         return 'Anda adalah asisten AI yang merangkum dokumen. Berikan ringkasan singkat dan akurat dari bagian dokumen yang diberikan.';
     }
 
-    protected function buildSummarizationPrompt(string $content): string
+    protected function buildSummarizationPrompt(
+        string $content,
+        string $mode = 'single',
+        int $partNumber = 1,
+        int $totalParts = 1
+    ): string
     {
-        $template = config('ai.prompts.summarization.partial');
-        if (is_string($template) && trim($template) !== '') {
-            return str_replace(
-                ['{batch}', '{part_number}', '{total_parts}'],
-                [$content, '1', '1'],
-                $template
-            );
+        if ($mode === 'final') {
+            $template = config('ai.prompts.summarization.final');
+            if (is_string($template) && trim($template) !== '') {
+                return str_replace('{combined_summaries}', $content, $template);
+            }
+
+            return 'Gabungkan ringkasan bagian-bagian berikut menjadi ringkasan akhir yang padat dan akurat: ' . $content;
         }
 
-        return 'Rangkum bagian dokumen berikut dengan detail dan akurat: ' . $content;
+        if ($mode === 'partial') {
+            $template = config('ai.prompts.summarization.partial');
+            if (is_string($template) && trim($template) !== '') {
+                return str_replace(
+                    ['{batch}', '{part_number}', '{total_parts}'],
+                    [$content, (string) $partNumber, (string) $totalParts],
+                    $template
+                );
+            }
+
+            return 'Rangkum bagian dokumen berikut dengan detail dan akurat: ' . $content;
+        }
+
+        $template = config('ai.prompts.summarization.single');
+        if (is_string($template) && trim($template) !== '') {
+            return str_replace('{document}', $content, $template);
+        }
+
+        return 'Rangkum dokumen berikut dengan detail dan akurat: ' . $content;
     }
 
     public function deleteDocument(string $filename, ?string $userId = null): bool

--- a/laravel/app/Services/Document/Parsing/PdfToImageRenderer.php
+++ b/laravel/app/Services/Document/Parsing/PdfToImageRenderer.php
@@ -14,9 +14,9 @@ class PdfToImageRenderer
 
     public function __construct()
     {
-        $this->dpi = config('ai.vision_cascade.image_dpi', 150);
-        $this->format = config('ai.vision_cascade.image_format', 'png');
-        $this->maxPages = config('ai.vision_cascade.max_pages', 20);
+        $this->dpi = (int) config('ai.ocr.image_dpi', 200);
+        $this->format = config('ai.ocr.image_format', 'png');
+        $this->maxPages = (int) config('ai.ocr.max_pages', 20);
     }
 
     public function renderToImages(string $pdfPath): array

--- a/laravel/tests/Unit/Services/Document/LaravelDocumentServiceTest.php
+++ b/laravel/tests/Unit/Services/Document/LaravelDocumentServiceTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Services\Document\LaravelDocumentService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
@@ -373,5 +374,46 @@ class LaravelDocumentServiceTest extends TestCase
         $this->assertEquals('Ringkasan dari file fallback', $result['summary']);
         $this->assertNotEmpty($result['sources']);
         $this->assertEquals('file_attachment', $result['sources'][0]['mode']);
+    }
+
+    public function test_summarize_calls_chat_completions_endpoint_not_responses(): void
+    {
+        Config::set('ai.cascade.enabled', true);
+        Config::set('ai.cascade.nodes', [[
+            'label' => 'Test Node',
+            'provider' => 'openai',
+            'model' => 'test-model',
+            'api_key' => 'test-key',
+            'base_url' => 'https://test.example/v1',
+        ]]);
+
+        Http::fake([
+            'https://test.example/v1/chat/completions' => Http::response([
+                'choices' => [[
+                    'message' => ['content' => 'Ringkasan hasil dari /chat/completions'],
+                ]],
+            ], 200),
+            'https://test.example/v1/responses' => Http::response(
+                ['error' => ['code' => 'api_not_supported']],
+                404
+            ),
+        ]);
+
+        $service = new class extends LaravelDocumentService {
+            public function summarize(string $content): array
+            {
+                return $this->summarizeWithCascade($content);
+            }
+        };
+
+        $result = $service->summarize('konten dokumen test.');
+
+        $this->assertEquals('test-model', $result['model']);
+        $this->assertStringContainsString('/chat/completions', $result['text'] ?? '');
+
+        Http::assertSent(function ($request) {
+            return str_ends_with($request->url(), '/chat/completions')
+                && !str_ends_with($request->url(), '/responses');
+        });
     }
 }

--- a/laravel/tests/Unit/Services/Document/LaravelDocumentServiceTest.php
+++ b/laravel/tests/Unit/Services/Document/LaravelDocumentServiceTest.php
@@ -184,6 +184,36 @@ class LaravelDocumentServiceTest extends TestCase
         $this->assertGreaterThan(0, $tokens);
     }
 
+    public function test_build_summarization_prompt_uses_real_part_numbers_for_partial_mode(): void
+    {
+        $service = new LaravelDocumentService();
+
+        $reflection = new \ReflectionClass($service);
+        $method = $reflection->getMethod('buildSummarizationPrompt');
+        $method->setAccessible(true);
+
+        $prompt = $method->invoke($service, 'Isi batch contoh', 'partial', 2, 4);
+
+        $this->assertStringContainsString('bagian 2 dari 4', $prompt);
+        $this->assertStringContainsString('Isi batch contoh', $prompt);
+    }
+
+    public function test_build_summarization_prompt_uses_final_template_for_combine_mode(): void
+    {
+        $service = new LaravelDocumentService();
+
+        $reflection = new \ReflectionClass($service);
+        $method = $reflection->getMethod('buildSummarizationPrompt');
+        $method->setAccessible(true);
+
+        $prompt = $method->invoke($service, 'Ringkasan A' . "\n\n" . 'Ringkasan B', 'final', 1, 1);
+
+        $this->assertStringContainsString('Gabungkan ringkasan bagian-bagian berikut', $prompt);
+        $this->assertStringContainsString('Ringkasan A', $prompt);
+        $this->assertStringContainsString('Ringkasan B', $prompt);
+        $this->assertStringNotContainsString('Ini adalah bagian', $prompt);
+    }
+
     public function test_summarize_single_batch_with_document_chunks_returns_metadata(): void
     {
         Config::set('ai.laravel_ai.api_key', 'test-key');
@@ -212,9 +242,20 @@ class LaravelDocumentServiceTest extends TestCase
 
         $service = new class extends LaravelDocumentService {
             public array $cascadeCalls = [];
-            protected function summarizeWithCascade(string $content): array
+            protected function summarizeWithCascade(
+                string $content,
+                string $promptMode = 'single',
+                int $partNumber = 1,
+                int $totalParts = 1
+            ): array
             {
-                $this->cascadeCalls[] = $content;
+                $this->cascadeCalls[] = [
+                    'content' => $content,
+                    'prompt_mode' => $promptMode,
+                    'part_number' => $partNumber,
+                    'total_parts' => $totalParts,
+                ];
+
                 return [
                     'text' => 'Ringkasan AI dari dokumen.',
                     'model' => 'openai/gpt-4.1',
@@ -232,6 +273,9 @@ class LaravelDocumentServiceTest extends TestCase
         $this->assertEquals('doc-single.pdf', $result['sources'][0]['filename']);
         $this->assertEquals($document->id, $result['sources'][0]['document_id']);
         $this->assertCount(1, $service->cascadeCalls, 'Single-batch path should call cascade exactly once');
+        $this->assertSame('single', $service->cascadeCalls[0]['prompt_mode']);
+        $this->assertSame(1, $service->cascadeCalls[0]['part_number']);
+        $this->assertSame(1, $service->cascadeCalls[0]['total_parts']);
     }
 
     public function test_summarize_multi_batch_with_final_summary_returns_correct_metadata(): void
@@ -264,17 +308,30 @@ class LaravelDocumentServiceTest extends TestCase
         }
 
         $service = new class extends LaravelDocumentService {
-            public int $cascadeCallCount = 0;
-            protected function summarizeWithCascade(string $content): array
+            public array $cascadeCalls = [];
+            protected function summarizeWithCascade(
+                string $content,
+                string $promptMode = 'single',
+                int $partNumber = 1,
+                int $totalParts = 1
+            ): array
             {
-                $this->cascadeCallCount++;
-                if ($this->cascadeCallCount === 1) {
-                    return ['text' => 'Batch 1 summary', 'model' => 'groq/llama-3.3-70b', 'provider' => 'groq'];
+                $this->cascadeCalls[] = [
+                    'content' => $content,
+                    'prompt_mode' => $promptMode,
+                    'part_number' => $partNumber,
+                    'total_parts' => $totalParts,
+                ];
+
+                if ($promptMode === 'final') {
+                    return ['text' => 'Final combined summary', 'model' => 'openai/gpt-4o', 'provider' => 'github_models'];
                 }
-                if ($this->cascadeCallCount === 2) {
-                    return ['text' => 'Batch 2 summary', 'model' => 'groq/llama-3.3-70b', 'provider' => 'groq'];
-                }
-                return ['text' => 'Final combined summary', 'model' => 'openai/gpt-4o', 'provider' => 'github_models'];
+
+                return [
+                    'text' => "Batch {$partNumber} summary",
+                    'model' => 'groq/llama-3.3-70b',
+                    'provider' => 'groq',
+                ];
             }
         };
 
@@ -283,8 +340,22 @@ class LaravelDocumentServiceTest extends TestCase
         $this->assertEquals('success', $result['status']);
         $this->assertEquals('Final combined summary', $result['summary']);
         $this->assertEquals('openai/gpt-4o', $result['model'], 'Final summary model harus digunakan, bukan model batch');
-        $this->assertGreaterThanOrEqual(3, $service->cascadeCallCount, 'Multi-batch + final summary harus memicu setidaknya 3 cascade calls');
+        $this->assertGreaterThanOrEqual(3, count($service->cascadeCalls), 'Multi-batch + final summary harus memicu setidaknya 3 cascade calls');
         $this->assertNotEmpty($result['sources']);
+
+        $partialCalls = array_slice($service->cascadeCalls, 0, -1);
+        $finalCall = $service->cascadeCalls[count($service->cascadeCalls) - 1];
+
+        $this->assertNotEmpty($partialCalls);
+        foreach ($partialCalls as $index => $call) {
+            $this->assertSame('partial', $call['prompt_mode']);
+            $this->assertSame($index + 1, $call['part_number']);
+            $this->assertSame(count($partialCalls), $call['total_parts']);
+        }
+
+        $this->assertSame('final', $finalCall['prompt_mode']);
+        $this->assertSame(1, $finalCall['part_number']);
+        $this->assertSame(1, $finalCall['total_parts']);
     }
 
     public function test_summarize_fallback_provider_when_primary_fails(): void
@@ -319,7 +390,13 @@ class LaravelDocumentServiceTest extends TestCase
 
         $service = new class extends LaravelDocumentService {
             public array $providerCalls = [];
-            protected function runSummarizationOnNode(array $node, \Laravel\Ai\AnonymousAgent $agent, string $content): string
+            protected function runSummarizationOnNode(
+                array $node,
+                string $content,
+                string $promptMode = 'single',
+                int $partNumber = 1,
+                int $totalParts = 1
+            ): string
             {
                 $this->providerCalls[] = $node['model'];
 

--- a/laravel/tests/Unit/Services/Document/Parsing/OcrServicesTest.php
+++ b/laravel/tests/Unit/Services/Document/Parsing/OcrServicesTest.php
@@ -23,6 +23,30 @@ class OcrServicesTest extends TestCase
         $this->assertInstanceOf(PdfToImageRenderer::class, $renderer);
     }
 
+    public function test_pdf_to_image_renderer_reads_image_settings_from_ocr_config(): void
+    {
+        config([
+            'ai.ocr.image_dpi' => 275,
+            'ai.ocr.image_format' => 'jpeg',
+            'ai.ocr.max_pages' => 7,
+            'ai.vision_cascade.max_pages' => 99,
+        ]);
+
+        $renderer = new PdfToImageRenderer();
+        $reflection = new \ReflectionClass($renderer);
+
+        $dpi = $reflection->getProperty('dpi');
+        $dpi->setAccessible(true);
+        $format = $reflection->getProperty('format');
+        $format->setAccessible(true);
+        $maxPages = $reflection->getProperty('maxPages');
+        $maxPages->setAccessible(true);
+
+        $this->assertSame(275, $dpi->getValue($renderer));
+        $this->assertSame('jpeg', $format->getValue($renderer));
+        $this->assertSame(7, $maxPages->getValue($renderer));
+    }
+
     public function test_ocr_orchestrator_can_be_instantiated(): void
     {
         config(['ai.ocr.enabled' => false]);


### PR DESCRIPTION
## Status Arsip

Item ini diarsipkan sebagai bagian dari rangkaian **migrasi Laravel-only / AI parity** yang sudah tidak menjadi jalur roadmap aktif. Roadmap aktif kembali mengacu ke issue utama #1, dengan kelanjutan Tahap 6 dan Tahap 7 di #116-#119 dan PR #120.

- Jenis item: Pull Request #114.
- Status GitHub saat dirapikan: MERGED.
- Keputusan: jangan dipakai sebagai acuan implementasi baru kecuali untuk referensi historis.
- Catatan: konten lama tetap dipertahankan di bawah agar riwayat teknis masih bisa ditelusuri.

## Konten Lama

## What changed
- re-applies the summarization `/chat/completions` bypass that was stranded outside `main`
- fixes multi-batch summarization prompt selection so `single`, `partial`, and `final` flows use the correct template and real part numbering
- aligns `PdfToImageRenderer` with `ai.ocr.*` image settings
- adds extra chat stream logging for easier Laravel-side runtime tracing
- adds regression tests for summarization prompt modes, endpoint selection, and OCR renderer config wiring

## Why it changed
PR #112 fixed several config regressions, but summarization still had follow-up gaps:
- runtime summarization was still vulnerable to the `/responses` endpoint incompatibility on GitHub Models
- multi-batch summarization always rendered `part 1 of 1` and reused the partial template during final combine
- OCR image rendering read DPI/format from the wrong config section

This branch consolidates those fixes on top of `main` and supersedes the leftover review branches that were not the correct merge target.

## Impact
- summarize runtime should work again on Laravel-only flow
- multi-batch summaries should produce better final output quality
- OCR PDF image rendering now respects the intended Laravel config keys
- Laravel logs now show chat stream start/completion per node, which helps replace the old Python-side visibility

## Validation
- `cd laravel && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test`
- `cd python-ai && source venv/bin/activate && pytest`

## Notes
- full Laravel verification is green with existing risky warnings in `PdfParserRuntimeTest` / `ProcessDocumentTest`, but no failing tests remain
- local system dependencies `ghostscript` and `poppler` were installed to satisfy the Laravel PDF runtime test path

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hasbi1605/ista-ai/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
