### PR TITLE
Integrasi unified memo workspace di halaman Chat

### DIFF
--- a/laravel/app/Livewire/Chat/ChatIndex.php
+++ b/laravel/app/Livewire/Chat/ChatIndex.php
@@ -31,6 +31,9 @@ class ChatIndex extends Component
     #[Url]
     public $q = '';
 
+    #[Url]
+    public string $tab = 'chat';
+
     public $prompt = '';
 
     public $currentConversationId;

--- a/laravel/app/Livewire/Memos/MemoWorkspace.php
+++ b/laravel/app/Livewire/Memos/MemoWorkspace.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace App\Livewire\Memos;
+
+use App\Models\Memo;
+use App\Services\Memo\MemoGenerationService;
+use App\Services\OnlyOffice\JwtSigner;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\URL;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+class MemoWorkspace extends Component
+{
+    public ?int $activeMemoId = null;
+
+    public string $memoType = 'memo_internal';
+
+    public string $title = '';
+
+    public string $memoPrompt = '';
+
+    public array $memoChatMessages = [];
+
+    public bool $isGenerating = false;
+
+    public string $previewMode = 'preview'; // 'preview' or 'editor'
+
+    public ?string $previewHtml = null;
+
+    public function mount(): void
+    {
+        $this->addSystemMessage('Halo! Saya siap membantu Anda membuat memo. Silakan isi jenis dan judul memo di atas, lalu ketik instruksi untuk konten memo yang ingin digenerate.');
+    }
+
+    public function loadMemo(int $memoId): void
+    {
+        $memo = Memo::where('id', $memoId)
+            ->where('user_id', Auth::id())
+            ->first();
+
+        if (! $memo) {
+            return;
+        }
+
+        $this->activeMemoId = $memo->id;
+        $this->memoType = $memo->memo_type;
+        $this->title = $memo->title;
+        $this->previewHtml = $memo->searchable_text ? nl2br(e($memo->searchable_text)) : null;
+        $this->previewMode = 'preview';
+
+        $this->memoChatMessages = [];
+        $this->addSystemMessage("Memo \"{$memo->title}\" dimuat. Anda bisa meminta revisi atau generate ulang.");
+    }
+
+    public function startNewMemo(): void
+    {
+        $this->reset(['activeMemoId', 'memoType', 'title', 'memoPrompt', 'memoChatMessages', 'previewHtml', 'isGenerating']);
+        $this->memoType = 'memo_internal';
+        $this->previewMode = 'preview';
+        $this->addSystemMessage('Halo! Saya siap membantu Anda membuat memo baru. Silakan isi jenis dan judul memo, lalu ketik instruksi.');
+    }
+
+    public function sendMemoChat(): void
+    {
+        $this->validate([
+            'memoPrompt' => 'required|string|min:1',
+        ]);
+
+        $userMessage = trim($this->memoPrompt);
+        $this->memoPrompt = '';
+
+        $this->memoChatMessages[] = [
+            'role' => 'user',
+            'content' => $userMessage,
+            'timestamp' => now()->format('H:i'),
+        ];
+
+        // If we have enough context, auto-generate
+        if ($this->title && $this->memoType) {
+            $this->generateFromChat($userMessage);
+        } else {
+            $this->addSystemMessage('Silakan lengkapi jenis memo dan judul terlebih dahulu, lalu saya bisa generate draft untuk Anda.');
+        }
+    }
+
+    public function generateFromChat(string $context): void
+    {
+        $this->validate([
+            'memoType' => ['required', 'in:' . implode(',', array_keys(Memo::TYPES))],
+            'title' => ['required', 'string', 'max:160'],
+        ]);
+
+        $this->isGenerating = true;
+
+        try {
+            $generationService = app(MemoGenerationService::class);
+
+            $memo = $generationService->generate(
+                Auth::user(),
+                $this->memoType,
+                $this->title,
+                $context,
+            );
+
+            $this->activeMemoId = $memo->id;
+            $this->previewHtml = $memo->searchable_text ? nl2br(e($memo->searchable_text)) : '<p class="text-stone-500">Draft berhasil digenerate. Gunakan tab Editor untuk melihat dokumen lengkap.</p>';
+            $this->previewMode = 'preview';
+
+            $this->addSystemMessage("Draft memo \"{$memo->title}\" berhasil digenerate! Anda bisa melihat preview di panel kanan, atau beralih ke Editor untuk mengedit dokumen DOCX secara langsung.\n\nMau saya revisi bagian tertentu?");
+        } catch (\Throwable $e) {
+            $this->addSystemMessage('Maaf, terjadi kesalahan saat generate memo: ' . $e->getMessage());
+        } finally {
+            $this->isGenerating = false;
+        }
+    }
+
+    public function regenerate(): void
+    {
+        if (! $this->activeMemoId) {
+            $this->addSystemMessage('Belum ada memo aktif untuk di-regenerate. Silakan buat memo baru.');
+
+            return;
+        }
+
+        $lastUserMessage = collect($this->memoChatMessages)
+            ->where('role', 'user')
+            ->last();
+
+        $context = $lastUserMessage['content'] ?? $this->title;
+        $this->generateFromChat($context);
+    }
+
+    public function switchPreviewMode(string $mode): void
+    {
+        $this->previewMode = in_array($mode, ['preview', 'editor']) ? $mode : 'preview';
+    }
+
+    public function editorConfig(): ?array
+    {
+        if (! $this->activeMemoId) {
+            return null;
+        }
+
+        $memo = Memo::find($this->activeMemoId);
+
+        if (! $memo || ! $memo->file_path) {
+            return null;
+        }
+
+        $signer = app(JwtSigner::class);
+        $laravelInternalUrl = rtrim((string) config('services.onlyoffice.laravel_internal_url', config('app.url')), '/');
+        $ttlMinutes = max(1, (int) config('services.onlyoffice.signed_url_ttl_minutes', 30));
+        $documentPath = URL::temporarySignedRoute('memos.file.signed', now()->addMinutes($ttlMinutes), $memo, false);
+        $callbackPath = route('onlyoffice.callback', $memo, false);
+
+        $config = [
+            'document' => [
+                'fileType' => 'docx',
+                'key' => 'memo-' . $memo->id . '-' . $memo->updated_at?->timestamp,
+                'title' => $memo->title . '.docx',
+                'url' => $laravelInternalUrl . $documentPath,
+            ],
+            'documentType' => 'word',
+            'editorConfig' => [
+                'callbackUrl' => $laravelInternalUrl . $callbackPath,
+                'mode' => 'edit',
+                'lang' => 'id',
+                'user' => [
+                    'id' => (string) Auth::id(),
+                    'name' => (string) Auth::user()?->name,
+                ],
+            ],
+        ];
+
+        $config['token'] = $signer->sign($config);
+
+        return $config;
+    }
+
+    public function render()
+    {
+        $memos = Memo::where('user_id', Auth::id())
+            ->orderBy('updated_at', 'desc')
+            ->get();
+
+        return view('livewire.memos.memo-workspace', [
+            'memos' => $memos,
+            'memoTypes' => Memo::TYPES,
+            'editorConfig' => $this->editorConfig(),
+            'onlyOfficeApiUrl' => rtrim((string) config('services.onlyoffice.public_url', ''), '/') . '/web-apps/apps/api/documents/api.js',
+        ]);
+    }
+
+    protected function addSystemMessage(string $content): void
+    {
+        $this->memoChatMessages[] = [
+            'role' => 'assistant',
+            'content' => $content,
+            'timestamp' => now()->format('H:i'),
+        ];
+    }
+}

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -832,6 +832,41 @@ const registerChatPageData = (Alpine) => {
         },
     }));
 
