### PR TITLE
Hardening ownership chat, scope dokumen, dan retry processing

### DIFF
--- a/issue/issue-148-chat-security-document-retry-fix-2026-05-11.md
+++ b/issue/issue-148-chat-security-document-retry-fix-2026-05-11.md
@@ -1,0 +1,81 @@
+# Issue #148 — Harden Chat Ownership, Document Scoping, and Processing Retries
+
+## Latar Belakang
+
+GitHub issue #148 melaporkan tiga temuan audit pada alur chat dan pemrosesan dokumen:
+
+1. `sendMessage()` dapat memakai `currentConversationId` dari public Livewire state tanpa verifikasi ownership conversation.
+2. `conversationDocuments` dari client diteruskan ke service dan query dokumen tidak di-scope ulang berdasarkan user/status server-side.
+3. `ProcessDocument` mendefinisikan retry queue tetapi `handle()` menangkap exception dan tidak melempar ulang sehingga retry tidak berjalan.
+
+Audit ulang oleh sub-agent read-only dan security reviewer mengonfirmasi ketiga temuan valid.
+
+## Tujuan
+
+- Mencegah user menulis pesan ke conversation milik user lain.
+- Memastikan dokumen chat yang dikirim ke AI/RAG hanya dokumen milik user aktif dan berstatus `ready`.
+- Mengaktifkan retry queue untuk kegagalan transient pada `ProcessDocument`, serta tetap menandai dokumen `error` setelah retry habis.
+- Menambahkan/menyesuaikan test Laravel agar perilaku security dan retry tertutup regresi.
+
+## Ruang Lingkup
+
+- Perbaikan Laravel pada service chat dan job pemrosesan dokumen.
+- Test feature/unit relevan untuk chat ownership, document scoping, dan retry `ProcessDocument`.
+- Validasi Laravel test dan build frontend bila diperlukan.
+- Membuat branch kerja dan PR yang mereferensikan GitHub issue #148.
+
+## Di Luar Scope
+
+- Perubahan UI besar pada halaman chat.
+- Perubahan protokol API Python/RAG di luar kebutuhan payload dokumen yang sudah tersaring.
+- Perubahan database/migration baru.
+- Merge otomatis PR tanpa persetujuan eksplisit user.
+
+## Area / File Terkait
+
+- `laravel/app/Services/ChatOrchestrationService.php`
+- `laravel/app/Livewire/Chat/ChatIndex.php` bila perlu penyesuaian error handling Livewire.
+- `laravel/app/Jobs/ProcessDocument.php`
+- `laravel/tests/Feature/Chat/ChatUiTest.php` atau test chat terkait.
+- `laravel/tests/Feature/Jobs/ProcessDocumentTest.php`
+
+## Risiko
+
+- `abort(403)` / `AuthorizationException` di Livewire action perlu diverifikasi agar tidak membuat UX chat rusak untuk owner valid.
+- Perubahan retry job bisa membuat status dokumen tetap `processing` selama retry berjalan; ini intentional agar tidak menjadi `error` prematur.
+- Kegagalan permanen seperti file hilang sebaiknya tidak retry tanpa batas; perlu tetap ditangani sebagai `error` langsung atau failure final yang jelas.
+- Test lama yang mengharapkan HTTP 500 langsung menjadi `error` harus diperbarui karena perilaku tersebut adalah bug yang diperbaiki.
+
+## Langkah Implementasi
+
+1. Buat branch kerja `codex/issue-148-chat-security-retry` dari `main`.
+2. Di `ChatOrchestrationService`, verifikasi conversation existing dengan `whereKey($id)->where('user_id', Auth::id())`; jika tidak valid, fail closed dengan authorization error.
+3. Di query dokumen chat, filter ulang `user_id = Auth::id()` dan `status = ready` sebelum mengambil filename.
+4. Di `ProcessDocument`, jangan telan exception transient; rethrow agar queue retry berjalan, dan gunakan `failed()` untuk status `error` setelah retry habis. Pertahankan handling failure permanen bila file tidak ditemukan.
+5. Tambah/update test untuk:
+   - user B tidak bisa mengirim pesan ke conversation user A;
+   - dokumen user lain atau belum `ready` tidak masuk payload dokumen;
+   - HTTP/Python service failure melempar exception agar retry queue aktif;
+   - `failed()` menandai dokumen `error`.
+6. Jalankan test relevan dan readiness checks sebelum commit/PR.
+
+## Rencana Test
+
+- `cd laravel && php artisan test --filter=ChatUiTest`
+- `cd laravel && php artisan test --filter=ChatOrchestrationServiceTest` bila file test ada/ditambahkan.
+- `cd laravel && php artisan test --filter=ProcessDocumentTest`
+- `cd laravel && php artisan test`
+- `cd laravel && npm run build` bila perubahan menyentuh asset/frontend atau sebagai readiness build.
+- Final verification sesuai `AGENTS.md` setelah review bersih:
+  - `cd laravel && php artisan test`
+  - `cd python-ai && source venv/bin/activate && pytest`
+
+## Kriteria Selesai
+
+- Ketiga finding issue #148 telah diperbaiki atau didokumentasikan bila ada bagian yang tidak valid.
+- Test baru/terupdate membuktikan ownership, document scoping, dan retry behavior.
+- Validasi relevan lulus.
+- Branch kerja sudah dipush dan PR dibuat dengan referensi `Closes #148` atau link issue #148.
+- Preview `https://ista-ai.app` dideploy dari commit PR terbaru.
+- PR review loop dan QC final tidak menemukan blocker.
+- Tidak ada merge tanpa approval eksplisit user.

