### PR TITLE
Nonaktifkan route standalone /memos

### DIFF
--- a/issue/issue-disable-standalone-memos-route-2026-05-10.md
+++ b/issue/issue-disable-standalone-memos-route-2026-05-10.md
@@ -1,0 +1,17 @@
+# Disable Standalone `/memos` Pages
+
+## Tujuan
+Memastikan semua akses halaman memo standalone di `/memos` diarahkan ke workspace memo baru di `/chat?tab=memo`, karena pengelolaan memo saat ini sudah dipusatkan di `https://ista-ai.app/chat?tab=memo`.
+
+## Scope
+- Nonaktifkan halaman user-facing `/memos`, `/memos/create`, dan `/memos/{memo}` dengan redirect ke route `chat` tab `memo`.
+- Pindahkan endpoint teknis memo yang masih dipakai workspace baru dari `/memos/...` ke `/chat/memos/...`, seperti download, export PDF, dan signed file OnlyOffice.
+- Pertahankan callback OnlyOffice yang tidak berada di `/memos`.
+- Sesuaikan test rute agar perilaku redirect baru terdokumentasi.
+
+## Risiko
+- Route name teknis tetap `memos.*` agar referensi internal tidak perlu refactor besar, tetapi path publiknya tidak lagi di bawah `/memos`.
+- Jika target akhirnya ingin menghapus seluruh backend memo lama, perlu fase lanjutan yang lebih besar karena chat memo masih memakai model dan service memo.
+
+## Verifikasi
+- Jalankan test Laravel relevan untuk dashboard, route memo, dan policy/file memo.

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -51,10 +51,11 @@ Route::middleware(['auth', 'verified'])
 
 Route::middleware(['auth', 'verified'])
     ->prefix('memos')
+    ->name('memos.')
     ->group(function () {
-        Route::redirect('/', '/chat?tab=memo')->name('memos.index');
-        Route::redirect('/create', '/chat?tab=memo')->name('memos.create');
-        Route::redirect('/{memo}', '/chat?tab=memo')->name('memos.edit');
+        Route::redirect('/', '/chat?tab=memo')->name('index');
+        Route::redirect('/create', '/chat?tab=memo')->name('create');
+        Route::redirect('/{memo}', '/chat?tab=memo')->name('edit');
         Route::redirect('/{legacyMemoPath}', '/chat?tab=memo')
             ->where('legacyMemoPath', '.*');
     });

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -6,8 +6,6 @@ use App\Http\Controllers\Documents\DocumentPreviewController;
 use App\Http\Controllers\Memos\MemoFileController;
 use App\Http\Controllers\OnlyOfficeCallbackController;
 use App\Livewire\Chat\ChatIndex;
-use App\Livewire\Memos\MemoCanvas;
-use App\Livewire\Memos\MemoIndex;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -40,18 +38,25 @@ Route::get('chat', ChatIndex::class)
 Route::post('onlyoffice/callback/{memo}', OnlyOfficeCallbackController::class)
     ->name('onlyoffice.callback');
 
-Route::get('memos/{memo}/signed-file', [MemoFileController::class, 'signed'])
+Route::get('chat/memos/{memo}/signed-file', [MemoFileController::class, 'signed'])
     ->name('memos.file.signed');
 
 Route::middleware(['auth', 'verified'])
-    ->prefix('memos')
+    ->prefix('chat/memos')
     ->name('memos.')
     ->group(function () {
-        Route::get('/', MemoIndex::class)->name('index');
-        Route::get('/create', MemoCanvas::class)->name('create');
         Route::get('/{memo}/download', [MemoFileController::class, 'download'])->name('download');
         Route::get('/{memo}/export-pdf', [MemoFileController::class, 'exportPdf'])->name('export.pdf');
-        Route::get('/{memo}', MemoCanvas::class)->name('edit');
+    });
+
+Route::middleware(['auth', 'verified'])
+    ->prefix('memos')
+    ->group(function () {
+        Route::redirect('/', '/chat?tab=memo')->name('memos.index');
+        Route::redirect('/create', '/chat?tab=memo')->name('memos.create');
+        Route::redirect('/{memo}', '/chat?tab=memo')->name('memos.edit');
+        Route::redirect('/{legacyMemoPath}', '/chat?tab=memo')
+            ->where('legacyMemoPath', '.*');
     });
 
 Route::middleware(['auth', 'verified'])

