### PR TITLE
Fix ISTA AI chat, memo mobile, and dashboard polish

### DIFF
--- a/issue/issue-ista-ai-chat-memo-dashboard-polish-2026-05-09.md
+++ b/issue/issue-ista-ai-chat-memo-dashboard-polish-2026-05-09.md
@@ -1,0 +1,80 @@
+# Peningkatan ISTA AI: Chat, Memo Mobile, Typewriter, Drive Picker, History, dan Dark Mode Dashboard
+
+GitHub Issue: https://github.com/Hasbi1605/ISTA-AI/issues/133
+
+## Latar Belakang
+Beberapa regresi dan inkonsistensi UI muncul pada ISTA AI: tampilan bubble chat belum konsisten dengan memo, tab memo sulit dipakai di mobile, efek typewriter jawaban AI tidak berjalan lagi, pemilihan file dari Google Drive belum langsung masuk ke input chat, loading tombol Drive bersifat global, grouping history `Today` tidak berbasis tanggal hari ini, dan dashboard awal belum mengikuti dark mode seperti `/chat` dan tab memo.
+
+## Tujuan
+- Menyamakan pengalaman visual chat dengan tab memo.
+- Membuat tab memo usable pada viewport mobile.
+- Mengembalikan efek jawaban AI yang smooth/typewriter untuk jawaban baru.
+- Memastikan file Google Drive yang dipilih dari input chat langsung terpilih sebagai dokumen percakapan.
+- Membatasi loading tombol `Pakai` hanya pada file Drive yang sedang diproses.
+- Memperbaiki grouping history chat agar `Today` hanya berisi percakapan hari ini.
+- Menambahkan dark mode dashboard awal yang konsisten dengan `/chat` dan memo.
+
+## Ruang Lingkup
+1. Styling bubble user/output chat di tab chat agar ber-background merah seperti bubble user pada panel chat memo.
+2. Responsive layout tab memo untuk mobile dengan kontrol berpindah antara panel chat dan panel dokumen.
+3. Investigasi dan perbaikan flow typewriter jawaban assistant pada chat.
+4. Integrasi hasil import Google Drive ke `conversationDocuments` input chat.
+5. Perbaikan loading state tombol `Pakai` pada modal Google Drive picker.
+6. Grouping history sidebar chat berdasarkan `updated_at` dalam timezone `Asia/Jakarta`.
+7. Dark mode dashboard standalone dan menu profile dashboard.
+
+## Di Luar Scope
+- Perubahan besar arsitektur streaming AI/Python kecuali terbukti diperlukan untuk bug typewriter.
+- Redesign total dashboard, chat, atau memo di luar konsistensi dark mode/responsive yang diminta.
+- Perubahan model database atau migrasi data.
+- Perubahan behavior pemrosesan dokumen selain menambahkan dokumen hasil Drive ke konteks percakapan.
+
+## Area / File Terkait
+- `laravel/app/Livewire/Chat/ChatIndex.php`
+- `laravel/app/Livewire/Chat/GoogleDrivePicker.php`
+- `laravel/app/Services/Chat/ChatDocumentStateService.php`
+- `laravel/resources/views/livewire/chat/partials/chat-messages.blade.php`
+- `laravel/resources/views/livewire/chat/partials/chat-composer.blade.php`
+- `laravel/resources/views/livewire/chat/partials/chat-left-sidebar.blade.php`
+- `laravel/resources/views/livewire/chat/google-drive-picker.blade.php`
+- `laravel/resources/views/livewire/memos/memo-workspace.blade.php`
+- `laravel/resources/views/livewire/memos/partials/memo-chat.blade.php`
+- `laravel/resources/views/livewire/memos/partials/memo-preview-panel.blade.php`
+- `laravel/resources/js/chat-page.js`
+- `laravel/resources/views/dashboard.blade.php`
+- `laravel/resources/views/livewire/dashboard-nav-profile.blade.php`
+- Test Laravel terkait chat, Google Drive picker, dan state dokumen.
+
+## Risiko
+- Efek typewriter melibatkan Livewire streaming + Alpine; perubahan harus menjaga state streaming agar tidak double-render atau menghapus jawaban.
+- File Google Drive hasil import bisa berstatus `pending/processing`; chip input perlu bisa tampil tanpa memaksa dokumen siap dipakai di AI sebelum status `ready`.
+- Responsive memo mobile harus tidak mengganggu desktop layout dan OnlyOffice preview.
+- Dark mode dashboard standalone perlu inisialisasi `localStorage.theme` sendiri agar tidak FOUC dan konsisten dengan layout `/chat`.
+- Timezone history harus eksplisit `Asia/Jakarta` agar grouping `Today` tidak tergantung timezone server.
+
+## Langkah Implementasi
+1. Buat branch kerja dan GitHub Issue dari plan ini.
+2. Perbaiki bubble user chat dan optimistic user message agar memakai background `bg-ista-primary text-white`.
+3. Ubah grouping history sidebar chat menjadi `todayChats` dan `olderChats` berdasarkan `updated_at` timezone `Asia/Jakarta`.
+4. Scope loading tombol Google Drive picker per file ID.
+5. Saat `google-drive-document-imported`, reload dokumen lalu tambahkan `documentId` ke `conversationDocuments`, dan kirim preview event agar chip muncul di composer tanpa membuka Dokumen Saya.
+6. Perbaiki flow typewriter dengan menjaga `newMessageId` setelah reload conversation dan mencegah event `message-complete` mematikan animasi persisted terlalu cepat.
+7. Tambahkan responsive state `memoMobilePanel`/preview toggle di memo workspace, lalu hide/show panel chat dan preview dengan layout mobile yang jelas.
+8. Tambahkan dark mode dashboard: init `darkMode`, toggle button, class `dark`, dark variants pada body/header/search/cards/footer/profile menu.
+9. Tambahkan/ubah test untuk ChatIndex history + Drive import dan GoogleDrivePicker loading markup bila memungkinkan.
+10. Jalankan verifikasi relevan Laravel dan frontend build/lint yang tersedia.
+
+## Rencana Test
+- `cd laravel && php artisan test --filter=ChatUiTest`
+- `cd laravel && php artisan test --filter=GoogleDrivePickerTest`
+- `cd laravel && php artisan test --filter=ChatDocumentStateServiceTest`
+- Jika ada test baru spesifik: jalankan filter nama test tersebut.
+- `cd laravel && npm run build` untuk validasi asset Blade/JS/Tailwind.
+- Manual/visual: chat bubble merah, memo mobile 375px/768px/desktop, typewriter jawaban baru, Drive picker satu tombol loading, history `Today`, dashboard dark mode.
+
+## Kriteria Selesai
+- Semua 7 item permintaan terimplementasi sesuai scope.
+- Issue markdown dan GitHub Issue tersedia sebagai acuan.
+- Test relevan dan build frontend berjalan dengan hasil jelas.
+- Review paralel final tidak menemukan blocker.
+- Perubahan di-commit, di-push ke branch kerja, dan PR dibuat.