--- a/laravel/app/Jobs/ProcessDocument.php
+++ b/laravel/app/Jobs/ProcessDocument.php
@@ -3,7 +3,6 @@
 namespace App\Jobs;
 
 use App\Models\Document;
-use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Queue\Queueable;
@@ -40,9 +39,8 @@ class ProcessDocument implements ShouldQueue
      */
     public function handle(): void
     {
-        try {
-            // 1. Update status to processing
-            $this->document->update(['status' => 'processing']);
+        // 1. Update status to processing
+        $this->document->update(['status' => 'processing']);
 
             // 2. Prepare file - Try both private and public paths
             $filePath = Storage::disk('local')->path($this->document->file_path);
@@ -52,9 +50,12 @@ class ProcessDocument implements ShouldQueue
                 $filePath = Storage::disk('local')->path('private/'.$this->document->file_path);
             }
 
-            if (! file_exists($filePath)) {
-                throw new Exception("File not found. Tried: {$this->document->file_path} and private/{$this->document->file_path}");
-            }
+        if (! file_exists($filePath)) {
+            $this->document->update(['status' => 'error']);
+            logger()->error("Document processing failed for ID {$this->document->id}: File not found. Tried: {$this->document->file_path} and private/{$this->document->file_path}");
+
+            return;
+        }
 
             // 3. Send to Python Microservice (with extended timeout for embedding)
             $pythonUrl = rtrim((string) config('services.ai_document_service.url', config('services.ai_service.url', 'http://127.0.0.1:8001')), '/')
@@ -74,28 +75,22 @@ class ProcessDocument implements ShouldQueue
                     'user_id' => (string) $this->document->user_id,
                 ]);
 
-            if ($response->successful()) {
-                // 4. Update status to ready
-                $this->document->update(['status' => 'ready']);
+        if ($response->successful()) {
+            // 4. Update status to ready
+            $this->document->update(['status' => 'ready']);
 
                 // 5. Dispatch preview rendering job as a fallback if the
                 // eager upload-time dispatch has not already completed it.
-                try {
-                    $freshDocument = $this->document->fresh();
-                    if ($freshDocument !== null && $freshDocument->preview_status !== Document::PREVIEW_STATUS_READY) {
-                        RenderDocumentPreview::dispatch($freshDocument);
-                    }
-                } catch (\Throwable $e) {
-                    logger()->warning("Preview dispatch failed for document {$this->document->id}, proceeding: ".$e->getMessage());
+            try {
+                $freshDocument = $this->document->fresh();
+                if ($freshDocument !== null && $freshDocument->preview_status !== Document::PREVIEW_STATUS_READY) {
+                    RenderDocumentPreview::dispatch($freshDocument);
                 }
-            } else {
-                throw new Exception('Microservice error: '.$response->body());
+            } catch (\Throwable $e) {
+                logger()->warning("Preview dispatch failed for document {$this->document->id}, proceeding: ".$e->getMessage());
             }
-
-        } catch (Exception $e) {
-            $this->document->update(['status' => 'error']);
-            // Log the error
-            logger()->error("Document processing failed for ID {$this->document->id}: ".$e->getMessage());
+        } else {
+            throw new \RuntimeException('Microservice error: '.$response->body());
         }
     }
 

--- a/laravel/app/Jobs/ProcessDocument.php
+++ b/laravel/app/Jobs/ProcessDocument.php
@@ -57,6 +57,14 @@ class ProcessDocument implements ShouldQueue
             return;
         }
 
