### PR TITLE
Perbaikan dokumen: buka preview PDF dan percepat render

### DIFF
--- a/issue/issue-chat-document-preview-blocked-loading-2026-04-30.md
+++ b/issue/issue-chat-document-preview-blocked-loading-2026-04-30.md
@@ -1,0 +1,29 @@
+# Issue Plan: Perbaiki Preview Dokumen Chat
+
+## Masalah
+- Preview PDF di chat sidebar muncul sebagai halaman yang diblokir Chrome.
+- Preview DOCX/XLSX terlalu lama masuk ke state `ready`, sehingga modal preview terasa menunggu terlalu lama.
+
+## Tujuan
+- PDF bisa tampil inline tanpa diblokir browser.
+- Preview Word/Excel diproses lebih cepat dan tidak menunggu antrean embedding dokumen.
+- Perilaku preview tetap terjaga untuk dokumen milik user yang sedang login.
+
+## Dugaan Akar Masalah
+- PDF dirender lewat iframe yang dibungkus `sandbox`, sehingga viewer PDF Chrome tidak bisa jalan normal.
+- Preview DOCX/XLSX baru dijadwalkan setelah proses embedding selesai, jadi preview ikut terlambat walaupun tidak bergantung pada embedding.
+
+## Rencana Perbaikan
+1. Hapus sandbox yang tidak perlu dari iframe PDF atau ganti ke rendering yang lebih ramah browser.
+2. Jalankan preview rendering segera setelah file tersimpan, bukan menunggu job embedding selesai.
+3. Pisahkan queue preview dari queue embedding agar preview tidak ikut antre di jalur yang sama.
+4. Tambahkan atau perbarui test untuk:
+   - PDF stream tetap inline dan bisa dibuka oleh owner.
+   - Preview job dijadwalkan saat upload dokumen.
+   - Viewer PDF tidak lagi memakai sandbox yang memblokir Chrome.
+
+## Risiko
+- Jika queue preview dipisah, Horizon harus tahu queue baru tersebut.
+- Preview DOCX/XLSX masih bisa lama untuk file besar, tapi tidak lagi tertahan oleh job embedding.
+- Perubahan preview harus tetap aman untuk authorization dan cleanup file preview lama.
+

--- a/laravel/app/Jobs/ProcessDocument.php
+++ b/laravel/app/Jobs/ProcessDocument.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Models\Document;
+use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Queue\Queueable;
@@ -10,18 +11,18 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
-use Exception;
 
 class ProcessDocument implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public $tries = 3;
+
     public $backoff = [30, 60, 120];
-    
+
     /**
      * The number of seconds the job can run before timing out.
-     * 
+     *
      * @var int
      */
     public $timeout = 900; // 15 minutes timeout
@@ -45,19 +46,19 @@ class ProcessDocument implements ShouldQueue
 
             // 2. Prepare file - Try both private and public paths
             $filePath = Storage::disk('local')->path($this->document->file_path);
-            
+
             // Laravel 11+ stores in private/ by default