+    Alpine.data('memoWorkspace', () => ({
+        showMemoSidebar: !window.matchMedia('(max-width: 1023px)').matches,
+        isMobile: window.matchMedia('(max-width: 1023px)').matches,
+
+        init() {
+            const mediaQuery = window.matchMedia('(max-width: 1023px)');
+            const syncState = (event) => {
+                this.isMobile = event.matches;
+                this.showMemoSidebar = !event.matches;
+            };
+
+            mediaQuery.addEventListener('change', syncState);
+
+            // Auto-scroll memo chat on new messages
+            this.$watch('$wire.memoChatMessages', () => {
+                this.$nextTick(() => this.scrollMemoChatToBottom());
+            });
+        },
+
+        scrollMemoChatToBottom() {
+            const chatBox = document.getElementById('memo-chat-box');
+
+            if (!chatBox) {
+                return;
+            }
+
+            this.$nextTick(() => {
+                chatBox.scrollTo({
+                    top: chatBox.scrollHeight,
+                    behavior: 'smooth',
+                });
+            });
+        },
+    }));
+
     Alpine.data('documentViewerExport', (config = {}) => ({
         contentUrl: config.contentUrl || '',
         extractUrl: config.extractUrl || '',

--- a/laravel/resources/views/livewire/chat/chat-index.blade.php
+++ b/laravel/resources/views/livewire/chat/chat-index.blade.php
@@ -26,66 +26,83 @@
         ];
     @endphp
 
-    <!-- LEFT SIDEBAR: Chat History -->
-    @include('livewire.chat.partials.chat-left-sidebar')
+    {{-- ===== CHAT TAB CONTENT ===== --}}
+    <template x-if="$wire.tab === 'chat'">
+        <div class="flex w-full h-full overflow-hidden">
+            <!-- LEFT SIDEBAR: Chat History -->
+            @include('livewire.chat.partials.chat-left-sidebar')
 
-    <!-- CENTER MAIN: Chat Area -->
-    <main class="flex-1 flex flex-col relative w-full h-full bg-transparent z-0 overflow-hidden min-w-0">
+            <!-- CENTER MAIN: Chat Area -->
+            <main class="flex-1 flex flex-col relative w-full h-full bg-transparent z-0 overflow-hidden min-w-0">
 
-            <!-- Header for Chat Space -->
-            <div class="h-[61px] flex-shrink-0 flex items-center justify-between px-3 sm:px-6 z-20 border-b border-stone-200/60/70 dark:border-[#1E293B]/70 backdrop-blur-sm">
-                <!-- Left toggler and title -->
-                <div class="flex items-center gap-2 sm:gap-4">
-                    <button type="button" @click="showLeftSidebar = !showLeftSidebar" class="p-2 rounded-[10px] hover:bg-[#F1F5F9] dark:hover:bg-gray-800 transition-colors flex-shrink-0">
-                        <img src="{{ $uiIcons['collapseLeftLight'] }}" alt="" class="h-5 w-5 dark:hidden transition-transform duration-300 ease-in-out" :class="showLeftSidebar ? 'rotate-0' : 'rotate-180'" />
-                        <img src="{{ $uiIcons['collapseLeftDark'] }}" alt="" class="h-5 w-5 hidden dark:block transition-transform duration-300 ease-in-out" :class="showLeftSidebar ? 'rotate-0' : 'rotate-180'" />
-                    </button>
-                    <button type="button"
-                            @click="$dispatch('chat-new-optimistic'); $dispatch('conversation-loading'); $wire.startNewChat().finally(() => $dispatch('conversation-loaded'))"
-                            class="group flex items-center gap-2"><div class="ista-brand-title text-xl text-ista-primary not-italic transition-transform duration-300 group-hover:scale-105">ISTA <span class="font-light italic text-ista-gold">AI</span></div></button>
-                </div>
+                    <!-- Header for Chat Space -->
+                    <div class="h-[61px] flex-shrink-0 flex items-center justify-between px-3 sm:px-6 z-20 border-b border-stone-200/60/70 dark:border-[#1E293B]/70 backdrop-blur-sm">
+                        <!-- Left toggler and title -->
+                        <div class="flex items-center gap-2 sm:gap-4">
+                            <button type="button" @click="showLeftSidebar = !showLeftSidebar" class="p-2 rounded-[10px] hover:bg-[#F1F5F9] dark:hover:bg-gray-800 transition-colors flex-shrink-0">
+                                <img src="{{ $uiIcons['collapseLeftLight'] }}" alt="" class="h-5 w-5 dark:hidden transition-transform duration-300 ease-in-out" :class="showLeftSidebar ? 'rotate-0' : 'rotate-180'" />
+                                <img src="{{ $uiIcons['collapseLeftDark'] }}" alt="" class="h-5 w-5 hidden dark:block transition-transform duration-300 ease-in-out" :class="showLeftSidebar ? 'rotate-0' : 'rotate-180'" />
+                            </button>
+                            <button type="button"
+                                    @click="$dispatch('chat-new-optimistic'); $dispatch('conversation-loading'); $wire.startNewChat().finally(() => $dispatch('conversation-loaded'))"
+                                    class="group flex items-center gap-2"><div class="ista-brand-title text-xl text-ista-primary not-italic transition-transform duration-300 group-hover:scale-105">ISTA <span class="font-light italic text-ista-gold">AI</span></div></button>
+                        </div>
 
-                <!-- Right toggles -->
-                <div class="flex items-center gap-1 sm:gap-3">
-                    <!-- Theme Toggle Button -->
-                    <button type="button" @click="darkMode = !darkMode" class="p-2 rounded-[10px] hover:bg-[#F1F5F9] dark:hover:bg-gray-800 transition-colors">
-                        <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-[#64748B]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />
-                        </svg>
-                        <svg x-show="darkMode === true" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z" />
-                        </svg>
-                    </button>
+                        <!-- Center: Tab Toggle -->
+                        <div class="flex items-center">
+                            @include('livewire.chat.partials.chat-memo-tab-toggle')
+                        </div>
 
-                    <button type="button" @click="showRightSidebar = !showRightSidebar" class="p-2 rounded-[10px] hover:bg-[#F1F5F9] dark:hover:bg-gray-800 transition-colors flex-shrink-0">
-                        <img src="{{ $uiIcons['collapseRightLight'] }}" alt="" class="h-5 w-5 dark:hidden transition-transform duration-300 ease-in-out" :class="showRightSidebar ? 'rotate-0' : 'rotate-180'" />
-                        <img src="{{ $uiIcons['collapseRightDark'] }}" alt="" class="h-5 w-5 hidden dark:block transition-transform duration-300 ease-in-out" :class="showRightSidebar ? 'rotate-0' : 'rotate-180'" />
-                    </button>
-                </div>
-            </div>
+                        <!-- Right toggles -->
+                        <div class="flex items-center gap-1 sm:gap-3">
+                            <!-- Theme Toggle Button -->
+                            <button type="button" @click="darkMode = !darkMode" class="p-2 rounded-[10px] hover:bg-[#F1F5F9] dark:hover:bg-gray-800 transition-colors">
+                                <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-[#64748B]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />
+                                </svg>
+                                <svg x-show="darkMode === true" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z" />
+                                </svg>
+                            </button>
 
-            <div x-show="isSwitchingConversation"
-                 x-transition.opacity
-                 class="pointer-events-none absolute left-0 right-0 top-[77px] z-30 px-3 sm:px-6"
-                 style="display: none;">
-                <div class="mx-auto flex max-w-3xl items-center gap-2 rounded-xl border border-stone-200/60 bg-white/95 px-4 py-3 text-[13px] text-[#64748B] shadow-sm backdrop-blur-sm dark:border-gray-800 dark:bg-gray-800/95 dark:text-[#94A3B8]">
-                    <span class="h-3.5 w-3.5 rounded-full border-2 border-current border-t-transparent animate-spin"></span>
-                    <span>Membuka chat...</span>
-                </div>
-            </div>
+                            <button type="button" @click="showRightSidebar = !showRightSidebar" class="p-2 rounded-[10px] hover:bg-[#F1F5F9] dark:hover:bg-gray-800 transition-colors flex-shrink-0">
+                                <img src="{{ $uiIcons['collapseRightLight'] }}" alt="" class="h-5 w-5 dark:hidden transition-transform duration-300 ease-in-out" :class="showRightSidebar ? 'rotate-0' : 'rotate-180'" />
+                                <img src="{{ $uiIcons['collapseRightDark'] }}" alt="" class="h-5 w-5 hidden dark:block transition-transform duration-300 ease-in-out" :class="showRightSidebar ? 'rotate-0' : 'rotate-180'" />
+                            </button>
+                        </div>
+                    </div>
 
-            <!-- Messages List -->
-            @include('livewire.chat.partials.chat-messages')
+                    <div x-show="isSwitchingConversation"
+                         x-transition.opacity
+                         class="pointer-events-none absolute left-0 right-0 top-[77px] z-30 px-3 sm:px-6"
+                         style="display: none;">
+                        <div class="mx-auto flex max-w-3xl items-center gap-2 rounded-xl border border-stone-200/60 bg-white/95 px-4 py-3 text-[13px] text-[#64748B] shadow-sm backdrop-blur-sm dark:border-gray-800 dark:bg-gray-800/95 dark:text-[#94A3B8]">
+                            <span class="h-3.5 w-3.5 rounded-full border-2 border-current border-t-transparent animate-spin"></span>
+                            <span>Membuka chat...</span>
+                        </div>
+                    </div>
 
-            <!-- Input Area (Composer) -->
-            @include('livewire.chat.partials.chat-composer', ['prompt' => $prompt])
+                    <!-- Messages List -->
+                    @include('livewire.chat.partials.chat-messages')
 
-    </main>
+                    <!-- Input Area (Composer) -->
+                    @include('livewire.chat.partials.chat-composer', ['prompt' => $prompt])
 
-    <!-- RIGHT SIDEBAR: Documents -->
-    @include('livewire.chat.partials.chat-right-sidebar')
+            </main>
 
-    <livewire:chat.google-drive-picker />
+            <!-- RIGHT SIDEBAR: Documents -->
+            @include('livewire.chat.partials.chat-right-sidebar')
+
+            <livewire:chat.google-drive-picker />
+        </div>
+    </template>
+
+    {{-- ===== MEMO TAB CONTENT ===== --}}
+    <template x-if="$wire.tab === 'memo'">
+        <div class="flex w-full h-full overflow-hidden">
+            <livewire:memos.memo-workspace />
+        </div>
+    </template>
 
     <!-- Drag & Drop Overlay Visual -->
     <div x-show="isDraggingFile" x-transition.opacity class="fixed inset-0 z-[60] bg-ista-primary/10 backdrop-blur-[2px] flex items-center justify-center pointer-events-none">

--- a/laravel/resources/views/livewire/chat/partials/chat-memo-tab-toggle.blade.php
+++ b/laravel/resources/views/livewire/chat/partials/chat-memo-tab-toggle.blade.php
@@ -1,0 +1,29 @@
+{{-- Tab Toggle: Chat / Memo --}}
+<div class="inline-flex items-center rounded-full border border-stone-200/80 bg-white/80 p-1 shadow-sm backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800/80">
+    <button
+        type="button"
+        wire:click="$set('tab', 'chat')"
+        :class="$wire.tab === 'chat'
+            ? 'bg-white text-stone-900 shadow-sm dark:bg-gray-700 dark:text-gray-100'
+            : 'text-stone-500 hover:text-stone-700 dark:text-gray-400 dark:hover:text-gray-200'"
+        class="inline-flex items-center gap-1.5 rounded-full px-4 py-1.5 text-[13px] font-semibold transition-all duration-200"
+    >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+        </svg>
+        Chat
+    </button>
+    <button
+        type="button"
+        wire:click="$set('tab', 'memo')"
+        :class="$wire.tab === 'memo'
+            ? 'bg-ista-primary text-white shadow-sm'
+            : 'text-stone-500 hover:text-stone-700 dark:text-gray-400 dark:hover:text-gray-200'"
+        class="inline-flex items-center gap-1.5 rounded-full px-4 py-1.5 text-[13px] font-semibold transition-all duration-200"
+    >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+        Memo
+    </button>
+</div>

--- a/laravel/resources/views/livewire/memos/memo-workspace.blade.php
+++ b/laravel/resources/views/livewire/memos/memo-workspace.blade.php
@@ -1,0 +1,12 @@
+<div x-data="memoWorkspace" class="flex w-full h-full overflow-hidden">
+
+    {{-- LEFT SIDEBAR: Memo History --}}
+    @include('livewire.memos.partials.memo-history-sidebar')
+
+    {{-- CENTER: AI Chat Panel --}}
+    @include('livewire.memos.partials.memo-chat')
+
+    {{-- RIGHT: Preview / Editor Panel --}}
+    @include('livewire.memos.partials.memo-preview-panel')
+
+</div>

--- a/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
+++ b/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
@@ -1,0 +1,112 @@
+{{-- Memo AI Chat Panel (Center Column ~380px) --}}
+<div class="flex flex-col w-full lg:w-[380px] flex-shrink-0 border-r border-stone-200/60 dark:border-[#1E293B] bg-white/50 dark:bg-gray-900/50 overflow-hidden">
+
+    {{-- Header: Tab toggle + sidebar toggle --}}
+    <div class="h-[61px] flex-shrink-0 flex items-center justify-between px-4 border-b border-stone-200/60 dark:border-[#1E293B]/70">
+        <div class="flex items-center gap-2">
+            <button type="button" @click="showMemoSidebar = !showMemoSidebar" class="p-2 rounded-[10px] hover:bg-[#F1F5F9] dark:hover:bg-gray-800 transition-colors">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-stone-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 6h16M4 12h16M4 18h7" />
+                </svg>
+            </button>
+            <span class="text-[14px] font-semibold text-stone-700 dark:text-gray-200">Memo Assistant</span>
+        </div>
+        <div class="flex items-center">
+            @include('livewire.chat.partials.chat-memo-tab-toggle')
+        </div>
+    </div>
+
+    {{-- Context Form (Jenis + Judul) --}}
+    <div class="px-4 py-3 border-b border-stone-100 dark:border-gray-800/60 bg-stone-50/50 dark:bg-gray-900/30">
+        <div class="flex gap-2">
+            <div class="flex-shrink-0 w-[130px]">
+                <label class="text-[10.5px] font-bold text-stone-500 dark:text-gray-400 uppercase tracking-wider">Jenis</label>
+                <select wire:model="memoType" class="mt-1 w-full rounded-lg border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-[12px] py-1.5 focus:border-ista-primary focus:ring-ista-primary/20">
+                    @foreach ($memoTypes as $value => $label)
+                        <option value="{{ $value }}">{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="flex-1 min-w-0">
+                <label class="text-[10.5px] font-bold text-stone-500 dark:text-gray-400 uppercase tracking-wider">Judul</label>
+                <input type="text" wire:model="title" placeholder="Contoh: Rapat Koordinasi Mingguan"
+                       class="mt-1 w-full rounded-lg border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-[12px] py-1.5 focus:border-ista-primary focus:ring-ista-primary/20">
+            </div>
+        </div>
+    </div>
+
+    {{-- Chat Messages Area --}}
+    <div class="flex-1 overflow-y-auto px-4 py-4 space-y-4" x-ref="memoChatBox" id="memo-chat-box">
+        @foreach ($memoChatMessages as $index => $msg)
+            <div wire:key="memo-msg-{{ $index }}" class="flex gap-2.5 {{ $msg['role'] === 'user' ? 'justify-end' : 'justify-start' }}">
+                @if ($msg['role'] === 'assistant')
+                    <div class="flex-shrink-0 mt-1">
+                        <div class="h-7 w-7 rounded-full bg-ista-primary/10 flex items-center justify-center">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5 text-ista-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                            </svg>
+                        </div>
+                    </div>
+                @endif
+
+                <div class="max-w-[85%] {{ $msg['role'] === 'user'
+                    ? 'bg-ista-primary text-white rounded-2xl rounded-br-md px-4 py-2.5'
+                    : 'bg-stone-100 dark:bg-gray-800 text-stone-800 dark:text-gray-200 rounded-2xl rounded-bl-md px-4 py-2.5' }}">
+                    <p class="text-[13px] leading-relaxed whitespace-pre-wrap">{{ $msg['content'] }}</p>
+                    <span class="text-[10px] mt-1 block {{ $msg['role'] === 'user' ? 'text-white/60' : 'text-stone-400 dark:text-gray-500' }}">{{ $msg['timestamp'] }}</span>
+                </div>
+
+                @if ($msg['role'] === 'user')
+                    <div class="flex-shrink-0 mt-1">
+                        <div class="h-7 w-7 rounded-full bg-stone-200 dark:bg-gray-700 flex items-center justify-center">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5 text-stone-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                            </svg>
+                        </div>
+                    </div>
+                @endif
+            </div>
+        @endforeach
+
+        {{-- Generating indicator --}}
+        @if ($isGenerating)
+            <div class="flex gap-2.5 justify-start">
+                <div class="flex-shrink-0 mt-1">
+                    <div class="h-7 w-7 rounded-full bg-ista-primary/10 flex items-center justify-center">
+                        <span class="h-3 w-3 rounded-full border-2 border-ista-primary border-t-transparent animate-spin"></span>
+                    </div>
+                </div>
+                <div class="bg-stone-100 dark:bg-gray-800 rounded-2xl rounded-bl-md px-4 py-2.5">
+                    <p class="text-[13px] text-stone-500 dark:text-gray-400">Sedang membuat draft memo...</p>
+                </div>
+            </div>
+        @endif
+    </div>
+
+    {{-- Chat Input --}}
+    <div class="flex-shrink-0 border-t border-stone-200/60 dark:border-[#1E293B] bg-white dark:bg-gray-900 px-4 py-3">
+        <form wire:submit="sendMemoChat" class="flex items-end gap-2">
+            <div class="flex-1 relative">
+                <textarea
+                    wire:model="memoPrompt"
+                    x-ref="memoInput"
+                    @keydown.enter.prevent="if(!$event.shiftKey) { $wire.sendMemoChat(); }"
+                    placeholder="Ketik instruksi memo..."
+                    rows="1"
+                    class="w-full resize-none rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-800 text-[13px] px-4 py-2.5 pr-3 focus:border-ista-primary focus:ring-1 focus:ring-ista-primary/20 transition-all placeholder:text-stone-400 dark:placeholder:text-gray-500"
+                    style="max-height: 120px; overflow-y: auto;"
+                    x-on:input="$el.style.height = 'auto'; $el.style.height = Math.min($el.scrollHeight, 120) + 'px'"
+                ></textarea>
+            </div>
+            <button type="submit"
+                    wire:loading.attr="disabled"
+                    wire:target="sendMemoChat,generateFromChat"
+                    :disabled="$wire.isGenerating"
+                    class="flex-shrink-0 h-10 w-10 rounded-xl bg-ista-primary text-white flex items-center justify-center hover:bg-ista-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19V5m0 0l-7 7m7-7l7 7" />
+                </svg>
+            </button>
+        </form>
+    </div>
+</div>

--- a/laravel/resources/views/livewire/memos/partials/memo-history-sidebar.blade.php
+++ b/laravel/resources/views/livewire/memos/partials/memo-history-sidebar.blade.php
@@ -1,0 +1,60 @@
+{{-- Memo History Sidebar (Left Column ~220px) --}}
+<aside
+    x-show="showMemoSidebar"
+    :class="[
+        isMobile ? 'fixed left-0 top-0 h-full w-[240px] shadow-2xl z-50' : 'relative w-[240px]'
+    ]"
+    class="flex-shrink-0 flex flex-col border-r border-stone-200/60 dark:border-[#1E293B] bg-white dark:bg-gray-900 overflow-hidden transition-all duration-300"
+>
+    {{-- Header --}}
+    <div class="flex items-center justify-between px-4 pt-4 pb-2">
+        <h2 class="text-[13px] font-bold text-stone-700 dark:text-gray-200 uppercase tracking-wider">Memo</h2>
+        <button type="button" x-show="isMobile" @click="showMemoSidebar = false" class="p-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-500">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+        </button>
+    </div>
+
+    {{-- New Memo Button --}}
+    <div class="px-4 pb-3">
+        <button type="button"
+                wire:click="startNewMemo"
+                class="w-full flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg border border-stone-200/60 dark:border-gray-700 bg-white dark:bg-transparent hover:bg-gray-50 dark:hover:bg-white/5 text-[13px] font-semibold text-stone-700 dark:text-gray-200 transition-all shadow-sm">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 5v14m-7-7h14" />
+            </svg>
+            Buat Memo Baru
+        </button>
+    </div>
+
+    {{-- Memo List --}}
+    <div class="flex-1 overflow-y-auto px-3">
+        @forelse ($memos as $memo)
+            <button
+                type="button"
+                wire:click="loadMemo({{ $memo->id }})"
+                wire:key="memo-sidebar-{{ $memo->id }}"
+                :class="{ 'bg-ista-primary/5 border-ista-primary/20 dark:bg-ista-primary/10': $wire.activeMemoId === {{ $memo->id }} }"
+                class="w-full text-left px-3 py-2.5 rounded-lg mb-1 border border-transparent hover:bg-stone-50 dark:hover:bg-white/5 transition-all group"
+            >
+                <div class="flex items-start gap-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mt-0.5 flex-shrink-0 text-stone-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    </svg>
+                    <div class="min-w-0 flex-1">
+                        <p class="text-[12.5px] font-medium text-stone-800 dark:text-gray-200 truncate">{{ $memo->title }}</p>
+                        <div class="flex items-center gap-1.5 mt-0.5">
+                            <span class="text-[10.5px] font-medium px-1.5 py-0.5 rounded bg-stone-100 dark:bg-gray-800 text-stone-500 dark:text-gray-400">{{ $memo->type_label }}</span>
+                            <span class="text-[10.5px] text-stone-400 dark:text-gray-500">{{ $memo->updated_at->diffForHumans(short: true) }}</span>
+                        </div>
+                    </div>
+                </div>
+            </button>
+        @empty
+            <div class="px-3 py-6 text-center">
+                <p class="text-[12px] text-stone-400 dark:text-gray-500">Belum ada memo</p>
+            </div>
+        @endforelse
+    </div>
+</aside>

--- a/laravel/resources/views/livewire/memos/partials/memo-preview-panel.blade.php
+++ b/laravel/resources/views/livewire/memos/partials/memo-preview-panel.blade.php
@@ -1,0 +1,140 @@
+{{-- Memo Preview / Editor Panel (Right Column, flex-1) --}}
+<div class="flex-1 flex flex-col min-w-0 bg-stone-50 dark:bg-gray-950 overflow-hidden">
+
+    {{-- Preview/Editor Toggle Header --}}
+    <div class="h-[61px] flex-shrink-0 flex items-center justify-between px-5 border-b border-stone-200/60 dark:border-[#1E293B]/70">
+        <div class="flex items-center gap-1">
+            {{-- Preview Tab --}}
+            <button type="button"
+                    wire:click="switchPreviewMode('preview')"
+                    :class="$wire.previewMode === 'preview'
+                        ? 'bg-white dark:bg-gray-800 text-stone-800 dark:text-gray-200 shadow-sm border-stone-200 dark:border-gray-700'
+                        : 'text-stone-500 dark:text-gray-400 hover:text-stone-700 dark:hover:text-gray-300 border-transparent'"
+                    class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-[12.5px] font-semibold transition-all">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                </svg>
+                Preview
+            </button>
+            {{-- Editor Tab --}}
+            <button type="button"
+                    wire:click="switchPreviewMode('editor')"
+                    :class="$wire.previewMode === 'editor'
+                        ? 'bg-white dark:bg-gray-800 text-stone-800 dark:text-gray-200 shadow-sm border-stone-200 dark:border-gray-700'
+                        : 'text-stone-500 dark:text-gray-400 hover:text-stone-700 dark:hover:text-gray-300 border-transparent'"
+                    class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-[12.5px] font-semibold transition-all">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+                Editor
+            </button>
+        </div>
+
+        {{-- Actions --}}
+        @if ($activeMemoId)
+            <div class="flex items-center gap-2">
+                <button type="button" wire:click="regenerate" wire:loading.attr="disabled" wire:target="regenerate,generateFromChat"
+                        class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-stone-200 dark:border-gray-700 text-[12px] font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-800 transition-all disabled:opacity-50">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                    </svg>
+                    <span wire:loading.remove wire:target="regenerate">Regenerate</span>
+                    <span wire:loading wire:target="regenerate">...</span>
+                </button>
+                <a href="{{ $activeMemoId ? route('memos.download', $activeMemoId) : '#' }}"
+                   class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-stone-200 dark:border-gray-700 text-[12px] font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-800 transition-all">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    </svg>
+                    DOCX
+                </a>
+                <a href="{{ $activeMemoId ? route('memos.export.pdf', $activeMemoId) : '#' }}"
+                   class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-ista-primary text-[12px] font-semibold text-white hover:bg-ista-dark transition-all">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    </svg>
+                    PDF
+                </a>
+            </div>
+        @endif
+    </div>
+
+    {{-- Content Area --}}
+    <div class="flex-1 overflow-y-auto">
+        @if ($previewMode === 'preview')
+            {{-- Rich-text Preview --}}
+            @if ($previewHtml)
+                <div class="max-w-3xl mx-auto p-8">
+                    <div class="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-stone-200/60 dark:border-gray-800 p-8 min-h-[500px]">
+                        {{-- Memo Type Badge --}}
+                        <div class="mb-4">
+                            <span class="inline-flex items-center px-2.5 py-1 rounded-md bg-ista-primary/10 text-ista-primary text-[11px] font-bold uppercase tracking-wider">
+                                {{ $memoTypes[$memoType] ?? $memoType }}
+                            </span>
+                        </div>
+                        {{-- Title --}}
+                        <h1 class="text-xl font-bold text-stone-900 dark:text-gray-100 mb-6">{{ $title ?: 'Untitled' }}</h1>
+                        {{-- Content --}}
+                        <div class="prose prose-stone dark:prose-invert prose-sm max-w-none leading-relaxed">
+                            {!! $previewHtml !!}
+                        </div>
+                    </div>
+                </div>
+            @else
+                {{-- Empty State --}}
+                <div class="flex h-full items-center justify-center px-6">
+                    <div class="text-center max-w-sm">
+                        <div class="mx-auto h-16 w-16 rounded-2xl bg-stone-100 dark:bg-gray-800 flex items-center justify-center mb-4">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-stone-300 dark:text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                            </svg>
+                        </div>
+                        <h3 class="text-[15px] font-semibold text-stone-700 dark:text-gray-300">Belum ada preview</h3>
+                        <p class="mt-2 text-[13px] text-stone-500 dark:text-gray-400 leading-relaxed">
+                            Isi form konteks di panel kiri, lalu ketik instruksi di chat untuk membuat draft memo. Preview akan muncul di sini setelah draft digenerate.
+                        </p>
+                    </div>
+                </div>
+            @endif
+        @else
+            {{-- OnlyOffice Editor --}}
+            @if ($editorConfig)
+                <div
+                    wire:ignore
+                    class="h-full min-h-[640px]"
+                    x-data="{
+                        config: @js($editorConfig),
+                        apiUrl: @js($onlyOfficeApiUrl),
+                        editor: null,
+                        load() {
+                            const boot = () => { this.editor = new DocsAPI.DocEditor('memo-workspace-editor', this.config); };
+                            if (window.DocsAPI) { boot(); return; }
+                            const script = document.createElement('script');
+                            script.src = this.apiUrl;
+                            script.onload = boot;
+                            document.head.appendChild(script);
+                        }
+                    }"
+                    x-init="load()"
+                >
+                    <div id="memo-workspace-editor" class="h-full min-h-[640px] w-full"></div>
+                </div>
+            @else
+                <div class="flex h-full min-h-[400px] items-center justify-center px-6 text-center">
+                    <div class="max-w-sm">
+                        <div class="mx-auto h-16 w-16 rounded-2xl bg-stone-100 dark:bg-gray-800 flex items-center justify-center mb-4">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-stone-300 dark:text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                            </svg>
+                        </div>
+                        <h3 class="text-[15px] font-semibold text-stone-700 dark:text-gray-300">Editor belum tersedia</h3>
+                        <p class="mt-2 text-[13px] text-stone-500 dark:text-gray-400 leading-relaxed">
+                            Generate draft memo terlebih dahulu melalui chat, kemudian editor OnlyOffice akan tersedia untuk mengedit dokumen DOCX secara langsung.
+                        </p>
+                    </div>
+                </div>
+            @endif
+        @endif
+    </div>
+</div>


### PR DESCRIPTION
<!-- opencode-standardized: github-writing-standard-v1 -->
## Ringkasan
- Mengintegrasikan halaman memo ke dalam `/chat` sebagai tab kedua (Unified Single Page)
- Three-column layout: memo history sidebar + AI chat panel + preview/editor panel
- Tab toggle instant tanpa page reload dengan URL deep-link (`/chat?tab=memo`)

Closes #128

## Perubahan Utama
| File / Area | Deskripsi |
|---|---|
| `/chat` | Disebut pada PR historis. |
| `/chat?tab=memo` | Disebut pada PR historis. |

### Detail Perubahan
| Area | Detail |
|------|--------|
| `ChatIndex.php` | Tambah `$tab` property (URL-bound) untuk switching chat/memo |
| `chat-index.blade.php` | Refactor ke conditional render via Alpine `x-if` |
| `MemoWorkspace.php` | Livewire component baru: memo CRUD, AI generate, preview |
| `memo-workspace.blade.php` | Layout three-column |
| `memo-history-sidebar.blade.php` | Sidebar daftar memo |
| `memo-chat.blade.php` | AI chat panel (memo-specific) |
| `memo-preview-panel.blade.php` | Preview rich-text + OnlyOffice toggle |
| `chat-memo-tab-toggle.blade.php` | Tab toggle component |
| `chat-page.js` | Alpine.js `memoWorkspace` data component |

## Validasi
- 154 tests passed, 0 failures (full Laravel test suite)
- PHP syntax validated
- Component instantiation verified via tinker

## Deploy / QA
- Status PR: Merged
- Base branch: `main`
- Head branch: `feat/unified-memo-workspace`
- Merged at: 2026-05-05T03:42:23Z
- Closed at: 2026-05-05T03:42:24Z
- Deploy/QA tidak dicatat eksplisit pada body lama.

## Catatan / Risiko Residual
- Risiko residual tidak dicatat eksplisit pada body lama.

## Relasi Issue
- Closes #128

## Catatan Historis
<details>
<summary>Body sebelum standardisasi</summary>

## Summary

- Mengintegrasikan halaman memo ke dalam `/chat` sebagai tab kedua (Unified Single Page)
- Three-column layout: memo history sidebar + AI chat panel + preview/editor panel
- Tab toggle instant tanpa page reload dengan URL deep-link (`/chat?tab=memo`)

Closes #128

## Perubahan Utama

| Area | Detail |
|------|--------|
| `ChatIndex.php` | Tambah `$tab` property (URL-bound) untuk switching chat/memo |
| `chat-index.blade.php` | Refactor ke conditional render via Alpine `x-if` |
| `MemoWorkspace.php` | Livewire component baru: memo CRUD, AI generate, preview |
| `memo-workspace.blade.php` | Layout three-column |
| `memo-history-sidebar.blade.php` | Sidebar daftar memo |
| `memo-chat.blade.php` | AI chat panel (memo-specific) |
| `memo-preview-panel.blade.php` | Preview rich-text + OnlyOffice toggle |
| `chat-memo-tab-toggle.blade.php` | Tab toggle component |
| `chat-page.js` | Alpine.js `memoWorkspace` data component |

## Fitur

- Tab toggle Chat/Memo di header
- Memo history sidebar (klik untuk load memo lama)
- AI Chat khusus memo (tidak shared dengan chat utama)
- Form context compact (jenis + judul) di atas chat
- Generate draft via chat instruksi -> auto-update preview
- Preview rich-text default + toggle ke OnlyOffice full editor
- Download DOCX / Export PDF
- Regenerate button
- Responsive (sidebar collapse di mobile)

## Test

- 154 tests passed, 0 failures (full Laravel test suite)
- PHP syntax validated
- Component instantiation verified via tinker

</details>