+        $fileContent = file_get_contents($filePath);
+        if ($fileContent === false) {
+            $this->document->update(['status' => 'error']);
+            logger()->error("Document processing failed for ID {$this->document->id}: unable to read file");
+
+            return;
+        }
+
             // 3. Send to Python Microservice (with extended timeout for embedding)
             $pythonUrl = rtrim((string) config('services.ai_document_service.url', config('services.ai_service.url', 'http://127.0.0.1:8001')), '/')
                 .'/api/documents/process';
@@ -68,7 +76,7 @@ class ProcessDocument implements ShouldQueue
                 ])
                 ->attach(
                     'file',
-                    file_get_contents($filePath),
+                    $fileContent,
                     $this->document->original_name
                 )
                 ->post($pythonUrl, [

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Conversation;
 use App\Models\Message;
 use App\Models\Document;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Auth;
 
 class ChatOrchestrationService
@@ -27,6 +28,14 @@ class ChatOrchestrationService
                 'title' => substr($prompt, 0, 50) . '...'
             ]);
             return $conversation->id;
+        }
+
+        $ownedConversationExists = Conversation::where('id', $currentConversationId)
+            ->where('user_id', Auth::id())
+            ->exists();
+
+        if (! $ownedConversationExists) {
+            throw new AuthorizationException('Unauthorized conversation access.');
         }
 
         return $currentConversationId;
@@ -60,9 +69,13 @@ class ChatOrchestrationService
             return null;
         }
 
-        return Document::whereIn('id', $conversationDocuments)
+        $filenames = Document::whereIn('id', $conversationDocuments)
+            ->where('user_id', Auth::id())
+            ->where('status', 'ready')
             ->pluck('original_name')
             ->toArray();
+
+        return empty($filenames) ? null : $filenames;
     }
 
     public function getSourcePolicy(?array $documentFilenames): string

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -8,7 +8,9 @@ use App\Models\Document;
 use App\Models\Message;
 use App\Models\User;
 use App\Services\AIService;
+use App\Services\ChatOrchestrationService;
 use App\Services\DocumentExportService;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\RateLimiter;
@@ -47,6 +49,74 @@ class ChatUiTest extends TestCase
             ->set('prompt', 'Halo')
             ->call('sendMessage')
             ->assertHasErrors(['rate_limit']);
+    }
+
+    public function test_create_conversation_if_needed_throws_for_unowned_conversation(): void
+    {
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        $conversation = Conversation::create([
+            'user_id' => $userA->id,
+            'title' => 'Owned by A',
+        ]);
+
+        $service = new ChatOrchestrationService();
+
+        $this->actingAs($userB);
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('Unauthorized conversation access.');
+
+        $service->createConversationIfNeeded($conversation->id, 'Prompt dari user B');
+    }
+
+    public function test_get_document_filenames_scopes_owned_and_ready_documents_only(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $ownedReady = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'owned-ready.pdf',
+            'original_name' => 'owned-ready.pdf',
+            'file_path' => 'documents/'.$user->id.'/owned-ready.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 100,
+            'status' => 'ready',
+        ]);
+
+        $ownedProcessing = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'owned-processing.pdf',
+            'original_name' => 'owned-processing.pdf',
+            'file_path' => 'documents/'.$user->id.'/owned-processing.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 100,
+            'status' => 'processing',
+        ]);
+
+        $otherReady = Document::create([
+            'user_id' => $otherUser->id,
+            'filename' => 'other-ready.pdf',
+            'original_name' => 'other-ready.pdf',
+            'file_path' => 'documents/'.$otherUser->id.'/other-ready.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 100,
+            'status' => 'ready',
+        ]);
+
+        $service = new ChatOrchestrationService();
+
+        $this->actingAs($user);
+
+        $result = $service->getDocumentFilenames([
+            $ownedReady->id,
+            $ownedProcessing->id,
+            $otherReady->id,
+        ]);
+
+        $this->assertSame(['owned-ready.pdf'], $result);
+        $this->assertNull($service->getDocumentFilenames([$ownedProcessing->id, $otherReady->id]));
     }
 
     public function test_send_message_rejects_prompt_over_8000_chars_before_rate_limit_or_ai_call(): void

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -138,6 +138,37 @@ class ChatUiTest extends TestCase
             ->assertHasErrors(['prompt' => 'max']);
     }
 