--- a/laravel/tests/Feature/Memos/MemoCanvasTest.php
+++ b/laravel/tests/Feature/Memos/MemoCanvasTest.php
@@ -76,7 +76,7 @@ class MemoCanvasTest extends TestCase
         Storage::disk('local')->assertExists($memo->file_path);
     }
 
-    public function test_canvas_forbids_non_owner(): void
+    public function test_legacy_canvas_route_redirects_to_chat_memo_tab(): void
     {
         $owner = User::factory()->create(['email_verified_at' => now()]);
         $other = User::factory()->create(['email_verified_at' => now()]);
@@ -91,7 +91,7 @@ class MemoCanvasTest extends TestCase
 
         $this->actingAs($other)
             ->get(route('memos.edit', $memo))
-            ->assertForbidden();
+            ->assertRedirect(route('chat', ['tab' => 'memo']));
     }
 
     public function test_editor_token_signs_exact_onlyoffice_config_shape(): void

--- a/laravel/tests/Feature/Memos/MemoPolicyTest.php
+++ b/laravel/tests/Feature/Memos/MemoPolicyTest.php
@@ -160,7 +160,7 @@ class MemoPolicyTest extends TestCase
         $this->assertSame('pdf', $conversionPayload['outputtype']);
         $this->assertStringStartsWith('memo-'.$memo->id.'-current-', $conversionPayload['key']);
         $this->assertStringEndsWith('-pdf', $conversionPayload['key']);
-        $this->assertStringStartsWith('http://laravel:8000/memos/'.$memo->id.'/signed-file?', $conversionPayload['url']);
+        $this->assertStringStartsWith('http://laravel:8000/chat/memos/'.$memo->id.'/signed-file?', $conversionPayload['url']);
         $this->assertSame('Memo-Test.docx', $conversionPayload['title']);
     }
 

--- a/laravel/tests/Feature/Memos/MemoRouteRedirectTest.php
+++ b/laravel/tests/Feature/Memos/MemoRouteRedirectTest.php
@@ -61,6 +61,38 @@ class MemoRouteRedirectTest extends TestCase
             ->assertRedirect(route('chat', ['tab' => 'memo']));
     }
 
