### PR TITLE
Fix memo mobile header layout

### DIFF
--- a/issue/issue-memo-mobile-header-layout-2026-05-10.md
+++ b/issue/issue-memo-mobile-header-layout-2026-05-10.md
@@ -1,0 +1,80 @@
+# Perbaikan Layout Header Memo Mobile
+
+## Latar Belakang
+
+Pada workspace memo, posisi kontrol header belum sesuai kebutuhan terbaru. Di tab memo, toggle Chat/Memo masih berada di area kanan bersama tombol Dokumen, sementara tombol Dokumen perlu diposisikan di pojok kanan dan toggle Chat/Memo perlu berada di tengah. Saat dokumen memo dibuka di versi mobile, tombol header seperti Kembali, Regenerate, DOCX, dan PDF juga berisiko saling bertabrakan karena ruang horizontal terbatas.
+
+## Tujuan
+
+- Memindahkan toggle Chat/Memo ke tengah header tab memo.
+- Memindahkan tombol Dokumen ke pojok kanan header tab memo.
+- Merapikan header dokumen memo pada mobile agar tombol tidak bertumpuk/bertabrakan.
+- Mempertahankan fungsi existing: buka panel dokumen, kembali ke chat memo, regenerate, download DOCX, download PDF, dark mode, dan tab switch Chat/Memo.
+
+## Ruang Lingkup
+
+- Penyesuaian struktur dan kelas responsive pada header memo chat.
+- Penyesuaian kelas responsive pada header dokumen memo, terutama untuk mobile.
+- Perubahan hanya pada UI Blade/Tailwind yang relevan.
+- Browser QA dilakukan hanya setelah PR dibuat, sesuai instruksi user.
+
+## Di Luar Scope
+
+- Perubahan backend Livewire/PHP untuk generate memo, versioning, atau download.
+- Perubahan Alpine state `memoWorkspace()` kecuali ditemukan kebutuhan kecil yang tidak bisa dihindari.
+- Refactor besar workspace memo atau desain ulang panel memo.
+- Perubahan template isi dokumen memo.
+
+## Area / File Terkait
+
+- `laravel/resources/views/livewire/memos/partials/memo-chat.blade.php`
+  - Header panel chat memo, tombol Dokumen mobile, toggle dark mode, dan include `chat-memo-tab-toggle`.
+- `laravel/resources/views/livewire/memos/partials/memo-preview-panel.blade.php`
+  - Header panel dokumen memo, tombol Kembali, Regenerate, DOCX, dan PDF.
+- `laravel/resources/views/livewire/chat/partials/chat-memo-tab-toggle.blade.php`
+  - Komponen toggle Chat/Memo; kemungkinan tidak perlu diubah.
+- `laravel/resources/js/chat-page.js`
+  - Referensi state mobile memo; hanya untuk verifikasi alur, bukan target utama perubahan.
+
+## Risiko
+
+- Header memo mobile bisa tetap padat pada viewport sangat kecil jika teks tombol tidak disembunyikan.
+- Perubahan alignment header bisa memengaruhi tampilan desktop/tablet jika breakpoint tidak dijaga.
+- Tombol Dokumen hanya relevan pada mobile/tablet (`lg:hidden`), sehingga posisi desktop perlu tetap aman.
+- QA visual baru boleh dilakukan setelah PR dibuat; sebelum PR validasi terbatas pada build/test/diff.
+
+## Langkah Implementasi
+
+1. Ubah header `memo-chat.blade.php` menjadi layout tiga area: kiri untuk sidebar/brand, tengah untuk toggle Chat/Memo, kanan untuk dark mode dan tombol Dokumen.
+2. Pastikan tombol Dokumen berada paling kanan dan tetap memanggil `showMemoDocumentPanel()`.
+3. Ubah header `memo-preview-panel.blade.php` agar mobile lebih ringkas:
+   - tombol aksi memakai padding/gap lebih kecil di mobile;
+   - teks Regenerate/DOCX/PDF disembunyikan di mobile dan muncul lagi di breakpoint lebih besar;
+   - badge/label Dokumen disembunyikan atau diringkas di mobile bila perlu.
+4. Pastikan tombol Kembali tetap tersedia saat mobile panel dokumen dibuka.
+5. Jalankan validasi build/test relevan sebelum commit dan PR.
+6. Setelah PR dibuat, lakukan browser QA pada live preview mobile dan desktop.
+
+## Rencana Test
+
+- Pra-PR:
+  - `cd laravel && npm run build`
+  - `cd laravel && php artisan test --filter=Memo`
+  - `git diff --check`
+- Pasca-PR:
+  - Browser QA via subagent pada `https://ista-ai.app` setelah branch PR dideploy.
+  - Cek desktop: toggle Chat/Memo di tengah, tombol Dokumen di kanan.
+  - Cek mobile: header dokumen memo tidak bertabrakan; tombol Kembali, Regenerate, DOCX, dan PDF terlihat/usable.
+  - Cek dark mode dan state kembali dari dokumen ke chat memo.
+- Verifikasi akhir penuh sebelum minta approval merge:
+  - `cd laravel && php artisan test`
+  - `cd python-ai && source venv/bin/activate && pytest`
+
+## Kriteria Selesai
+
+- Toggle Chat/Memo berada di tengah header tab memo.
+- Tombol Dokumen berada di pojok kanan header tab memo.
+- Pada mobile saat dokumen memo dibuka, tombol header tidak saling bertabrakan/bertumpuk.
+- Build frontend dan test relevan lulus.
+- PR dibuat, branch PR dideploy ke `https://ista-ai.app`, dan browser QA dilakukan setelah PR dibuat.
+- Review/QC PR tidak menemukan blocker sebelum user diminta approval merge.