+    public function test_send_message_does_not_persist_message_for_unauthorized_conversation(): void
+    {
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        $conversationA = Conversation::create([
+            'user_id' => $userA->id,
+            'title' => 'Owned by user A',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(array $messages, ?array $document_filenames = null, ?string $user_id = null, bool $force_web_search = false, ?string $source_policy = null, bool $allow_auto_realtime_web = true): \Generator
+            {
+                throw new \RuntimeException('AIService should not be called for unauthorized conversation access.');
+            }
+        });
+
+        Livewire::actingAs($userB)
+            ->test(ChatIndex::class)
+            ->set('currentConversationId', $conversationA->id)
+            ->set('prompt', 'Pesan tidak berizin')
+            ->call('sendMessage');
+
+        $this->assertDatabaseMissing('messages', [
+            'conversation_id' => $conversationA->id,
+            'content' => 'Pesan tidak berizin',
+        ]);
+        $this->assertCount(0, Message::where('conversation_id', $conversationA->id)->get());
+    }
+
     public function test_save_answer_to_google_drive_rate_limited_returns_error_before_export_service_call(): void
     {
         $user = User::factory()->create();

--- a/laravel/tests/Feature/Jobs/ProcessDocumentTest.php
+++ b/laravel/tests/Feature/Jobs/ProcessDocumentTest.php
@@ -78,8 +78,6 @@ class ProcessDocumentTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Microservice error:');
         $job->handle();
-
-        Http::assertSent(fn ($request) => $request->url() === 'http://python-ai-docs:8002/api/documents/process');
     }
 
     public function test_failed_method_sets_document_status_to_error(): void

--- a/laravel/tests/Feature/Jobs/ProcessDocumentTest.php
+++ b/laravel/tests/Feature/Jobs/ProcessDocumentTest.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
-use Exception;
 
 class ProcessDocumentTest extends TestCase
 {
@@ -52,7 +51,7 @@ class ProcessDocumentTest extends TestCase
         });
     }
 
-    public function test_job_updates_status_to_error_on_http_failure(): void
+    public function test_job_throws_runtime_exception_on_http_failure(): void
     {
         Storage::fake('local');
         config()->set('services.ai_document_service.url', 'http://python-ai-docs:8002');
@@ -76,10 +75,31 @@ class ProcessDocumentTest extends TestCase
         ]);
 
         $job = new ProcessDocument($document);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Microservice error:');
         $job->handle();
 
-        $this->assertEquals('error', $document->fresh()->status);
         Http::assertSent(fn ($request) => $request->url() === 'http://python-ai-docs:8002/api/documents/process');
+    }
+
+    public function test_failed_method_sets_document_status_to_error(): void
+    {
+        $user = User::factory()->create();
+
+        $document = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'failed-callback.pdf',
+            'original_name' => 'failed-callback.pdf',
+            'file_path' => 'documents/' . $user->id . '/failed-callback.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 123,
+            'status' => 'processing',
+        ]);
+
+        $job = new ProcessDocument($document);
+        $job->failed(new \RuntimeException('permanent failure'));
+
+        $this->assertSame('error', $document->fresh()->status);
     }
 
     public function test_job_updates_status_to_error_if_file_missing(): void


### PR DESCRIPTION
<!-- opencode-standardized: github-writing-standard-v1 -->
## Ringkasan
Perbaikan tiga temuan security/reliability dari audit issue #148:

1. **Chat ownership verification** — `createConversationIfNeeded()` sekarang memverifikasi conversation existing milik `Auth::id()` sebelum menerimanya. Jika bukan milik user aktif, throw `AuthorizationException` (fail closed).