-            if (!file_exists($filePath)) {
-                $filePath = Storage::disk('local')->path('private/' . $this->document->file_path);
+            if (! file_exists($filePath)) {
+                $filePath = Storage::disk('local')->path('private/'.$this->document->file_path);
             }
-            
-            if (!file_exists($filePath)) {
+
+            if (! file_exists($filePath)) {
                 throw new Exception("File not found. Tried: {$this->document->file_path} and private/{$this->document->file_path}");
             }
 
             // 3. Send to Python Microservice (with extended timeout for embedding)
             $pythonUrl = rtrim((string) config('services.ai_document_service.url', config('services.ai_service.url', 'http://127.0.0.1:8001')), '/')
-                . '/api/documents/process';
+                .'/api/documents/process';
             $token = config('services.ai_document_service.token', config('services.ai_service.token'));
 
             $response = Http::timeout(900) // 15 minutes timeout for large documents
@@ -77,31 +78,30 @@ class ProcessDocument implements ShouldQueue
                 // 4. Update status to ready
                 $this->document->update(['status' => 'ready']);
 
-                // 5. Dispatch preview rendering job (async, non-blocking).
-                // Isolated in its own try/catch so a queue/dispatch failure
-                // here cannot revert the document status back to 'error'.
+                // 5. Dispatch preview rendering job as a fallback if the
+                // eager upload-time dispatch has not already completed it.
                 try {
                     $freshDocument = $this->document->fresh();
-                    if ($freshDocument !== null) {
+                    if ($freshDocument !== null && $freshDocument->preview_status !== Document::PREVIEW_STATUS_READY) {
                         RenderDocumentPreview::dispatch($freshDocument);
                     }
                 } catch (\Throwable $e) {
-                    logger()->warning("Preview dispatch failed for document {$this->document->id}, proceeding: " . $e->getMessage());
+                    logger()->warning("Preview dispatch failed for document {$this->document->id}, proceeding: ".$e->getMessage());
                 }
             } else {
-                throw new Exception("Microservice error: " . $response->body());
+                throw new Exception('Microservice error: '.$response->body());
             }
 
         } catch (Exception $e) {
             $this->document->update(['status' => 'error']);
             // Log the error
-            logger()->error("Document processing failed for ID {$this->document->id}: " . $e->getMessage());
+            logger()->error("Document processing failed for ID {$this->document->id}: ".$e->getMessage());
         }
     }
 
     public function failed(\Throwable $exception): void
     {
         $this->document->update(['status' => 'error']);
-        logger()->error("Document processing permanently failed for ID {$this->document->id}: " . $exception->getMessage());
+        logger()->error("Document processing permanently failed for ID {$this->document->id}: ".$exception->getMessage());
     }
 }

--- a/laravel/app/Jobs/RenderDocumentPreview.php
+++ b/laravel/app/Jobs/RenderDocumentPreview.php
@@ -4,21 +4,32 @@ namespace App\Jobs;
 
 use App\Models\Document;
 use App\Services\Documents\DocumentPreviewRenderer;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 
-class RenderDocumentPreview implements ShouldQueue
+class RenderDocumentPreview implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public int $tries = 2;
 
-    public int $timeout = 180;
+    public int $timeout = 300;
 