--- a/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
+++ b/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
@@ -28,14 +28,11 @@
             </button>
         </div>
 
-        <div class="ml-auto flex shrink-0 items-center gap-2">
-            <button type="button" @click="showMemoDocumentPanel()" class="inline-flex items-center gap-1.5 rounded-[10px] border border-stone-200/70 px-2.5 py-2 text-[11px] font-semibold text-stone-600 transition hover:bg-[#F1F5F9] dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 lg:hidden" aria-label="Buka panel dokumen memo">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414A1 1 0 0 1 19 9.414V19a2 2 0 0 1-2 2Z" />
-                </svg>
-                <span>Dokumen</span>
-            </button>
+        <div class="flex flex-1 items-center justify-center">
+            @include('livewire.chat.partials.chat-memo-tab-toggle')
+        </div>
 
+        <div class="ml-auto flex shrink-0 items-center gap-2">
             <button type="button" @click="darkMode = !darkMode" :aria-pressed="darkMode ? 'true' : 'false'" class="p-2 rounded-[10px] hover:bg-[#F1F5F9] dark:hover:bg-gray-800 transition-colors" aria-label="Toggle dark mode">
                 <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-[#64748B]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />
@@ -45,7 +42,12 @@
                 </svg>
             </button>
 
-            @include('livewire.chat.partials.chat-memo-tab-toggle')
+            <button type="button" @click="showMemoDocumentPanel()" class="inline-flex items-center gap-1.5 rounded-[10px] border border-stone-200/70 px-2.5 py-2 text-[11px] font-semibold text-stone-600 transition hover:bg-[#F1F5F9] dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 lg:hidden" aria-label="Buka panel dokumen memo">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414A1 1 0 0 1 19 9.414V19a2 2 0 0 1-2 2Z" />
+                </svg>
+                <span>Dokumen</span>
+            </button>
         </div>
     </div>
 

--- a/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
+++ b/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
@@ -11,8 +11,8 @@
 >
 
     {{-- Header with sidebar toggle, brand, tab toggle, and theme toggle --}}
-    <div class="h-[61px] flex-shrink-0 flex items-center justify-between gap-2 px-3 sm:px-6 z-20 border-b border-stone-200/70 dark:border-[#1E293B]/70 backdrop-blur-sm">
-        <div class="flex min-w-0 items-center gap-2">
+    <div class="h-[61px] flex-shrink-0 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 px-3 sm:px-6 z-20 border-b border-stone-200/70 dark:border-[#1E293B]/70 backdrop-blur-sm">
+        <div class="flex min-w-0 items-center gap-2 justify-self-start">
             <button type="button" @click="showMemoSidebar = !showMemoSidebar" class="p-2 rounded-[10px] hover:bg-[#F1F5F9] dark:hover:bg-gray-800 transition-colors flex-shrink-0" aria-label="Toggle memo sidebar">
                 <img src="{{ asset('images/icons/collapse-left-light.svg') }}" alt="" class="h-5 w-5 dark:hidden transition-transform duration-300 ease-in-out" :class="showMemoSidebar ? 'rotate-0' : 'rotate-180'" />
                 <img src="{{ asset('images/icons/collapse-left-dark.svg') }}" alt="" class="h-5 w-5 hidden dark:block transition-transform duration-300 ease-in-out" :class="showMemoSidebar ? 'rotate-0' : 'rotate-180'" />
@@ -28,11 +28,11 @@
             </button>
         </div>
 
-        <div class="flex flex-1 items-center justify-center">
+        <div class="justify-self-center">
             @include('livewire.chat.partials.chat-memo-tab-toggle')
         </div>
 
-        <div class="ml-auto flex shrink-0 items-center gap-2">
+        <div class="flex shrink-0 items-center gap-2 justify-self-end">
             <button type="button" @click="darkMode = !darkMode" :aria-pressed="darkMode ? 'true' : 'false'" class="p-2 rounded-[10px] hover:bg-[#F1F5F9] dark:hover:bg-gray-800 transition-colors" aria-label="Toggle dark mode">
                 <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-[#64748B]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />
@@ -42,7 +42,7 @@
                 </svg>
             </button>
 
-            <button type="button" @click="showMemoDocumentPanel()" class="inline-flex items-center gap-1.5 rounded-[10px] border border-stone-200/70 px-2.5 py-2 text-[11px] font-semibold text-stone-600 transition hover:bg-[#F1F5F9] dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 lg:hidden" aria-label="Buka panel dokumen memo">
+            <button type="button" @click="showMemoDocumentPanel()" title="Dokumen" aria-label="Buka panel dokumen memo" class="inline-flex items-center gap-1.5 rounded-[10px] border border-stone-200/70 px-2.5 py-2 text-[11px] font-semibold text-stone-600 transition hover:bg-[#F1F5F9] dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 lg:hidden">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414A1 1 0 0 1 19 9.414V19a2 2 0 0 1-2 2Z" />
                 </svg>

--- a/laravel/resources/views/livewire/memos/partials/memo-preview-panel.blade.php
+++ b/laravel/resources/views/livewire/memos/partials/memo-preview-panel.blade.php
@@ -32,11 +32,11 @@
                 <button type="button" wire:click="regenerate" wire:loading.attr="disabled" wire:target="regenerate,generateRevisionFromChat,generateFromChat"
                         class="inline-flex items-center gap-1 px-2 py-1.5 sm:px-3 rounded-lg border border-stone-200 dark:border-gray-700 text-[12px] font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-800 transition-all disabled:opacity-50"
                         aria-label="Regenerate dokumen" title="Regenerate">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <span wire:loading wire:target="regenerate,generateRevisionFromChat" class="h-3.5 w-3.5 rounded-full border-2 border-current border-t-transparent animate-spin" aria-hidden="true"></span>
+                    <svg wire:loading.remove wire:target="regenerate,generateRevisionFromChat" xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                     </svg>
-                    <span wire:loading.remove wire:target="regenerate" class="hidden sm:inline">Regenerate</span>
-                    <span wire:loading wire:target="regenerate,generateRevisionFromChat" class="hidden sm:inline">...</span>
+                    <span class="hidden sm:inline">Regenerate</span>
                 </button>
                 <button type="button"
                         data-download-url="{{ route('memos.download', $memoDownloadRouteParameters) }}"

--- a/laravel/resources/views/livewire/memos/partials/memo-preview-panel.blade.php
+++ b/laravel/resources/views/livewire/memos/partials/memo-preview-panel.blade.php
@@ -2,18 +2,18 @@
 <div x-show="!isMobile || memoMobilePanel === 'document'" x-cloak class="flex-1 flex flex-col min-w-0 bg-stone-50 dark:bg-gray-950 overflow-hidden">
 
     {{-- Document Header --}}
-    <div class="relative z-30 min-h-[61px] flex-shrink-0 flex items-center justify-between gap-3 px-5 border-b border-stone-200/60 bg-white/85 backdrop-blur-sm dark:border-[#1E293B]/70 dark:bg-gray-800/85">
-        <div class="flex min-w-0 flex-wrap items-center gap-3">
-            <button type="button" @click="showMemoChatPanel()" class="inline-flex items-center justify-center rounded-lg border border-stone-200 bg-white p-2 text-stone-600 shadow-sm transition hover:bg-stone-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 lg:hidden" aria-label="Kembali ke chat memo">
+    <div class="relative z-30 min-h-[61px] flex-shrink-0 flex items-center justify-between gap-2 px-3 sm:px-5 border-b border-stone-200/60 bg-white/85 backdrop-blur-sm dark:border-[#1E293B]/70 dark:bg-gray-800/85">
+        <div class="flex min-w-0 items-center gap-2">
+            <button type="button" @click="showMemoChatPanel()" class="inline-flex items-center justify-center rounded-lg border border-stone-200 bg-white p-2 text-stone-600 shadow-sm transition hover:bg-stone-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 lg:hidden" aria-label="Kembali ke chat memo" title="Kembali">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M15 19l-7-7 7-7" />
                 </svg>
             </button>
-            <div class="inline-flex items-center gap-1.5 rounded-lg border border-stone-200 bg-white px-3 py-1.5 text-[12.5px] font-semibold text-stone-800 shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200">
+            <div class="inline-flex items-center gap-1.5 rounded-lg border border-stone-200 bg-white px-2.5 py-1 text-[12.5px] font-semibold text-stone-800 shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                 </svg>
-                Dokumen
+                <span class="hidden sm:inline">Dokumen</span>
             </div>
         </div>
 
@@ -26,16 +26,17 @@
                 ], fn ($value) => filled($value));
             @endphp
             <div