2. **Server-side document scoping** — `getDocumentFilenames()` sekarang memfilter dokumen berdasarkan `user_id = Auth::id()` dan `status = ready` di server, mencegah ID dokumen user lain atau dokumen belum siap masuk ke payload AI/RAG.

3. **ProcessDocument retry semantics** — Hapus `try/catch` yang menelan semua exception di `handle()`. Kegagalan transient microservice sekarang melempar `RuntimeException` agar queue retry berjalan. Status `error` final dipindahkan ke `failed()` setelah retry habis. File-not-found tetap ditangani sebagai permanent failure tanpa retry.

## Perubahan Utama
| File / Area | Deskripsi |
|---|---|
| `laravel/app/Services/ChatOrchestrationService.php` | Disebut pada PR historis. |
| `laravel/app/Jobs/ProcessDocument.php` | Disebut pada PR historis. |
| `laravel/tests/Feature/Chat/ChatUiTest.php` | Disebut pada PR historis. |
| `laravel/tests/Feature/Jobs/ProcessDocumentTest.php` | Disebut pada PR historis. |
| `issue/issue-148-chat-security-document-retry-fix-2026-05-11.md` | Disebut pada PR historis. |

### Detail Perubahan
Perbaikan tiga temuan security/reliability dari audit issue #148:

1. **Chat ownership verification** — `createConversationIfNeeded()` sekarang memverifikasi conversation existing milik `Auth::id()` sebelum menerimanya. Jika bukan milik user aktif, throw `AuthorizationException` (fail closed).

2. **Server-side document scoping** — `getDocumentFilenames()` sekarang memfilter dokumen berdasarkan `user_id = Auth::id()` dan `status = ready` di server, mencegah ID dokumen user lain atau dokumen belum siap masuk ke payload AI/RAG.

3. **ProcessDocument retry semantics** — Hapus `try/catch` yang menelan semua exception di `handle()`. Kegagalan transient microservice sekarang melempar `RuntimeException` agar queue retry berjalan. Status `error` final dipindahkan ke `failed()` setelah retry habis. File-not-found tetap ditangani sebagai permanent failure tanpa retry.

## Validasi
- Body historis tidak mencatat command validasi spesifik.

## Deploy / QA
- Status PR: Merged
- Base branch: `main`
- Head branch: `codex/issue-148-chat-security-retry`
- Merged at: 2026-05-11T13:45:50Z
- Closed at: 2026-05-11T13:45:50Z
- Deploy/QA tidak dicatat eksplisit pada body lama.

## Catatan / Risiko Residual
- Risiko residual tidak dicatat eksplisit pada body lama.

## Relasi Issue
- Closes #148

## Catatan Historis
<details>
<summary>Body sebelum standardisasi</summary>

## Ringkasan

Perbaikan tiga temuan security/reliability dari audit issue #148:

1. **Chat ownership verification** — `createConversationIfNeeded()` sekarang memverifikasi conversation existing milik `Auth::id()` sebelum menerimanya. Jika bukan milik user aktif, throw `AuthorizationException` (fail closed).

2. **Server-side document scoping** — `getDocumentFilenames()` sekarang memfilter dokumen berdasarkan `user_id = Auth::id()` dan `status = ready` di server, mencegah ID dokumen user lain atau dokumen belum siap masuk ke payload AI/RAG.

3. **ProcessDocument retry semantics** — Hapus `try/catch` yang menelan semua exception di `handle()`. Kegagalan transient microservice sekarang melempar `RuntimeException` agar queue retry berjalan. Status `error` final dipindahkan ke `failed()` setelah retry habis. File-not-found tetap ditangani sebagai permanent failure tanpa retry.

## File yang diubah

- `laravel/app/Services/ChatOrchestrationService.php`
- `laravel/app/Jobs/ProcessDocument.php`
- `laravel/tests/Feature/Chat/ChatUiTest.php`
- `laravel/tests/Feature/Jobs/ProcessDocumentTest.php`
- `issue/issue-148-chat-security-document-retry-fix-2026-05-11.md`

## Verifikasi

- `php artisan test` → **220 passed, 0 failed**
- Test baru: `create_conversation_if_needed_throws_for_unowned_conversation`, `get_document_filenames_scopes_owned_and_ready_documents_only`, `job_throws_runtime_exception_on_http_failure`, `failed_method_sets_document_status_to_error`

Closes #148

</details>