+    public function test_legacy_memo_export_pdf_path_redirects_to_chat_memo_tab(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $memo = Memo::create([
+            'user_id' => $user->id,
+            'title' => 'Memo Test',
+            'memo_type' => 'memo_internal',
+            'file_path' => 'memos/'.$user->id.'/memo.docx',
+            'status' => Memo::STATUS_GENERATED,
+        ]);
+
+        $this->actingAs($user)
+            ->get('/memos/'.$memo->id.'/export-pdf')
+            ->assertRedirect(route('chat', ['tab' => 'memo']));
+    }
+
+    public function test_legacy_memo_signed_file_path_redirects_to_chat_memo_tab(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $memo = Memo::create([
+            'user_id' => $user->id,
+            'title' => 'Memo Test',
+            'memo_type' => 'memo_internal',
+            'file_path' => 'memos/'.$user->id.'/memo.docx',
+            'status' => Memo::STATUS_GENERATED,
+        ]);
+
+        $this->actingAs($user)
+            ->get('/memos/'.$memo->id.'/signed-file')
+            ->assertRedirect(route('chat', ['tab' => 'memo']));
+    }
+
     public function test_guest_standalone_memos_still_requires_login(): void
     {
         $this->get(route('memos.index'))

--- a/laravel/tests/Feature/Memos/MemoRouteRedirectTest.php
+++ b/laravel/tests/Feature/Memos/MemoRouteRedirectTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Memos;
+
+use App\Models\Memo;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MemoRouteRedirectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_standalone_memo_index_redirects_to_chat_memo_tab(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($user)
+            ->get(route('memos.index'))
+            ->assertRedirect(route('chat', ['tab' => 'memo']));
+    }
+
+    public function test_standalone_memo_create_redirects_to_chat_memo_tab(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($user)
+            ->get(route('memos.create'))
+            ->assertRedirect(route('chat', ['tab' => 'memo']));
+    }
+
+    public function test_standalone_memo_edit_redirects_to_chat_memo_tab(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $memo = Memo::create([
+            'user_id' => $user->id,
+            'title' => 'Memo Test',
+            'memo_type' => 'memo_internal',
+            'file_path' => 'memos/'.$user->id.'/memo.docx',
+            'status' => Memo::STATUS_GENERATED,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('memos.edit', $memo))
+            ->assertRedirect(route('chat', ['tab' => 'memo']));
+    }
+
+    public function test_legacy_memo_download_path_redirects_to_chat_memo_tab(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $memo = Memo::create([
+            'user_id' => $user->id,
+            'title' => 'Memo Test',
+            'memo_type' => 'memo_internal',
+            'file_path' => 'memos/'.$user->id.'/memo.docx',
+            'status' => Memo::STATUS_GENERATED,
+        ]);
+
+        $this->actingAs($user)
+            ->get('/memos/'.$memo->id.'/download')
+            ->assertRedirect(route('chat', ['tab' => 'memo']));
+    }
+
+    public function test_guest_standalone_memos_still_requires_login(): void
+    {
+        $this->get(route('memos.index'))
+            ->assertRedirect(route('login'));
+    }
+}


### PR DESCRIPTION
<!-- opencode-standardized: github-writing-standard-v1 -->
## Ringkasan
- Redirect legacy `/memos` pages and wildcard legacy memo paths to `/chat?tab=memo`.
- Move active memo file endpoints to `/chat/memos/...` while keeping internal `memos.*` route names stable.
- Add route coverage for the legacy redirects and update signed-file URL expectations.

## Perubahan Utama
| File / Area | Deskripsi |
|---|---|
| `/memos` | Disebut pada PR historis. |
| `/chat?tab=memo` | Disebut pada PR historis. |
| `/chat/memos/...` | Disebut pada PR historis. |

### Detail Perubahan
- Redirect legacy `/memos` pages and wildcard legacy memo paths to `/chat?tab=memo`.
- Move active memo file endpoints to `/chat/memos/...` while keeping internal `memos.*` route names stable.
- Add route coverage for the legacy redirects and update signed-file URL expectations.

## Validasi
- `php artisan test tests/Feature/DashboardTest.php tests/Feature/Memos/MemoRouteRedirectTest.php tests/Feature/Memos/MemoCanvasTest.php tests/Feature/Memos/MemoPolicyTest.php tests/Feature/Memos/OnlyOfficeCallbackTest.php`
- `php artisan route:list --path=memos`

Closes #142

## Deploy / QA
- Status PR: Merged
- Base branch: `main`
- Head branch: `codex/disable-standalone-memos`
- Merged at: 2026-05-10T14:52:28Z
- Closed at: 2026-05-10T14:52:28Z
- Deploy/QA tidak dicatat eksplisit pada body lama.

## Catatan / Risiko Residual
- Risiko residual tidak dicatat eksplisit pada body lama.

## Relasi Issue
- Closes #142

## Catatan Historis
<details>
<summary>Body sebelum standardisasi</summary>

## Summary
- Redirect legacy `/memos` pages and wildcard legacy memo paths to `/chat?tab=memo`.
- Move active memo file endpoints to `/chat/memos/...` while keeping internal `memos.*` route names stable.
- Add route coverage for the legacy redirects and update signed-file URL expectations.

## Why
Memo handling is now centralized in the chat memo workspace at `/chat?tab=memo`, so standalone `/memos` should no longer expose the old memo UI or file endpoints.

## Validation
- `php artisan test tests/Feature/DashboardTest.php tests/Feature/Memos/MemoRouteRedirectTest.php tests/Feature/Memos/MemoCanvasTest.php tests/Feature/Memos/MemoPolicyTest.php tests/Feature/Memos/OnlyOfficeCallbackTest.php`
- `php artisan route:list --path=memos`

Closes #142

</details>