-                class="flex flex-shrink-0 items-center gap-2"
+                class="flex flex-shrink-0 items-center gap-1.5 sm:gap-2"
                 x-data="memoDocumentDownloads"
             >
                 <button type="button" wire:click="regenerate" wire:loading.attr="disabled" wire:target="regenerate,generateRevisionFromChat,generateFromChat"
-                        class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-stone-200 dark:border-gray-700 text-[12px] font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-800 transition-all disabled:opacity-50">
+                        class="inline-flex items-center gap-1 px-2 py-1.5 sm:px-3 rounded-lg border border-stone-200 dark:border-gray-700 text-[12px] font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-800 transition-all disabled:opacity-50"
+                        aria-label="Regenerate dokumen" title="Regenerate">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                     </svg>
-                    <span wire:loading.remove wire:target="regenerate">Regenerate</span>
-                    <span wire:loading wire:target="regenerate,generateRevisionFromChat">...</span>
+                    <span wire:loading.remove wire:target="regenerate" class="hidden sm:inline">Regenerate</span>
+                    <span wire:loading wire:target="regenerate,generateRevisionFromChat" class="hidden sm:inline">...</span>
                 </button>
                 <button type="button"
                         data-download-url="{{ route('memos.download', $memoDownloadRouteParameters) }}"