--- a/laravel/app/Livewire/Chat/ChatIndex.php
+++ b/laravel/app/Livewire/Chat/ChatIndex.php
@@ -119,7 +119,7 @@ class ChatIndex extends Component
         $this->hasDocumentsInProgress = $state['has_documents_in_progress'];
     }
 
-    public function loadConversation($id)
+    public function loadConversation($id, bool $clearNewMessageId = true)
     {
         $conversation = Conversation::where('id', $id)
             ->where('user_id', Auth::id())
@@ -130,7 +130,9 @@ class ChatIndex extends Component
 
         $this->currentConversationId = $conversation->id;
         $this->messages = $conversation->messages->toArray();
-        $this->newMessageId = null;
+        if ($clearNewMessageId) {
+            $this->newMessageId = null;
+        }
         $this->dispatch('conversation-activated', id: $conversation->id);
     }
 
@@ -331,6 +333,31 @@ class ChatIndex extends Component
     public function refreshDocumentsAfterGoogleDriveImport(?int $documentId = null): void
     {
         $this->loadAvailableDocuments();
+
+        if ($documentId !== null) {
+            $document = Document::query()
+                ->whereKey((int) $documentId)
+                ->where('user_id', Auth::id())
+                ->first();
+
+            if ($document) {
+                $this->conversationDocuments = $this->chatDocumentStateService()->addDocumentIds(
+                    $this->conversationDocuments,
+                    (int) $documentId,
+                );
+
+                $this->dispatch('conversation-documents-preview',
+                    ids: $this->conversationDocuments,
+                    documents: [[
+                        'id' => (int) $document->id,
+                        'name' => (string) $document->original_name,
+                        'extension' => (string) $document->extension,
+                        'status' => (string) $document->status,
+                    ]],
+                );
+            }
+        }
+
         $this->attachmentUploadStatus = 'success';
         $this->attachmentUploadMessage = 'File Google Drive berhasil ditambahkan dan sedang diproses.';
 
@@ -534,7 +561,7 @@ class ChatIndex extends Component
         $assistantMsg = $orchestrator->saveAssistantMessage($this->currentConversationId, $cleanContent);
         $this->newMessageId = $assistantMsg->id;
 
-        $this->loadConversation($this->currentConversationId);
+        $this->loadConversation($this->currentConversationId, clearNewMessageId: false);
         $this->loadConversations();
         $this->dispatch('assistant-message-persisted');
     }

--- a/laravel/app/Livewire/Chat/GoogleDrivePicker.php
+++ b/laravel/app/Livewire/Chat/GoogleDrivePicker.php
@@ -135,7 +135,6 @@ class GoogleDrivePicker extends Component
             $this->isOpen = false;
 
             $this->dispatch('google-drive-document-imported', documentId: $document->id);
-            $this->dispatch('open-sidebar-right');
         } catch (\Throwable $e) {
             $this->errorMessage = $e->getMessage();
             $this->statusMessage = null;

--- a/laravel/app/Services/Chat/ChatDocumentStateService.php
+++ b/laravel/app/Services/Chat/ChatDocumentStateService.php
@@ -55,6 +55,19 @@ class ChatDocumentStateService
     }
 
     /**
+     * @param  array<int, int|string>  $documentIds
+     * @param  array<int, int|string>|int  $addedDocumentIds
+     * @return array<int, int>
+     */
+    public function addDocumentIds(array $documentIds, array|int $addedDocumentIds): array
+    {
+        return array_values(array_unique(array_merge(
+            $this->normalizeDocumentIds($documentIds),
+            $this->normalizeDocumentIds((array) $addedDocumentIds),
+        )));
+    }
+
+    /**
      * @return array<int, int>
      */
     public function selectAllReadyDocuments(int $userId): array