-    public function __construct(public Document $document) {}
+    public int $uniqueFor = 3600;
+
+    public function __construct(public Document $document)
+    {
+        $this->onQueue('document-previews');
+    }
+
+    public function uniqueId(): string
+    {
+        return (string) $this->document->getKey();
+    }
 
     public function handle(DocumentPreviewRenderer $renderer): void
     {

--- a/laravel/app/Services/DocumentLifecycleService.php
+++ b/laravel/app/Services/DocumentLifecycleService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Jobs\ProcessDocument;
+use App\Jobs\RenderDocumentPreview;
 use App\Models\Document;
 use App\Services\Documents\DocumentPreviewRenderer;
 use Illuminate\Http\UploadedFile;
@@ -14,8 +15,9 @@ use InvalidArgumentException;
 class DocumentLifecycleService
 {
     public const MAX_DOCUMENTS_PER_USER = 10;
+
     public const SOFT_DELETE_RETENTION_DAYS = 7;
-    
+
     public const ALLOWED_ATTACHMENT_MIME_TYPES = [
         'application/pdf',
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -25,9 +27,6 @@ class DocumentLifecycleService
     /**
      * Upload and initiate document processing
      *
-     * @param UploadedFile $file
-     * @param int $userId
-     * @return Document
      * @throws ValidationException
      * @throws \Exception
      */
@@ -45,7 +44,7 @@ class DocumentLifecycleService
         $originalName = $file->getClientOriginalName();
         $detectedMimeType = (string) $file->getMimeType();
 
-        if (!in_array($detectedMimeType, self::ALLOWED_ATTACHMENT_MIME_TYPES, true)) {
+        if (! in_array($detectedMimeType, self::ALLOWED_ATTACHMENT_MIME_TYPES, true)) {
             throw ValidationException::withMessages([
                 'file' => 'Tipe MIME file tidak valid. Gunakan PDF, DOCX, atau XLSX.',
             ]);
@@ -63,11 +62,11 @@ class DocumentLifecycleService
         }
 
         // 4. Store file
-        $filename = time() . '_' . $file->hashName();
-        $filePath = $file->storeAs('documents/' . $userId, $filename);
+        $filename = time().'_'.$file->hashName();
+        $filePath = $file->storeAs('documents/'.$userId, $filename);
 
-        if (!$filePath) {
-            throw new \Exception("Gagal menyimpan file ke storage.");
+        if (! $filePath) {
+            throw new \Exception('Gagal menyimpan file ke storage.');
         }
 
         // 5. Create Database Record
@@ -81,7 +80,12 @@ class DocumentLifecycleService
             'status' => 'pending',
         ]);
 
-        // 6. Dispatch Processing Job
+        // 6. Dispatch preview and processing jobs on separate queues.
+        try {
+            $this->dispatchPreviewRendering($document);
+        } catch (\Throwable $e) {
+            logger()->warning("Preview dispatch failed for document {$document->id}, proceeding: ".$e->getMessage());
+        }
         $this->dispatchProcessing($document);
 
         return $document;
@@ -89,9 +93,6 @@ class DocumentLifecycleService
 
     /**
      * Dispatch the job to process a document
-     *
-     * @param Document $document
-     * @return void
      */
     public function dispatchProcessing(Document $document): void
     {
@@ -99,10 +100,16 @@ class DocumentLifecycleService
     }
 
     /**
+     * Dispatch the job to render a document preview.
+     */
+    public function dispatchPreviewRendering(Document $document): void
+    {
+        RenderDocumentPreview::dispatch($document);
+    }
+
+    /**
      * Delete document and perform cleanup (Vector DB, Storage, Database)
      *
-     * @param Document $document
-     * @return bool
      * @throws \Exception
      */
     public function deleteDocument(Document $document): bool
@@ -112,12 +119,11 @@ class DocumentLifecycleService
         // 3. Delete database record (Soft Delete)
         return $document->delete();
     }
-    
+
     /**
      * Delete multiple documents
-     * 
-     * @param iterable<Document> $documents
-     * @return void
+     *
+     * @param  iterable<Document>  $documents
      */
     public function deleteDocuments(iterable $documents): void
     {
@@ -149,9 +155,6 @@ class DocumentLifecycleService
     /**
      * Summarize a document, with readiness guard
      *
-     * @param Document $document
-     * @param AIService $aiService
-     * @return array
      * @throws InvalidArgumentException
      * @throws \Exception
      */
@@ -176,14 +179,14 @@ class DocumentLifecycleService
         try {
             app(DocumentPreviewRenderer::class)->deletePreview($document);
         } catch (\Throwable $e) {
-            logger()->warning("Preview cleanup failed for document {$document->id}, proceeding anyway: " . $e->getMessage());
+            logger()->warning("Preview cleanup failed for document {$document->id}, proceeding anyway: ".$e->getMessage());
         }
     }
 
     private function deleteDocumentVectors(Document $document): void
     {
         $pythonUrl = rtrim((string) config('services.ai_document_service.url', config('services.ai_service.url', 'http://127.0.0.1:8001')), '/')
-            . '/api/documents/' . urlencode($document->original_name);
+            .'/api/documents/'.urlencode($document->original_name);
         $token = config('services.ai_document_service.token', config('services.ai_service.token'));
 
         try {
@@ -191,11 +194,11 @@ class DocumentLifecycleService
                 'Authorization' => "Bearer {$token}",
             ])->delete($pythonUrl);
 
-            if (!$response->successful() && $response->status() !== 404) {
-                logger()->warning("Vector deletion failed for {$document->original_name}, proceeding anyway: " . $response->body());
+            if (! $response->successful() && $response->status() !== 404) {
+                logger()->warning("Vector deletion failed for {$document->original_name}, proceeding anyway: ".$response->body());
             }
         } catch (\Exception $e) {
-            logger()->warning("Vector deletion HTTP request failed for {$document->original_name}, proceeding anyway: " . $e->getMessage());
+            logger()->warning("Vector deletion HTTP request failed for {$document->original_name}, proceeding anyway: ".$e->getMessage());
         }
     }
 

--- a/laravel/config/horizon.php
+++ b/laravel/config/horizon.php
@@ -99,6 +99,7 @@ return [
     'waits' => [
         'redis:mail' => 60,
         'redis:default' => 60,
+        'redis:document-previews' => 60,
     ],
 
     /*
@@ -221,12 +222,36 @@ return [
                 'balanceMaxShift' => 1,
                 'balanceCooldown' => 3,
             ],
+            'supervisor-document-previews' => [
+                'connection' => 'redis',
+                'queue' => ['document-previews'],
+                'balance' => 'simple',
+                'maxProcesses' => 1,
+                'maxTime' => 0,
+                'maxJobs' => 0,
+                'memory' => 256,
+                'tries' => 2,
+                'timeout' => 300,
+                'nice' => 0,
+            ],
         ],
 
         'local' => [
             'supervisor-1' => [
                 'queue' => ['mail', 'default'],
                 'maxProcesses' => 3,
+            ],
+            'supervisor-document-previews' => [
+                'connection' => 'redis',
+                'queue' => ['document-previews'],
+                'balance' => 'simple',
+                'maxProcesses' => 1,
+                'maxTime' => 0,
+                'maxJobs' => 0,
+                'memory' => 256,
+                'tries' => 2,
+                'timeout' => 300,
+                'nice' => 0,
             ],
         ],
     ],

--- a/laravel/resources/views/livewire/documents/document-viewer.blade.php
+++ b/laravel/resources/views/livewire/documents/document-viewer.blade.php
@@ -38,8 +38,7 @@
                     @elseif ($kind === 'pdf')
                         <iframe src="{{ $streamUrl }}"
                                 class="w-full h-[70vh] bg-white"
-                                title="Preview {{ $document->original_name }}"
-                                sandbox="allow-same-origin allow-scripts"></iframe>
+                                title="Preview {{ $document->original_name }}"></iframe>
                     @elseif (in_array($kind, ['docx', 'xlsx'], true))
                         @if ($previewStatus === \App\Models\Document::PREVIEW_STATUS_READY)
                             <div wire:poll.30s.keep-alive

--- a/laravel/tests/Feature/Chat/DocumentUploadTest.php
+++ b/laravel/tests/Feature/Chat/DocumentUploadTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Chat;
 
 use App\Jobs\ProcessDocument;
+use App\Jobs\RenderDocumentPreview;
 use App\Livewire\Chat\ChatIndex;
 use App\Models\Document;
 use App\Models\User;
@@ -37,6 +38,9 @@ class DocumentUploadTest extends TestCase
         $this->assertNotNull($document->file_size_bytes);
         $this->assertSame('pending', $document->status);
 
+        Queue::assertPushed(RenderDocumentPreview::class, function ($job) {
+            return $job->queue === 'document-previews';
+        });
         Queue::assertPushed(ProcessDocument::class, 1);
     }
 
@@ -132,9 +136,9 @@ class DocumentUploadTest extends TestCase
     {
         return Document::create(array_merge([
             'user_id' => $user->id,
-            'filename' => uniqid('doc_', true) . '.pdf',
-            'original_name' => uniqid('file_', true) . '.pdf',
-            'file_path' => 'documents/' . $user->id . '/' . uniqid('path_', true) . '.pdf',
+            'filename' => uniqid('doc_', true).'.pdf',
+            'original_name' => uniqid('file_', true).'.pdf',
+            'file_path' => 'documents/'.$user->id.'/'.uniqid('path_', true).'.pdf',
             'mime_type' => 'application/pdf',
             'file_size_bytes' => 120 * 1024,
             'status' => 'ready',

--- a/laravel/tests/Feature/Documents/DocumentIndexTest.php
+++ b/laravel/tests/Feature/Documents/DocumentIndexTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Documents;
 
 use App\Jobs\ProcessDocument;
+use App\Jobs\RenderDocumentPreview;
 use App\Livewire\Documents\DocumentIndex;
 use App\Models\Document;
 use App\Models\User;
@@ -45,6 +46,9 @@ class DocumentIndexTest extends TestCase
         $this->assertSame('dokumen.pdf', $document->original_name);
         $this->assertSame('pending', $document->status);
 
+        Queue::assertPushed(RenderDocumentPreview::class, function ($job) {
+            return $job->queue === 'document-previews';
+        });
         Queue::assertPushed(ProcessDocument::class, 1);
     }
 

--- a/laravel/tests/Feature/Documents/DocumentViewerLivewireTest.php
+++ b/laravel/tests/Feature/Documents/DocumentViewerLivewireTest.php
@@ -45,6 +45,27 @@ class DocumentViewerLivewireTest extends TestCase
             ->assertSee($document->original_name);
     }
 
+    public function test_pdf_preview_is_rendered_without_sandbox(): void
+    {
+        $user = User::factory()->create();
+        $document = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'sample.pdf',
+            'original_name' => 'sample.pdf',
+            'file_path' => 'documents/'.$user->id.'/sample.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 100,
+            'status' => 'ready',
+            'preview_status' => Document::PREVIEW_STATUS_READY,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(DocumentViewer::class)
+            ->dispatch('open-document-preview', documentId: $document->id)
+            ->assertSeeHtml('<iframe')
+            ->assertDontSeeHtml('sandbox=');
+    }
+
     public function test_viewer_does_not_render_other_users_document(): void
     {
         $owner = User::factory()->create();

--- a/laravel/tests/Unit/Services/DocumentLifecycleServiceTest.php
+++ b/laravel/tests/Unit/Services/DocumentLifecycleServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Jobs\ProcessDocument;
+use App\Models\User;
+use App\Services\DocumentLifecycleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+class DocumentLifecycleServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_upload_document_continues_when_preview_dispatch_fails(): void
+    {
+        Storage::fake('local');
+        Queue::fake();
+
+        $user = User::factory()->create();
+
+        $service = $this->partialMock(DocumentLifecycleService::class, function (MockInterface $mock) {
+            $mock->shouldReceive('dispatchPreviewRendering')
+                ->once()
+                ->andThrow(new \RuntimeException('queue down'));
+        });
+
+        $document = $service->uploadDocument(
+            UploadedFile::fake()->create('referensi.pdf', 120, 'application/pdf'),
+            $user->id,
+        );
+
+        $this->assertDatabaseCount('documents', 1);
+        $this->assertSame('referensi.pdf', $document->original_name);
+        $this->assertSame('pending', $document->status);
+
+        Queue::assertPushed(ProcessDocument::class, 1);
+    }
+}


### PR DESCRIPTION
<!-- opencode-standardized: github-writing-standard-v1 -->
## Ringkasan
- Unblock Chrome PDF preview by removing the sandboxed iframe, dispatch document preview earlier on a dedicated queue, and keep upload processing best-effort. Adds Horizon support and regression tests for the preview flow.

## Perubahan Utama
| File / Area | Deskripsi |
|---|---|
| Area umum | File spesifik tidak dicatat eksplisit pada body lama. |

### Detail Perubahan
- Unblock Chrome PDF preview by removing the sandboxed iframe, dispatch document preview earlier on a dedicated queue, and keep upload processing best-effort. Adds Horizon support and regression tests for the preview flow.

## Validasi
- Body historis tidak mencatat command validasi spesifik.

## Deploy / QA
- Status PR: Merged
- Base branch: `main`
- Head branch: `codex/fix-document-preview-blocking`
- Merged at: 2026-04-30T07:37:47Z
- Closed at: 2026-04-30T07:37:47Z
- Deploy/QA tidak dicatat eksplisit pada body lama.

## Catatan / Risiko Residual
- Risiko residual tidak dicatat eksplisit pada body lama.

## Relasi Issue
- Relasi issue tidak ditemukan eksplisit pada body lama.

## Catatan Historis
<details>
<summary>Body sebelum standardisasi</summary>

Unblock Chrome PDF preview by removing the sandboxed iframe, dispatch document preview earlier on a dedicated queue, and keep upload processing best-effort. Adds Horizon support and regression tests for the preview flow.

</details>