@@ -45,12 +46,13 @@
                         wire:loading.attr="disabled"
                         wire:target="switchMemoVersion,generateRevisionFromChat,generateFromChat,generateConfiguredMemo"
                         :disabled="downloadLoading !== null"
-                        class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-stone-200 dark:border-gray-700 text-[12px] font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-800 transition-all disabled:cursor-not-allowed disabled:opacity-60">
+                        class="inline-flex items-center gap-1 px-2 py-1.5 sm:px-3 rounded-lg border border-stone-200 dark:border-gray-700 text-[12px] font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-800 transition-all disabled:cursor-not-allowed disabled:opacity-60"
+                        aria-label="Unduh DOCX" title="Unduh DOCX">
                     <span x-show="downloadLoading === 'docx'" style="display:none;" class="h-3.5 w-3.5 rounded-full border-2 border-current border-t-transparent animate-spin" aria-hidden="true"></span>
                     <svg x-show="downloadLoading !== 'docx'" xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                     </svg>
-                    DOCX
+                    <span class="hidden sm:inline">DOCX</span>
                 </button>
                 <button type="button"
                         data-download-url="{{ route('memos.export.pdf', $memoDownloadRouteParameters) }}"
@@ -60,12 +62,13 @@
                         wire:loading.attr="disabled"
                         wire:target="switchMemoVersion,generateRevisionFromChat,generateFromChat,generateConfiguredMemo"
                         :disabled="downloadLoading !== null"