--- a/laravel/resources/css/app.css
+++ b/laravel/resources/css/app.css
@@ -17,6 +17,10 @@
     --app-viewport-height: 100vh;
 }
 
+[x-cloak] {
+    display: none !important;
+}
+
 @supports (height: 100dvh) {
     :root {
         --app-viewport-height: 100dvh;
@@ -55,12 +59,19 @@
             #fdfcfb;
     }
 
+    .dark .ista-shell {
+        background:
+            radial-gradient(circle at top left, rgba(245, 158, 11, 0.04) 0%, transparent 34%),
+            radial-gradient(circle at bottom right, rgba(139, 8, 54, 0.12) 0%, transparent 36%),
+            #111827;
+    }
+
     .ista-navbar {
-        @apply sticky top-0 z-20 border-b border-stone-200/80 bg-white/80 backdrop-blur-xl;
+        @apply sticky top-0 z-20 border-b border-stone-200/80 bg-white/80 backdrop-blur-xl dark:border-[#1E293B]/70 dark:bg-gray-900/80;
     }
 
     .ista-pill {
-        @apply rounded-full border border-stone-200 bg-white px-5 py-2 text-xs font-bold uppercase tracking-widest text-stone-500 shadow-sm transition hover:border-ista-primary/20 hover:text-ista-primary hover:shadow-md;
+        @apply rounded-full border border-stone-200 bg-white px-5 py-2 text-xs font-bold uppercase tracking-widest text-stone-500 shadow-sm transition hover:border-ista-primary/20 hover:text-ista-primary hover:shadow-md dark:border-gray-800 dark:bg-gray-800/90 dark:text-[#94A3B8] dark:hover:border-ista-primary/50 dark:hover:text-amber-300;
     }
 
     .ista-brand-title {
@@ -76,11 +87,11 @@
     .ista-hero-title {
         font-family: "Fraunces", serif;
         font-variation-settings: "SOFT" 0, "WONK" 1;
-        @apply text-center text-7xl italic leading-[0.85] tracking-tighter text-ista-dark md:text-9xl;
+        @apply text-center text-7xl italic leading-[0.85] tracking-tighter text-ista-dark md:text-9xl dark:text-gray-100;
     }
 
     .ista-hero-title strong {
-        @apply block not-italic font-bold text-stone-900;
+        @apply block not-italic font-bold text-stone-900 dark:text-gray-100;
     }
 
     .ista-search-shell {
@@ -89,7 +100,7 @@
 
     .ista-search-input {
         font-family: "Plus Jakarta Sans", "Inter", sans-serif;
-        @apply w-full rounded-2xl border border-stone-200 bg-white py-5 pl-8 pr-36 text-base font-bold text-stone-800 placeholder-stone-300 shadow-2xl outline-none transition-all focus:border-ista-gold focus:ring focus:ring-ista-gold/20;
+        @apply w-full rounded-2xl border border-stone-200 bg-white py-5 pl-8 pr-36 text-base font-bold text-stone-800 placeholder-stone-300 shadow-2xl outline-none transition-all focus:border-ista-gold focus:ring focus:ring-ista-gold/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-500 dark:shadow-none;
     }
 
     .ista-primary-cta {

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -918,6 +918,7 @@ const registerChatPageData = (Alpine) => {
     Alpine.data('memoWorkspace', () => ({
         showMemoSidebar: !window.matchMedia('(max-width: 1023px)').matches,
         isMobile: window.matchMedia('(max-width: 1023px)').matches,
+        memoMobilePanel: 'chat',
         memoRevisionText: '',
         memoRevisionLoading: false,
 
@@ -926,6 +927,10 @@ const registerChatPageData = (Alpine) => {
             const syncState = (event) => {
                 this.isMobile = event.matches;
                 this.showMemoSidebar = !event.matches;
+
+                if (!event.matches) {
+                    this.memoMobilePanel = 'chat';
+                }
             };
 
             mediaQuery.addEventListener('change', syncState);
@@ -937,6 +942,20 @@ const registerChatPageData = (Alpine) => {
         },
 
         collapseMemoSidebarForDocument() {
+            this.showMemoSidebar = false;
+
+            if (this.isMobile) {
+                this.memoMobilePanel = 'document';
+            }
+        },
+
+        showMemoChatPanel() {
+            this.memoMobilePanel = 'chat';
+            this.showMemoSidebar = false;
+        },
+
+        showMemoDocumentPanel() {
+            this.memoMobilePanel = 'document';
             this.showMemoSidebar = false;
         },
 

--- a/laravel/resources/views/dashboard.blade.php
+++ b/laravel/resources/views/dashboard.blade.php
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}"
+      x-data="{ darkMode: localStorage.getItem('theme') === 'dark' }"
+      x-init="$watch('darkMode', value => { localStorage.setItem('theme', value ? 'dark' : 'light'); document.documentElement.classList.toggle('dark', value); })"
+      :class="{ 'dark': darkMode }">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -12,13 +15,20 @@
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
+        <script>
+            if (localStorage.theme === 'dark') {
+                document.documentElement.classList.add('dark');
+            } else {
+                document.documentElement.classList.remove('dark');
+            }
+        </script>
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
-    <body class="ista-shell ista-display-sans text-stone-800">
+    <body class="ista-shell ista-display-sans text-stone-800 dark:text-gray-100 transition-colors duration-300">
         <x-page-loader />
-        <div class="relative min-h-screen overflow-hidden" style="background-image: radial-gradient(circle at 0 0, rgba(245, 158, 11, 0.08) 0%, rgba(245, 158, 11, 0) 30%), radial-gradient(circle at 100% 100%, rgba(76, 5, 25, 0.08) 0%, rgba(76, 5, 25, 0) 35%), url('{{ asset('images/ista/dashboard-grid.png') }}'); background-size: auto, auto, 8px 8px;">
-            <div class="pointer-events-none absolute -left-20 -top-20 h-[28rem] w-[28rem] rounded-full bg-amber-100/50 blur-3xl"></div>
-            <div class="pointer-events-none absolute -right-24 top-32 h-[24rem] w-[24rem] rounded-full bg-rose-100/60 blur-3xl"></div>
+        <div class="relative min-h-screen overflow-hidden bg-stone-50/50 transition-colors duration-300 dark:bg-gray-900" style="background-image: radial-gradient(circle at 0 0, rgba(245, 158, 11, 0.08) 0%, rgba(245, 158, 11, 0) 30%), radial-gradient(circle at 100% 100%, rgba(76, 5, 25, 0.08) 0%, rgba(76, 5, 25, 0) 35%), url('{{ asset('images/ista/dashboard-grid.png') }}'); background-size: auto, auto, 8px 8px;">
+            <div class="pointer-events-none absolute -left-20 -top-20 h-[28rem] w-[28rem] rounded-full bg-amber-100/50 blur-3xl dark:bg-amber-500/5"></div>
+            <div class="pointer-events-none absolute -right-24 top-32 h-[24rem] w-[24rem] rounded-full bg-rose-100/60 blur-3xl dark:bg-ista-primary/10"></div>
 
             <header class="ista-navbar">
                 <div class="mx-auto flex w-full max-w-7xl items-center justify-between px-5 py-4 sm:px-10">
@@ -26,7 +36,15 @@
                         <img src="{{ asset('images/ista/logo.png') }}" alt="ISTA AI" class="h-8 w-8 object-contain transition-transform duration-300 group-hover:rotate-6 group-hover:scale-110">
                         <div class="ista-brand-title text-xl text-ista-primary not-italic">ISTA <span class="font-light italic text-ista-gold">AI</span></div>
                     </a>
-                    <div class="flex items-center gap-4 sm:gap-8">
+                    <div class="flex items-center gap-2 sm:gap-4">
+                        <button type="button" @click="darkMode = !darkMode" class="inline-flex h-10 w-10 items-center justify-center rounded-[10px] text-[#64748B] transition-colors hover:bg-[#F1F5F9] dark:text-gray-300 dark:hover:bg-gray-800" aria-label="Toggle dark mode">
+                            <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />
+                            </svg>
+                            <svg x-show="darkMode === true" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z" />
+                            </svg>
+                        </button>
                         <livewire:dashboard-nav-profile />
                     </div>
                 </div>
@@ -50,7 +68,7 @@
             <main class="relative z-10 mx-auto flex min-h-[calc(100vh-136px)] w-full max-w-7xl items-center px-5 pb-20 pt-16 sm:px-10">
                 <section class="w-full text-center">
                     <div class="mx-auto w-fit ista-pill">Asisten Istana Pintar</div>
-                    <h1 class="ista-hero-title mt-8 text-stone-900">Tanya <strong><span class="text-ista-primary">ISTA</span> <span class="font-light italic text-ista-gold">AI</span></strong></h1>
+                    <h1 class="ista-hero-title mt-8 text-stone-900 dark:text-gray-100">Tanya <strong><span class="text-ista-primary">ISTA</span> <span class="font-light italic text-ista-gold">AI</span></strong></h1>
 
                     @auth
                     <form action="{{ route('chat') }}" method="GET" class="ista-search-shell">
@@ -66,20 +84,20 @@
 
                     <div class="mx-auto mt-10 grid max-w-xl grid-cols-1 gap-3 sm:grid-cols-2">
                         @auth
-                        <a href="{{ route('chat') }}" class="rounded-2xl border border-stone-200 bg-white/80 px-4 py-3 text-sm font-semibold text-stone-700 transition hover:border-ista-primary/30 hover:text-ista-primary">Buka Chat</a>
-                        <a href="{{ route('chat', ['tab' => 'memo']) }}" class="rounded-2xl border border-stone-200 bg-white/80 px-4 py-3 text-sm font-semibold text-stone-700 transition hover:border-ista-primary/30 hover:text-ista-primary">Buka Memo</a>
+                        <a href="{{ route('chat') }}" class="rounded-2xl border border-stone-200 bg-white/80 px-4 py-3 text-sm font-semibold text-stone-700 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-800/80 dark:text-gray-100 dark:hover:border-ista-primary/50">Buka Chat</a>
+                        <a href="{{ route('chat', ['tab' => 'memo']) }}" class="rounded-2xl border border-stone-200 bg-white/80 px-4 py-3 text-sm font-semibold text-stone-700 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-800/80 dark:text-gray-100 dark:hover:border-ista-primary/50">Buka Memo</a>
                         @else
-                        <a href="{{ route('guest-chat') }}" class="rounded-2xl border border-stone-200 bg-white/80 px-4 py-3 text-sm font-semibold text-stone-700 transition hover:border-ista-primary/30 hover:text-ista-primary">Buka Chat</a>
-                        <a href="{{ route('guest-memo') }}" class="rounded-2xl border border-stone-200 bg-white/80 px-4 py-3 text-sm font-semibold text-stone-700 transition hover:border-ista-primary/30 hover:text-ista-primary">Buka Memo</a>
+                        <a href="{{ route('guest-chat') }}" class="rounded-2xl border border-stone-200 bg-white/80 px-4 py-3 text-sm font-semibold text-stone-700 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-800/80 dark:text-gray-100 dark:hover:border-ista-primary/50">Buka Chat</a>
+                        <a href="{{ route('guest-memo') }}" class="rounded-2xl border border-stone-200 bg-white/80 px-4 py-3 text-sm font-semibold text-stone-700 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-800/80 dark:text-gray-100 dark:hover:border-ista-primary/50">Buka Memo</a>
                         @endauth
                     </div>
 
                 </section>
             </main>
 
-            <footer class="relative z-20 flex h-[72px] flex-col items-center justify-center border-t border-stone-200/80 bg-white/80 backdrop-blur">
-                <p class="text-[11px] font-bold uppercase tracking-widest text-[#78716c]">Copyright &copy; 2026 Istana Kepresidenan Yogyakarta</p>
-                <p class="mt-1 text-[9px] font-medium uppercase tracking-[0.3em] text-[#a8a29e]">All Rights Reserved.</p>
+            <footer class="relative z-20 flex h-[72px] flex-col items-center justify-center border-t border-stone-200/80 bg-white/80 backdrop-blur dark:border-[#1E293B]/70 dark:bg-gray-900/80">
+                <p class="text-[11px] font-bold uppercase tracking-widest text-[#78716c] dark:text-[#94A3B8]">Copyright &copy; 2026 Istana Kepresidenan Yogyakarta</p>
+                <p class="mt-1 text-[9px] font-medium uppercase tracking-[0.3em] text-[#a8a29e] dark:text-[#64748B]">All Rights Reserved.</p>
             </footer>
         </div>
     </body>

--- a/laravel/resources/views/livewire/chat/google-drive-picker.blade.php
+++ b/laravel/resources/views/livewire/chat/google-drive-picker.blade.php
@@ -230,11 +230,11 @@
                                         <button type="button"
                                                 wire:click="processFile(@js($item['id']))"
                                                 wire:loading.attr="disabled"
-                                                wire:target="processFile"
+                                                wire:target="processFile(@js($item['id']))"
                                                 @disabled(! $isProcessable)
                                                 class="inline-flex min-w-[116px] items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 {{ $isProcessable ? 'bg-ista-primary text-white hover:bg-stone-800' : 'bg-stone-100 text-stone-400 dark:bg-gray-800 dark:text-gray-500' }}">
-                                            <span wire:loading.remove wire:target="processFile">{{ $isProcessable ? 'Pakai' : 'Belum bisa' }}</span>
-                                            <span wire:loading.inline-flex wire:target="processFile" class="items-center gap-2">
+                                            <span wire:loading.remove wire:target="processFile(@js($item['id']))">{{ $isProcessable ? 'Pakai' : 'Belum bisa' }}</span>
+                                            <span wire:loading.inline-flex wire:target="processFile(@js($item['id']))" class="items-center gap-2">
                                                 <span class="h-3.5 w-3.5 rounded-full border-2 border-current border-t-transparent animate-spin"></span>
                                                 Memproses
                                             </span>

--- a/laravel/resources/views/livewire/chat/partials/chat-left-sidebar.blade.php
+++ b/laravel/resources/views/livewire/chat/partials/chat-left-sidebar.blade.php
@@ -33,15 +33,15 @@
     </div>
 
     <div class="flex-1 overflow-y-auto overflow-x-hidden px-4">
+        @php
+            $todayChats = $conversations->filter(fn ($conversation) => $conversation->updated_at?->timezone('Asia/Jakarta')->isToday());
+            $olderChats = $conversations->reject(fn ($conversation) => $conversation->updated_at?->timezone('Asia/Jakarta')->isToday());
+        @endphp
+
         <div class="mb-6">
             <h3 class="text-[11.6px] font-bold text-[#64748B] dark:text-[#94A3B8] uppercase tracking-wider mb-2">Today</h3>
             <ul class="space-y-1">
-                @php
-                    $visibleChats = $conversations->take(10);
-                    $olderChats = $conversations->skip(10);
-                @endphp
-
-                @foreach($visibleChats as $conversation)
+                @forelse($todayChats as $conversation)
                     <li class="group relative" wire:key="chat-history-visible-{{ $conversation->id }}">
                         <button type="button" @click="loadConversation({{ $conversation->id }}); if(isMobile) showLeftSidebar = false;"
                            data-chat-history-id="{{ $conversation->id }}"
@@ -62,7 +62,11 @@
                             </svg>
                         </button>
                     </li>
-                @endforeach
+                @empty
+                    <li class="rounded-lg border border-dashed border-stone-200/70 px-3 py-3 text-[12px] leading-relaxed text-stone-400 dark:border-gray-800 dark:text-gray-500">
+                        Belum ada percakapan hari ini.
+                    </li>
+                @endforelse
             </ul>
         </div>
 

--- a/laravel/resources/views/livewire/chat/partials/chat-messages.blade.php
+++ b/laravel/resources/views/livewire/chat/partials/chat-messages.blade.php
@@ -280,7 +280,7 @@
                             </div>
                         </div>
                     @else
-                        <div class="text-[14.5px] leading-relaxed text-stone-700 dark:text-gray-100 w-full max-w-[656px] min-w-0">
+                        <div class="w-full max-w-[656px] min-w-0 rounded-lg rounded-br-sm bg-ista-primary px-4 py-3 text-[14.5px] leading-relaxed text-white shadow-sm">
                             <p class="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{{ $message['content'] }}</p>
                         </div>
                     @endif
@@ -302,7 +302,7 @@
                     <div class="flex items-center gap-2 mb-1 justify-end">
                         <span class="text-[13px] font-bold text-stone-800 dark:text-[#F8FAFC]">Anda</span>
                     </div>
-                    <div class="text-[14.5px] leading-relaxed text-stone-700 dark:text-gray-100 w-full max-w-[656px] min-w-0">
+                    <div class="w-full max-w-[656px] min-w-0 rounded-lg rounded-br-sm bg-ista-primary px-4 py-3 text-[14.5px] leading-relaxed text-white shadow-sm">
                         <p class="whitespace-pre-wrap break-words [overflow-wrap:anywhere]" x-text="optimisticUserMessage"></p>
                     </div>
                 </div>

--- a/laravel/resources/views/livewire/dashboard-nav-profile.blade.php
+++ b/laravel/resources/views/livewire/dashboard-nav-profile.blade.php
@@ -13,13 +13,13 @@ new class extends Component {
 
 <div class="relative" x-data="{ open: false }" @click.outside="open = false" @close.stop="open = false">
     @auth
-    <button @click="open = ! open" class="flex items-center gap-2 rounded-full p-1 transition hover:bg-stone-100 focus:outline-none">
+    <button @click="open = ! open" class="flex items-center gap-2 rounded-full p-1 transition hover:bg-stone-100 focus:outline-none dark:hover:bg-gray-800">
         <div class="flex h-8 w-8 items-center justify-center rounded-full bg-ista-primary text-sm font-bold text-amber-400">
             {{ substr(auth()->user()->name, 0, 1) }}
         </div>
         <div class="hidden items-center gap-1 pr-2 sm:flex">
-            <span class="text-sm font-medium text-stone-600" x-data="{{ json_encode(['name' => auth()->user()->name]) }}" x-text="name" x-on:profile-updated.window="name = $event.detail.name"></span>
-            <svg class="h-4 w-4 text-stone-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <span class="text-sm font-medium text-stone-600 dark:text-gray-200" x-data="{{ json_encode(['name' => auth()->user()->name]) }}" x-text="name" x-on:profile-updated.window="name = $event.detail.name"></span>
+            <svg class="h-4 w-4 text-stone-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
             </svg>
         </div>
@@ -32,30 +32,30 @@ new class extends Component {
          x-transition:leave="transition ease-in duration-75"
          x-transition:leave-start="opacity-100 scale-100"
          x-transition:leave-end="opacity-0 scale-95"
-         class="absolute right-0 z-50 mt-2 w-48 origin-top-right rounded-xl border border-stone-100 bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5"
+          class="absolute right-0 z-50 mt-2 w-48 origin-top-right rounded-xl border border-stone-100 bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 dark:border-gray-800 dark:bg-gray-900"
          style="display: none;">
         
-        <div class="block border-b border-stone-100 px-4 py-2 sm:hidden">
-            <p class="truncate text-sm font-medium text-stone-800">{{ auth()->user()->name }}</p>
-            <p class="truncate text-xs text-stone-500">{{ auth()->user()->email }}</p>
+        <div class="block border-b border-stone-100 px-4 py-2 dark:border-gray-800 sm:hidden">
+            <p class="truncate text-sm font-medium text-stone-800 dark:text-gray-100">{{ auth()->user()->name }}</p>
+            <p class="truncate text-xs text-stone-500 dark:text-gray-400">{{ auth()->user()->email }}</p>
         </div>
 
-        <a href="{{ route('profile') }}" class="block px-4 py-2 text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary">
+        <a href="{{ route('profile') }}" class="block px-4 py-2 text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-amber-300">
             Profil
         </a>
         
-        <button wire:click="logout" class="block w-full px-4 py-2 text-left text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary">
+        <button wire:click="logout" class="block w-full px-4 py-2 text-left text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-amber-300">
             Keluar
         </button>
     </div>
     @else
-    <button @click="open = ! open" class="flex items-center gap-2 rounded-full p-1 transition hover:bg-stone-100 focus:outline-none">
-        <div class="flex h-8 w-8 items-center justify-center rounded-full bg-stone-300 text-sm font-bold text-stone-600">
+    <button @click="open = ! open" class="flex items-center gap-2 rounded-full p-1 transition hover:bg-stone-100 focus:outline-none dark:hover:bg-gray-800">
+        <div class="flex h-8 w-8 items-center justify-center rounded-full bg-stone-300 text-sm font-bold text-stone-600 dark:bg-gray-700 dark:text-gray-200">
             G
         </div>
         <div class="hidden items-center gap-1 pr-2 sm:flex">
-            <span class="text-sm font-medium text-stone-600">Guest</span>
-            <svg class="h-4 w-4 text-stone-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <span class="text-sm font-medium text-stone-600 dark:text-gray-200">Guest</span>
+            <svg class="h-4 w-4 text-stone-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
             </svg>
         </div>
@@ -68,10 +68,10 @@ new class extends Component {
          x-transition:leave="transition ease-in duration-75"
          x-transition:leave-start="opacity-100 scale-100"
          x-transition:leave-end="opacity-0 scale-95"
-         class="absolute right-0 z-50 mt-2 w-48 origin-top-right rounded-xl border border-stone-100 bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5"
+          class="absolute right-0 z-50 mt-2 w-48 origin-top-right rounded-xl border border-stone-100 bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 dark:border-gray-800 dark:bg-gray-900"
          style="display: none;">
         
-        <a href="{{ route('login') }}" class="block px-4 py-2 text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary">
+        <a href="{{ route('login') }}" class="block px-4 py-2 text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-amber-300">
             Login
         </a>
     </div>

--- a/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
+++ b/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
@@ -1,5 +1,7 @@
 {{-- Memo AI Chat Panel (Center Column) --}}
 <div
+    x-show="!isMobile || memoMobilePanel === 'chat'"
+    x-cloak
     class="flex flex-col w-full lg:w-[460px] xl:w-[560px] flex-shrink-0 border-r border-stone-200/70 dark:border-[#1E293B] bg-transparent overflow-hidden"
     x-on:memo-configuration-invalid.window="$nextTick(() => {
         const error = $refs.memoChatBox?.querySelector('.memo-config-error');
@@ -27,6 +29,13 @@
         </div>
 
         <div class="ml-auto flex shrink-0 items-center gap-2">
+            <button type="button" @click="showMemoDocumentPanel()" class="inline-flex items-center gap-1.5 rounded-[10px] border border-stone-200/70 px-2.5 py-2 text-[11px] font-semibold text-stone-600 transition hover:bg-[#F1F5F9] dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 lg:hidden" aria-label="Buka panel dokumen memo">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414A1 1 0 0 1 19 9.414V19a2 2 0 0 1-2 2Z" />
+                </svg>
+                <span>Dokumen</span>
+            </button>
+
             <button type="button" @click="darkMode = !darkMode" class="p-2 rounded-[10px] hover:bg-[#F1F5F9] dark:hover:bg-gray-800 transition-colors" aria-label="Toggle dark mode">
                 <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-[#64748B]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />

--- a/laravel/resources/views/livewire/memos/partials/memo-preview-panel.blade.php
+++ b/laravel/resources/views/livewire/memos/partials/memo-preview-panel.blade.php
@@ -1,9 +1,14 @@
 {{-- Memo Document Panel (Right Column, flex-1) --}}
-<div class="flex-1 flex flex-col min-w-0 bg-stone-50 dark:bg-gray-950 overflow-hidden">
+<div x-show="!isMobile || memoMobilePanel === 'document'" x-cloak class="flex-1 flex flex-col min-w-0 bg-stone-50 dark:bg-gray-950 overflow-hidden">
 
     {{-- Document Header --}}
     <div class="relative z-30 min-h-[61px] flex-shrink-0 flex items-center justify-between gap-3 px-5 border-b border-stone-200/60 bg-white/85 backdrop-blur-sm dark:border-[#1E293B]/70 dark:bg-gray-800/85">
         <div class="flex min-w-0 flex-wrap items-center gap-3">
+            <button type="button" @click="showMemoChatPanel()" class="inline-flex items-center justify-center rounded-lg border border-stone-200 bg-white p-2 text-stone-600 shadow-sm transition hover:bg-stone-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 lg:hidden" aria-label="Kembali ke chat memo">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M15 19l-7-7 7-7" />
+                </svg>
+            </button>
             <div class="inline-flex items-center gap-1.5 rounded-lg border border-stone-200 bg-white px-3 py-1.5 text-[12.5px] font-semibold text-stone-800 shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -8,6 +8,7 @@ use App\Models\Document;
 use App\Models\Message;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -196,5 +197,87 @@ class ChatUiTest extends TestCase
             ->set('newMessageId', $message->id)
             ->call('loadConversation', $conversation->id)
             ->assertSet('newMessageId', null);
+    }
+
+    public function test_loading_conversation_can_preserve_latest_message_marker_for_typewriter(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Preserve latest marker test',
+        ]);
+
+        $message = Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Pesan baru dari AI.',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(ChatIndex::class)
+            ->set('newMessageId', $message->id)
+            ->call('loadConversation', $conversation->id, false)
+            ->assertSet('newMessageId', $message->id)
+            ->assertSee('wire:key="msg-typing-'.$message->id.'"', false);
+    }
+
+    public function test_chat_history_groups_today_by_jakarta_date(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-09 10:00:00', 'Asia/Jakarta'));
+
+        try {
+            $user = User::factory()->create();
+            $todayConversation = Conversation::create([
+                'user_id' => $user->id,
+                'title' => 'Percakapan hari ini',
+            ]);
+            $todayConversation->forceFill([
+                'created_at' => Carbon::now('Asia/Jakarta'),
+                'updated_at' => Carbon::now('Asia/Jakarta'),
+            ])->save();
+
+            $olderConversation = Conversation::create([
+                'user_id' => $user->id,
+                'title' => 'Percakapan kemarin',
+            ]);
+            $olderConversation->forceFill([
+                'created_at' => Carbon::now('Asia/Jakarta')->subDay(),
+                'updated_at' => Carbon::now('Asia/Jakarta')->subDay(),
+            ])->save();
+
+            $response = $this->actingAs($user)->get('/chat');
+
+            $response
+                ->assertOk()
+                ->assertSee('Today', false)
+                ->assertSee('Percakapan hari ini', false)
+                ->assertSee('Previous 7 Days', false)
+                ->assertSee('Percakapan kemarin', false);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_google_drive_import_is_added_to_chat_composer_documents(): void
+    {
+        $user = User::factory()->create();
+        $document = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'drive-import.pdf',
+            'original_name' => 'drive-import.pdf',
+            'file_path' => 'documents/'.$user->id.'/drive-import.pdf',
+            'source_provider' => 'google_drive',
+            'source_external_id' => 'drive-import-id',
+            'source_synced_at' => now(),
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 1234,
+            'status' => 'processing',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(ChatIndex::class)
+            ->call('refreshDocumentsAfterGoogleDriveImport', $document->id)
+            ->assertSet('conversationDocuments', [$document->id])
+            ->assertDispatched('conversation-documents-preview');
     }
 }

--- a/laravel/tests/Feature/Chat/GoogleDrivePickerTest.php
+++ b/laravel/tests/Feature/Chat/GoogleDrivePickerTest.php
@@ -124,5 +124,7 @@ class GoogleDrivePickerTest extends TestCase
 
         $this->assertStringContainsString('wire:click="goToFolder(\'folder-1\', \'Subfolder\')"', $html);
         $this->assertStringContainsString('wire:click="processFile(\'file-1\')"', $html);
+        $this->assertStringContainsString('wire:target="processFile(\'file-1\')"', $html);
+        $this->assertStringNotContainsString('wire:target="processFile"', $html);
     }
 }

--- a/laravel/tests/Unit/Services/Chat/ChatDocumentStateServiceTest.php
+++ b/laravel/tests/Unit/Services/Chat/ChatDocumentStateServiceTest.php
@@ -43,6 +43,7 @@ class ChatDocumentStateServiceTest extends TestCase
         $this->assertSame([], $service->toggleSelectAllDocuments([10], [10]));
         $this->assertSame([10, 12], $service->toggleSelectAllDocuments([], [10, 12]));
         $this->assertSame([10], $service->addSelectedDocumentsToChat([10, 12], [10]));
+        $this->assertSame([10, 12], $service->addDocumentIds([10], [10, 12]));
         $this->assertSame([10], $service->removeDocumentIds([10, 12], 12));
     }
 


### PR DESCRIPTION
## Summary
- Fixes chat/memo UI polish from issue #133, including red chat user bubbles, mobile memo panel switching, and dashboard dark mode parity.
- Restores persisted-answer typewriter behavior by preserving `newMessageId` after saving a new assistant message.
- Fixes Google Drive picker behavior so selected files go into chat context and per-file loading is scoped, plus corrects Today history grouping by Jakarta date.

## Tests
- `cd laravel && /opt/homebrew/opt/php/bin/php artisan test --filter=ChatUiTest`
- `cd laravel && /opt/homebrew/opt/php/bin/php artisan test --filter=GoogleDrivePickerTest`
- `cd laravel && /opt/homebrew/opt/php/bin/php artisan test --filter=ChatDocumentStateServiceTest`
- `cd laravel && /opt/homebrew/opt/php/bin/php artisan test --filter=DashboardTest`
- `cd laravel && /opt/homebrew/opt/php/bin/php vendor/bin/pint app/Livewire/Chat/ChatIndex.php app/Livewire/Chat/GoogleDrivePicker.php app/Services/Chat/ChatDocumentStateService.php tests/Feature/Chat/ChatUiTest.php tests/Feature/Chat/GoogleDrivePickerTest.php tests/Unit/Services/Chat/ChatDocumentStateServiceTest.php`

## Notes
- `npm run build` was not run because `npm`/`node` are not available in this shell PATH.
- Local issue plan: `issue/issue-ista-ai-chat-memo-dashboard-polish-2026-05-09.md`.

Closes #133