-                        class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-ista-primary text-[12px] font-semibold text-white hover:bg-ista-dark transition-all disabled:cursor-not-allowed disabled:opacity-70">
+                        class="inline-flex items-center gap-1 px-2 py-1.5 sm:px-3 rounded-lg bg-ista-primary text-[12px] font-semibold text-white hover:bg-ista-dark transition-all disabled:cursor-not-allowed disabled:opacity-70"
+                        aria-label="Unduh PDF" title="Unduh PDF">
                     <span x-show="downloadLoading === 'pdf'" style="display:none;" class="h-3.5 w-3.5 rounded-full border-2 border-white/70 border-t-transparent animate-spin" aria-hidden="true"></span>
                     <svg x-show="downloadLoading !== 'pdf'" xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                     </svg>
-                    PDF
+                    <span class="hidden sm:inline">PDF</span>
                 </button>
             </div>
         @endif

--- a/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
+++ b/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
@@ -41,7 +41,7 @@ class MemoWorkspaceTest extends TestCase
             ->assertSee('aria-label="Buat memo baru"', false)
             ->assertSee('title="Buat memo baru"', false)
             ->assertSee('bg-transparent overflow-hidden', false)
-            ->assertSee('h-[61px] flex-shrink-0 flex items-center justify-between gap-2 px-3 sm:px-6 z-20', false)
+            ->assertSee('h-[61px] flex-shrink-0 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 px-3 sm:px-6 z-20', false)
             ->assertSee('ISTA AI dapat keliru', false)
             ->assertDontSee('min-h-[61px] flex-shrink-0 flex items-center justify-between gap-2 px-3 sm:px-5 border-b border-stone-200/60 dark:border-[#1E293B]/70 bg-white/85 dark:bg-gray-800/85', false)
             ->assertDontSee('dark:bg-gray-950/85', false)


### PR DESCRIPTION
## Summary
- Closes #137
- Memindahkan toggle Chat/Memo ke tengah header tab memo dan tombol Dokumen ke pojok kanan.
- Merapikan header dokumen memo mobile dengan tombol aksi icon-only pada layar kecil dan label yang lebih ringkas.
- Menambahkan issue plan lokal di `issue/issue-memo-mobile-header-layout-2026-05-10.md`.

## Validation
- `cd laravel && npm run build` ✅
- `cd laravel && php artisan test --filter=Memo` ✅ (44 tests, 247 assertions)
- `git diff --check` ✅

## QA
- Browser QA belum dijalankan sesuai instruksi user: dilakukan hanya setelah PR dibuat.