### PR TITLE
Optimize ISTA AI response latency

### DIFF
--- a/issue/issue-percepat-respon-ista-ai-2026-05-11.md
+++ b/issue/issue-percepat-respon-ista-ai-2026-05-11.md
@@ -74,3 +74,17 @@ Analisis awal menunjukkan beberapa bottleneck berbasis kode:
 - PR dibuat, dideploy ke `https://ista-ai.app`, dan browser QA pasca-deploy selesai.
 - Review/QC tidak menemukan blocker.
 - Full final verification Laravel dan Python dijalankan sebelum meminta approval merge.
+
+## Follow-up Sebelum Merge: Navigasi Saat Chat Loading
+
+### Masalah
+User masih tidak bisa membuat chat baru atau pindah ke history chat lain ketika request chat sedang loading, baik chat biasa, RAG dokumen, maupun web search. Perilaku yang diinginkan adalah navigasi history/new chat tetap responsif walaupun proses AI untuk percakapan sebelumnya masih berjalan.
+
+### Scope Tambahan
+- Perbaiki mekanisme UI/Livewire chat history agar tombol New Chat dan history tidak terkunci oleh proses streaming chat yang lama.
+- Pastikan perpindahan history tidak merusak penyimpanan jawaban AI untuk percakapan asal.
+- Tambahkan test Laravel/JS-relevan bila memungkinkan untuk mencegah regresi.
+
+### Risiko Tambahan
+- Livewire request panjang dapat mengantre action lain pada komponen yang sama; fix harus menghindari kehilangan pesan atau menyimpan assistant response ke conversation yang salah.
+- Jika navigasi dilakukan via full page reload, proses streaming yang sedang berjalan bisa dibatalkan di browser; perlu memastikan data server tetap konsisten atau UX-nya jelas.

--- a/issue/issue-percepat-respon-ista-ai-2026-05-11.md
+++ b/issue/issue-percepat-respon-ista-ai-2026-05-11.md
@@ -1,0 +1,76 @@
+# Percepat Respon ISTA AI Tanpa Menurunkan Kualitas
+
+## Latar Belakang
+Respon ISTA AI saat ini masih terasa lambat pada tiga jalur utama: chat biasa, membaca dokumen/RAG, dan web search. Kelambatan pada jalur dokumen sebagian wajar karena proses chunking/retrieval perlu menjaga ketepatan, tetapi chat biasa dan web search juga perlu terasa lebih responsif tanpa mengurangi kualitas jawaban yang sudah ada.
+
+Analisis awal menunjukkan beberapa bottleneck berbasis kode:
+- Jalur dokumen masih memakai retrieval subprocess per request melalui `python-ai/app/retrieval_runner.py`, sehingga ada overhead spawn process dan import dependency berat sebelum token pertama bisa dikirim.
+- Jalur dokumen + web search melakukan retrieval dokumen lalu web search secara serial, padahal keduanya independen.
+- Jalur web search memakai request HTTP sinkron dan cache in-memory yang masih sederhana.
+- Jalur LLM streaming memakai cascade model sinkron; timeout/fallback yang terlalu longgar dapat memperpanjang waktu tunggu saat provider lambat.
+
+## Tujuan
+- Mempercepat time-to-first-byte dan total response time untuk chat biasa, dokumen/RAG, dan web search.
+- Menjaga kualitas jawaban dokumen dengan tetap mempertahankan rerank/HyDE/fallback penting secara selektif, bukan mematikannya secara agresif.
+- Membuat optimasi bertahap yang aman, terukur, dan mudah direview.
+- Menambahkan/menyesuaikan test untuk memastikan jalur kualitas dan fallback tetap berjalan.
+
+## Ruang Lingkup
+- Optimasi jalur Python AI yang memengaruhi `/api/chat`.
+- Optimasi retrieval dokumen agar mengurangi overhead blocking/subprocess bila aman.
+- Parallelisasi pekerjaan independen seperti retrieval dokumen dan web context ketika keduanya dibutuhkan.
+- Perbaikan cache/timeout yang aman untuk web search dan model cascade.
+- Test Python relevan untuk retrieval runner, chat routing, web search/cache, dan streaming/fallback.
+- Validasi Laravel/Python yang relevan karena Laravel memanggil service Python untuk chat streaming.
+
+## Di Luar Scope
+- Mengubah kualitas prompt utama, persona ISTA AI, atau gaya jawaban secara besar.
+- Mematikan total rerank, HyDE, retrieval, atau web search demi kecepatan.
+- Mengganti provider/model utama secara besar tanpa evaluasi kualitas.
+- Refactor arsitektur besar lintas Laravel/Python yang tidak diperlukan untuk optimasi awal.
+- Perubahan database/migration produksi.
+
+## Area / File Terkait
+- `python-ai/app/chat_api.py`: entry point `/api/chat`, policy web search, jalur dokumen, dan streaming response.
+- `python-ai/app/retrieval_runner.py`: wrapper retrieval dokumen yang saat ini memakai subprocess.
+- `python-ai/app/retrieval_tasks.py`: target CLI retrieval yang dapat menjadi kandidat reuse in-process.
+- `python-ai/app/services/rag_retrieval.py`: search chunk dokumen, vector search, hybrid/rerank/HYDE.
+- `python-ai/app/services/rag_policy.py`: policy web search dan `get_context_for_query`.
+- `python-ai/app/services/langsearch_service.py`: web search, rerank, timeout, cache.
+- `python-ai/app/services/llm_streaming.py`: LLM streaming, model cascade, timeout/fallback.
+- `python-ai/app/llm_manager.py`: penggabungan konteks web/RAG dan pemanggilan streaming.
+- `python-ai/tests/*`: test Python untuk routing, retrieval, policy, streaming, dan cache.
+- `laravel/app/Services/AIService.php`: Laravel client untuk Python AI; kemungkinan hanya validasi integrasi/timeout, bukan target utama.
+
+## Risiko
+- In-process retrieval dapat mengubah karakteristik memory/concurrency dibanding subprocess. Jika tidak aman, perlu fallback ke subprocess.
+- Parallelisasi dapat memunculkan race condition pada cache/service singleton bila tidak diberi guard.
+- Timeout yang terlalu agresif dapat membuat fallback ke model lebih lemah dan menurunkan kualitas jawaban kompleks.
+- Mengurangi kandidat rerank atau skip HyDE terlalu agresif dapat menurunkan akurasi dokumen.
+- Optimasi latency tanpa benchmark/logging bisa sulit dibuktikan; minimal perlu test perilaku dan ringkasan area yang dipercepat.
+
+## Langkah Implementasi
+1. Petakan jalur aktual chat biasa, dokumen, dan web search dari kode serta pilih slice optimasi dengan dampak tinggi dan risiko terkendali.
+2. Tambahkan jalur retrieval yang mengurangi overhead subprocess secara aman, dengan fallback config/env ke subprocess jika in-process bermasalah.
+3. Parallelkan retrieval dokumen dan web context pada `chat_api.py` hanya saat keduanya dibutuhkan, sambil menjaga output prompt/sources tetap sama.
+4. Perkuat cache/thread-safety web search dan hindari network call yang tidak perlu untuk query yang sudah cache hit.
+5. Sesuaikan timeout/cascade secara konservatif melalui config/env bila tersedia, tanpa memaksa fallback terlalu cepat.
+6. Tambahkan atau update test untuk jalur dokumen, web search, cache, dan fallback agar kualitas tidak turun.
+7. Jalankan validasi Python dan Laravel relevan, lalu lakukan PR review loop dan deploy preview sesuai workflow.
+
+## Rencana Test
+- `cd python-ai && source venv/bin/activate && pytest` atau subset relevan lebih dulu seperti:
+  - `pytest tests/test_retrieval_runner.py`
+  - `pytest tests/test_app_routing.py`
+  - `pytest tests/test_llm_streaming.py`
+  - test baru/terkait untuk `langsearch_service` atau `rag_policy` bila ditambahkan.
+- `cd laravel && php artisan test` atau subset Laravel relevan bila file Laravel tersentuh.
+- `git diff --check` sebelum commit.
+- Setelah PR dibuat dan branch dideploy ke `https://ista-ai.app`, jalankan browser QA pada chat biasa, chat dengan dokumen, dan web search.
+
+## Kriteria Selesai
+- Jalur chat biasa, dokumen/RAG, dan web search memiliki optimasi latency yang aman tanpa menghapus fitur kualitas utama.
+- Test relevan ditambahkan/diupdate dan lulus.
+- PR dibuat, dideploy ke `https://ista-ai.app`, dan browser QA pasca-deploy selesai.
+- Review/QC tidak menemukan blocker.
+- Full final verification Laravel dan Python dijalankan sebelum meminta approval merge.

--- a/issue/issue-pr152-background-chat-requests-2026-05-12.md
+++ b/issue/issue-pr152-background-chat-requests-2026-05-12.md
@@ -56,3 +56,8 @@ Saat user mengirim pesan lalu berpindah ke history chat lain atau New Chat, tamp
 - New Chat langsung muncul di history saat prompt dikirim.
 - Conversation pending menampilkan loading bubble saat dibuka.
 - Verifikasi relevan berhasil.
+
+## Follow-up: Completion Indicator Sidebar
+- Spinner pending di sidebar harus berhenti ketika jawaban background sudah tersimpan.
+- Conversation yang selesai diproses diberi titik biru sampai user membuka history tersebut.
+- Spinner sidebar harus berukuran bulat konsisten walaupun judul history panjang.

--- a/issue/issue-pr152-background-chat-requests-2026-05-12.md
+++ b/issue/issue-pr152-background-chat-requests-2026-05-12.md
@@ -61,3 +61,4 @@ Saat user mengirim pesan lalu berpindah ke history chat lain atau New Chat, tamp
 - Spinner pending di sidebar harus berhenti ketika jawaban background sudah tersimpan.
 - Conversation yang selesai diproses diberi titik biru sampai user membuka history tersebut.
 - Spinner sidebar harus berukuran bulat konsisten walaupun judul history panjang.
+- Titik biru hanya muncul jika user sedang tidak berada di conversation yang selesai diproses.

--- a/issue/issue-pr152-background-chat-requests-2026-05-12.md
+++ b/issue/issue-pr152-background-chat-requests-2026-05-12.md
@@ -1,0 +1,58 @@
+# PR 152 - Background Chat Requests
+
+## Latar Belakang
+Saat user mengirim pesan lalu berpindah ke history chat lain atau New Chat, tampilan chat aktif masih dapat tertahan di loading bubble request sebelumnya. Ini terjadi karena proses AI masih dijalankan sebagai request Livewire panjang pada komponen chat yang sama.
+
+## Tujuan
+- User dapat berpindah antar history chat atau New Chat saat request AI masih berjalan.
+- Request yang berjalan tetap terlihat sebagai loading kecil di sidebar kiri pada conversation asal.
+- New Chat yang dikirim langsung membuat item history baru sebelum jawaban AI selesai.
+- Conversation yang sedang diproses tetap menampilkan loading bubble saat dibuka kembali sampai jawaban selesai.
+
+## Ruang Lingkup
+- Ubah pengiriman pesan chat agar request AI diproses sebagai pekerjaan background.
+- Simpan user message dan conversation secara cepat sebelum proses AI dimulai.
+- Tambahkan pending state per conversation untuk sidebar dan polling ringan.
+- Refresh conversation aktif ketika jawaban background sudah tersimpan.
+
+## Di Luar Scope
+- Streaming token realtime lintas tab/history.
+- Cancel request AI.
+- Multi-request paralel dalam conversation yang sama.
+- Perubahan besar desain UI chat.
+
+## Area / File Terkait
+- `laravel/app/Livewire/Chat/ChatIndex.php`
+- `laravel/app/Jobs/GenerateChatResponse.php`
+- `laravel/resources/js/chat-page.js`
+- `laravel/resources/views/livewire/chat/partials/chat-left-sidebar.blade.php`
+- `laravel/resources/views/livewire/chat/partials/chat-messages.blade.php`
+- `laravel/resources/views/livewire/chat/chat-index.blade.php`
+- `laravel/tests/Feature/Chat/ChatUiTest.php`
+
+## Risiko
+- Perlu memastikan queue production memproses job chat cukup lama untuk AI timeout.
+- Polling harus ringan dan hanya aktif saat ada conversation pending.
+- Pending lama akibat job gagal harus diselesaikan dengan assistant error message agar spinner tidak menggantung.
+
+## Langkah Implementasi
+1. Tambahkan job background untuk memanggil AI service dan menyimpan assistant message ke conversation asal.
+2. Ubah `sendMessage` agar hanya membuat conversation/user message, dispatch job, reload history, dan selesai cepat.
+3. Tambahkan pending conversation ids berdasarkan latest message role user.
+4. Tambahkan polling saat ada pending conversation untuk refresh sidebar dan conversation aktif.
+5. Sesuaikan JS sidebar agar spinner pending mengikuti event per conversation.
+6. Pastikan bubble loading dipulihkan saat membuka conversation pending.
+
+## Rencana Test
+- Test `sendMessage` membuat conversation/user message, menandai pending, dan dispatch job.
+- Test user tetap bisa `loadConversation` lain setelah `sendMessage`.
+- Test refresh pending memuat assistant message ketika job selesai.
+- Test render sidebar memiliki binding pending spinner.
+- Jalankan build frontend dan test Laravel terkait chat.
+
+## Kriteria Selesai
+- Chat aktif bisa berpindah tanpa menunggu response AI.
+- Sidebar menampilkan spinner pada conversation yang masih menunggu jawaban.
+- New Chat langsung muncul di history saat prompt dikirim.
+- Conversation pending menampilkan loading bubble saat dibuka.
+- Verifikasi relevan berhasil.

--- a/issue/issue-pr152-chat-loading-regression-2026-05-12.md
+++ b/issue/issue-pr152-chat-loading-regression-2026-05-12.md
@@ -28,3 +28,13 @@
 
 ## Risiko
 - Fallback berbasis waktu bisa menampilkan bubble loading pada pesan user yang gagal diproses jika masih sangat baru. TTL dibuat terbatas agar tidak menampilkan loading lama secara permanen.
+
+## Follow-up 2: Blink Saat Pindah History
+
+### Masalah
+Setelah global loader besar ditekan, pindah antar history chat tetap terasa blink karena klik history selalu memakai full page navigation. Sebelum PR ini, perpindahan history saat idle memakai action Livewire sehingga tidak reload satu halaman penuh.
+
+### Rencana
+- Kembalikan jalur idle ke `loadConversation()` / `startNewChat()` agar perpindahan history tidak membuat layar blink.
+- Simpan fallback full navigation hanya ketika ada request chat aktif (`message-send` belum `message-complete`), karena jalur itu diperlukan agar navigasi tidak tertahan request streaming.
+- Tambahkan assertion UI agar perilaku hybrid ini tidak hilang.

--- a/issue/issue-pr152-chat-loading-regression-2026-05-12.md
+++ b/issue/issue-pr152-chat-loading-regression-2026-05-12.md
@@ -1,0 +1,30 @@
+# PR 152 Chat Loading Regression Follow-up
+
+## Masalah
+- Navigasi history chat di PR 152 memakai full page navigation agar tidak tertahan request Livewire yang sedang streaming, tetapi global page loader ikut tampil besar di tengah halaman.
+- Saat user kembali ke conversation yang masih memproses request AI, bubble loading assistant bisa hilang sampai jawaban selesai tersimpan.
+
+## Tujuan
+- Pertahankan loading navigasi history tetap minimal: spinner kecil di item history yang diklik dan cursor/progress browser, tanpa overlay loading global.
+- Saat membuka kembali conversation yang request AI-nya masih berjalan, tampilkan lagi bubble loading assistant selama pesan user terakhir belum punya jawaban assistant.
+- Jaga perubahan tetap kecil dan tidak mengubah arsitektur streaming/chat utama.
+
+## Akar Masalah Dugaan
+- Flag `window.__suppressGlobalPageLoaderOnce` hanya hidup di halaman asal, sehingga halaman tujuan tetap merender `x-page-loader` dalam keadaan terlihat.
+- Marker pending chat hanya disimpan setelah event `user-message-acked`; bila user pindah halaman sebelum event itu diterapkan di browser, halaman yang dibuka ulang tidak punya marker untuk memulihkan bubble loading.
+
+## Rencana Implementasi
+1. Tambahkan suppress flag berbasis `sessionStorage` untuk global page loader, supaya full navigation dari history chat tetap tidak menampilkan overlay besar di halaman tujuan.
+2. Simpan marker pending lebih awal untuk conversation yang sudah punya ID ketika user menekan kirim.
+3. Tambahkan fallback restore bubble untuk conversation yang punya pesan user terbaru tanpa assistant dan masih dalam rentang waktu request normal.
+4. Tambahkan metadata waktu pesan user terakhir pada partial chat messages.
+5. Update test UI/loader yang relevan.
+
+## Verifikasi
+- Jalankan test Laravel yang dekat dengan perubahan:
+  - `php artisan test --filter=PageLoaderComponentTest`
+  - `php artisan test --filter=ChatUiTest`
+- Jalankan `git diff --check`.
+
+## Risiko
+- Fallback berbasis waktu bisa menampilkan bubble loading pada pesan user yang gagal diproses jika masih sangat baru. TTL dibuat terbatas agar tidak menampilkan loading lama secara permanen.

--- a/laravel/app/Jobs/GenerateChatResponse.php
+++ b/laravel/app/Jobs/GenerateChatResponse.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Services\AIService;
+use App\Services\ChatOrchestrationService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+class GenerateChatResponse implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 1;
+
+    public int $timeout = 180;
+
+    /**
+     * @param  array<int, array{role: string, content: string}>  $history
+     * @param  array<int, int|string>  $conversationDocuments
+     */
+    public function __construct(
+        public readonly int $conversationId,
+        public readonly int $userId,
+        public readonly array $history,
+        public readonly array $conversationDocuments = [],
+        public readonly bool $webSearchMode = false,
+    ) {
+        $this->onQueue('default');
+    }
+
+    public function handle(AIService $aiService, ChatOrchestrationService $orchestrator): void
+    {
+        Auth::loginUsingId($this->userId);
+        set_time_limit($this->timeout);
+
+        if (! $this->conversationStillExists()) {
+            return;
+        }
+
+        $documentFilenames = $orchestrator->getDocumentFilenames($this->conversationDocuments);
+        $sourcePolicy = $orchestrator->getSourcePolicy($documentFilenames);
+        $allowAutoRealtimeWeb = $orchestrator->shouldAllowAutoRealtimeWeb($documentFilenames);
+
+        $fullResponse = '';
+        $streamBuffer = '';
+        $sources = [];
+
+        foreach (
+            $aiService->sendChat(
+                $this->history,
+                $documentFilenames,
+                (string) $this->userId,
+                $this->webSearchMode,
+                $sourcePolicy,
+                $allowAutoRealtimeWeb
+            ) as $chunk
+        ) {
+            [$chunk, $streamBuffer, $_modelName, $parsedSources] = $orchestrator->extractStreamMetadata(
+                (string) $chunk,
+                $streamBuffer
+            );
+
+            if (! empty($parsedSources)) {
+                $sources = $parsedSources;
+            }
+
+            $chunk = $orchestrator->sanitizeAssistantOutput((string) $chunk);
+
+            if ($chunk !== '') {
+                $fullResponse .= $chunk;
+            }
+        }
+
+        $cleanContent = $orchestrator->cleanResponseContent($fullResponse);
+
+        if (! empty($sources)) {
+            $cleanContent .= $orchestrator->sanitizeAndFormatSources($sources);
+        }
+
+        if ($cleanContent === '') {
+            $cleanContent = 'Maaf, ISTA AI belum menerima jawaban yang bisa ditampilkan. Silakan coba lagi.';
+        }
+
+        if ($orchestrator->saveAssistantMessage($this->conversationId, $cleanContent) !== null) {
+            Conversation::query()
+                ->whereKey($this->conversationId)
+                ->where('user_id', $this->userId)
+                ->touch();
+        }
+    }
+
+    public function failed(?\Throwable $exception): void
+    {
+        Auth::loginUsingId($this->userId);
+
+        Log::error('Background chat response failed', [
+            'conversation_id' => $this->conversationId,
+            'user_id' => $this->userId,
+            'message' => $exception?->getMessage(),
+        ]);
+
+        if (! $this->conversationStillExists()) {
+            return;
+        }
+
+        Message::create([
+            'conversation_id' => $this->conversationId,
+            'role' => 'assistant',
+            'content' => 'Maaf, jawaban gagal diproses. Silakan coba kirim ulang.',
+            'is_error' => true,
+        ]);
+
+        Conversation::query()
+            ->whereKey($this->conversationId)
+            ->where('user_id', $this->userId)
+            ->touch();
+    }
+
+    private function conversationStillExists(): bool
+    {
+        return Conversation::query()
+            ->whereKey($this->conversationId)
+            ->where('user_id', $this->userId)
+            ->exists();
+    }
+}

--- a/laravel/app/Livewire/Chat/ChatIndex.php
+++ b/laravel/app/Livewire/Chat/ChatIndex.php
@@ -512,7 +512,9 @@ class ChatIndex extends Component
             $this->prompt
         );
 
-        $userMessageArray = $orchestrator->saveUserMessage($this->currentConversationId, $this->prompt);
+        $conversationIdForRequest = (int) $this->currentConversationId;
+
+        $userMessageArray = $orchestrator->saveUserMessage($conversationIdForRequest, $this->prompt);
         $this->messages[] = $userMessageArray;
         $this->dispatch('user-message-acked');
         $this->prompt = '';
@@ -569,10 +571,12 @@ class ChatIndex extends Component
             $cleanContent .= $orchestrator->sanitizeAndFormatSources($this->sources);
         }
 
-        $assistantMsg = $orchestrator->saveAssistantMessage($this->currentConversationId, $cleanContent);
+        $assistantMsg = $orchestrator->saveAssistantMessage($conversationIdForRequest, $cleanContent);
         $this->newMessageId = $assistantMsg->id;
 
-        $this->loadConversation($this->currentConversationId, clearNewMessageId: false);
+        if ((int) $this->currentConversationId === $conversationIdForRequest) {
+            $this->loadConversation($conversationIdForRequest, clearNewMessageId: false);
+        }
         $this->loadConversations();
         $this->dispatch('assistant-message-persisted');
     }

--- a/laravel/app/Livewire/Chat/ChatIndex.php
+++ b/laravel/app/Livewire/Chat/ChatIndex.php
@@ -516,7 +516,7 @@ class ChatIndex extends Component
 
         $userMessageArray = $orchestrator->saveUserMessage($conversationIdForRequest, $this->prompt);
         $this->messages[] = $userMessageArray;
-        $this->dispatch('user-message-acked');
+        $this->dispatch('user-message-acked', conversationId: $conversationIdForRequest, messageId: $userMessageArray['id'] ?? null);
         $this->prompt = '';
         $this->sources = [];
 
@@ -585,7 +585,7 @@ class ChatIndex extends Component
             $this->loadConversation($conversationIdForRequest, clearNewMessageId: false);
         }
         $this->loadConversations();
-        $this->dispatch('assistant-message-persisted');
+        $this->dispatch('assistant-message-persisted', conversationId: $conversationIdForRequest, messageId: $assistantMsg?->id);
     }
 
     public function render()

--- a/laravel/app/Livewire/Chat/ChatIndex.php
+++ b/laravel/app/Livewire/Chat/ChatIndex.php
@@ -572,9 +572,16 @@ class ChatIndex extends Component
         }
 
         $assistantMsg = $orchestrator->saveAssistantMessage($conversationIdForRequest, $cleanContent);
-        $this->newMessageId = $assistantMsg->id;
+        if ($assistantMsg !== null) {
+            $this->newMessageId = $assistantMsg->id;
+        }
 
-        if ((int) $this->currentConversationId === $conversationIdForRequest) {
+        $originConversationStillExists = Conversation::query()
+            ->whereKey($conversationIdForRequest)
+            ->where('user_id', Auth::id())
+            ->exists();
+
+        if ((int) $this->currentConversationId === $conversationIdForRequest && $originConversationStillExists) {
             $this->loadConversation($conversationIdForRequest, clearNewMessageId: false);
         }
         $this->loadConversations();

--- a/laravel/app/Livewire/Chat/ChatIndex.php
+++ b/laravel/app/Livewire/Chat/ChatIndex.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Chat;
 
+use App\Jobs\GenerateChatResponse;
 use App\Models\CloudStorageFile;
 use App\Models\Conversation;
 use App\Models\Document;
@@ -42,6 +43,8 @@ class ChatIndex extends Component
     public $messages = [];
 
     public $conversations = [];
+
+    public $pendingConversationIds = [];
 
     public $selectedDocuments = [];
 
@@ -100,11 +103,21 @@ class ChatIndex extends Component
 
         if (! $user) {
             $this->conversations = collect();
+            $this->pendingConversationIds = [];
 
             return;
         }
 
-        $this->conversations = $user->conversations()->orderBy('updated_at', 'desc')->get();
+        $this->conversations = $user->conversations()
+            ->with('latestMessage')
+            ->orderBy('updated_at', 'desc')
+            ->get();
+        $this->pendingConversationIds = $this->conversations
+            ->filter(fn (Conversation $conversation) => $this->conversationHasPendingResponse($conversation))
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->values()
+            ->all();
     }
 
     protected function chatDocumentStateService(): ChatDocumentStateService
@@ -521,71 +534,72 @@ class ChatIndex extends Component
         $this->sources = [];
 
         $history = $orchestrator->buildHistory($this->messages);
+        $conversationDocuments = array_values(array_map('intval', $this->conversationDocuments));
+        $webSearchMode = (bool) $this->webSearchMode;
 
-        $this->stream('assistant-output', '', true);
-
-        $documentFilenames = $orchestrator->getDocumentFilenames($this->conversationDocuments);
-        $sourcePolicy = $orchestrator->getSourcePolicy($documentFilenames);
-        $allowAutoRealtimeWeb = $orchestrator->shouldAllowAutoRealtimeWeb($documentFilenames);
-
-        $fullResponse = '';
-        $modelName = 'AI';
-        $streamBuffer = '';
-
-        foreach (
-            $aiService->sendChat(
-                $history,
-                $documentFilenames,
-                (string) Auth::id(),
-                $this->webSearchMode,
-                $sourcePolicy,
-                $allowAutoRealtimeWeb
-            ) as $chunk
-        ) {
-            [$chunk, $streamBuffer, $parsedModelName, $parsedSources] = $orchestrator->extractStreamMetadata(
-                (string) $chunk,
-                $streamBuffer
-            );
-
-            if ($parsedModelName !== null) {
-                $modelName = $parsedModelName;
-                $this->stream('model-name', $modelName);
-            }
-
-            if (! empty($parsedSources)) {
-                $this->sources = $parsedSources;
-                $this->dispatch('assistant-sources', $this->sources);
-            }
-
-            $chunk = $orchestrator->sanitizeAssistantOutput((string) $chunk);
-
-            if ($chunk !== '') {
-                $fullResponse .= $chunk;
-                $this->stream('assistant-output', $chunk);
-            }
-        }
-
-        $cleanContent = $orchestrator->cleanResponseContent($fullResponse);
-
-        if (! empty($this->sources)) {
-            $cleanContent .= $orchestrator->sanitizeAndFormatSources($this->sources);
-        }
-
-        $assistantMsg = $orchestrator->saveAssistantMessage($conversationIdForRequest, $cleanContent);
-        if ($assistantMsg !== null) {
-            $this->newMessageId = $assistantMsg->id;
-        }
-
-        $originConversationStillExists = Conversation::query()
+        Conversation::query()
             ->whereKey($conversationIdForRequest)
             ->where('user_id', Auth::id())
-            ->exists();
+            ->touch();
 
-        if ((int) $this->currentConversationId === $conversationIdForRequest && $originConversationStillExists) {
-            $this->loadConversation($conversationIdForRequest, clearNewMessageId: false);
-        }
         $this->loadConversations();
-        $this->dispatch('assistant-message-persisted', conversationId: $conversationIdForRequest, messageId: $assistantMsg?->id);
+        $this->dispatch('conversation-activated', id: $conversationIdForRequest);
+
+        GenerateChatResponse::dispatch(
+            $conversationIdForRequest,
+            (int) Auth::id(),
+            $history,
+            $conversationDocuments,
+            $webSearchMode,
+        );
+
+        return [
+            'conversationId' => $conversationIdForRequest,
+            'messageId' => $userMessageArray['id'] ?? null,
+        ];
+    }
+
+    public function refreshPendingChatState(): void
+    {
+        $previousPendingIds = collect($this->pendingConversationIds)
+            ->map(fn ($id) => (int) $id)
+            ->values();
+        $activeConversationId = $this->currentConversationId ? (int) $this->currentConversationId : null;
+
+        $this->loadConversations();
+
+        $currentPendingIds = collect($this->pendingConversationIds)
+            ->map(fn ($id) => (int) $id)
+            ->values();
+        $completedIds = $previousPendingIds->diff($currentPendingIds)->values();
+
+        if ($activeConversationId !== null && ($previousPendingIds->contains($activeConversationId) || $currentPendingIds->contains($activeConversationId))) {
+            $latestAssistantId = Message::query()
+                ->where('conversation_id', $activeConversationId)
+                ->where('role', 'assistant')
+                ->latest('id')
+                ->value('id');
+
+            if ($completedIds->contains($activeConversationId) && $latestAssistantId) {
+                $this->newMessageId = (int) $latestAssistantId;
+            }
+
+            $this->loadConversation($activeConversationId, clearNewMessageId: false);
+        }
+
+        foreach ($completedIds as $completedConversationId) {
+            $latestAssistantId = Message::query()
+                ->where('conversation_id', (int) $completedConversationId)
+                ->where('role', 'assistant')
+                ->latest('id')
+                ->value('id');
+
+            $this->dispatch(
+                'assistant-message-persisted',
+                conversationId: (int) $completedConversationId,
+                messageId: $latestAssistantId ? (int) $latestAssistantId : null,
+            );
+        }
     }
 
     public function render()
@@ -593,6 +607,19 @@ class ChatIndex extends Component
         return view('livewire.chat.chat-index', [
             'googleDriveUploadAvailable' => app(GoogleDriveService::class)->canUploadWithConfiguredAccount(),
         ]);
+    }
+
+    private function conversationHasPendingResponse(Conversation $conversation): bool
+    {
+        $latestMessage = $conversation->latestMessage;
+
+        if (! $latestMessage || $latestMessage->role !== 'user') {
+            return false;
+        }
+
+        $createdAt = $latestMessage->created_at;
+
+        return $createdAt === null || $createdAt->greaterThan(now()->subMinutes(30));
     }
 
     private function normalizeDriveExportFormat(string $targetFormat): ?string

--- a/laravel/app/Models/Conversation.php
+++ b/laravel/app/Models/Conversation.php
@@ -20,4 +20,9 @@ class Conversation extends Model
     {
         return $this->hasMany(Message::class);
     }
+
+    public function latestMessage()
+    {
+        return $this->hasOne(Message::class)->latestOfMany();
+    }
 }

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -6,6 +6,7 @@ use App\Models\Conversation;
 use App\Models\Message;
 use App\Models\Document;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Auth;
 
 class ChatOrchestrationService
@@ -179,13 +180,43 @@ class ChatOrchestrationService
         return trim($cleanContent);
     }
 
-    public function saveAssistantMessage(int $conversationId, string $content): Message
+    public function saveAssistantMessage(int $conversationId, string $content): ?Message
+    {
+        if (! $this->conversationExists($conversationId)) {
+            return null;
+        }
+
+        try {
+            return $this->createAssistantMessage($conversationId, $content);
+        } catch (QueryException $e) {
+            if ($this->isConversationFkViolation($e)) {
+                return null;
+            }
+
+            throw $e;
+        }
+    }
+
+    protected function conversationExists(int $conversationId): bool
+    {
+        return Conversation::query()->whereKey($conversationId)->exists();
+    }
+
+    protected function createAssistantMessage(int $conversationId, string $content): Message
     {
         return Message::create([
             'conversation_id' => $conversationId,
             'role' => 'assistant',
-            'content' => $content
+            'content' => $content,
         ]);
+    }
+
+    protected function isConversationFkViolation(QueryException $e): bool
+    {
+        $sqlState = $e->errorInfo[0] ?? null;
+        $errorCode = $e->errorInfo[1] ?? null;
+
+        return $sqlState === '23000' && (int) $errorCode === 1452;
     }
 
     public function extractStreamMetadata(string $chunk, string $buffer = ''): array

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -199,7 +199,10 @@ class ChatOrchestrationService
 
     protected function conversationExists(int $conversationId): bool
     {
-        return Conversation::query()->whereKey($conversationId)->exists();
+        return Conversation::query()
+            ->whereKey($conversationId)
+            ->where('user_id', Auth::id())
+            ->exists();
     }
 
     protected function createAssistantMessage(int $conversationId, string $content): Message

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -2,7 +2,6 @@ let hasRegisteredChatPageData = false;
 const CHAT_PENDING_STORAGE_KEY = 'ista.chat.pendingResponses.v1';
 const CHAT_PENDING_MARKER_TTL_MS = 10 * 60 * 1000;
 const CHAT_PENDING_RECENT_TTL_MS = 3 * 60 * 1000;
-const GLOBAL_PAGE_LOADER_SUPPRESS_STORAGE_KEY = 'ista.globalPageLoader.suppressOnce';
 
 const loadPendingConversationMarkers = () => {
     try {
@@ -18,16 +17,6 @@ const loadPendingConversationMarkers = () => {
 const savePendingConversationMarkers = (markers) => {
     try {
         window.localStorage?.setItem(CHAT_PENDING_STORAGE_KEY, JSON.stringify(markers || {}));
-    } catch (_) {
-        // ignore storage write errors
-    }
-};
-
-const suppressGlobalPageLoaderOnce = () => {
-    window.__suppressGlobalPageLoaderOnce = true;
-
-    try {
-        window.sessionStorage?.setItem(GLOBAL_PAGE_LOADER_SUPPRESS_STORAGE_KEY, '1');
     } catch (_) {
         // ignore storage write errors
     }
@@ -473,24 +462,30 @@ const registerChatPageData = (Alpine) => {
     Alpine.data('chatHistory', (config = {}) => ({
         activeConversationId: config.activeConversationId ? Number(config.activeConversationId) : null,
         showOlderChats: config.showOlderChats || false,
+        pendingConversationIds: (config.pendingConversationIds || []).map((id) => Number(id)).filter(Boolean),
         loadingConversationId: null,
         isNavigating: false,
-        hasActiveChatRequest: false,
-        _messageSendHandler: null,
-        _messageCompleteHandler: null,
+        _chatMarkPendingHandler: null,
+        _assistantPersistedCleanup: null,
 
         init() {
             this.$nextTick(() => this.syncActiveHistoryItem());
             this.$watch('activeConversationId', () => this.syncActiveHistoryItem());
             window.chatHistoryNavigateToNewChat = (event) => this.navigateToNewChat(event);
-            this._messageSendHandler = () => {
-                this.hasActiveChatRequest = true;
+            this._chatMarkPendingHandler = (event) => {
+                const id = Number(event?.detail?.conversationId || 0);
+                if (id > 0 && !this.pendingConversationIds.includes(id)) {
+                    this.pendingConversationIds.push(id);
+                }
             };
-            this._messageCompleteHandler = () => {
-                this.hasActiveChatRequest = false;
-            };
-            window.addEventListener('message-send', this._messageSendHandler);
-            window.addEventListener('message-complete', this._messageCompleteHandler);
+            window.addEventListener('chat-mark-pending', this._chatMarkPendingHandler);
+            this._assistantPersistedCleanup = this.$wire.on('assistant-message-persisted', (data) => {
+                const payload = data?.[0] || {};
+                const id = Number(payload.conversationId || 0);
+                if (id > 0) {
+                    this.pendingConversationIds = this.pendingConversationIds.filter((pendingId) => pendingId !== id);
+                }
+            });
         },
 
         isActive(id) {
@@ -499,6 +494,10 @@ const registerChatPageData = (Alpine) => {
 
         isLoading(id) {
             return this.loadingConversationId === Number(id);
+        },
+
+        isPending(id) {
+            return this.pendingConversationIds.includes(Number(id));
         },
 
         setActiveConversation(id) {
@@ -562,15 +561,6 @@ const registerChatPageData = (Alpine) => {
                 return;
             }
 
-            if (this.hasActiveChatRequest) {
-                this.loadingConversationId = conversationId;
-                this.isNavigating = true;
-                this.$dispatch('conversation-loading');
-                suppressGlobalPageLoaderOnce();
-                window.location.assign(targetHref);
-                return;
-            }
-
             this.loadConversation(conversationId)
                 .then(() => window.history.pushState({}, '', targetHref));
         },
@@ -582,17 +572,6 @@ const registerChatPageData = (Alpine) => {
 
             const targetHref = event.currentTarget.href;
             event.preventDefault();
-
-            if (this.hasActiveChatRequest) {
-                this.setActiveConversation(null);
-                this.loadingConversationId = null;
-                this.isNavigating = true;
-                this.$dispatch('chat-new-optimistic');
-                this.$dispatch('conversation-loading');
-                suppressGlobalPageLoaderOnce();
-                window.location.assign(targetHref);
-                return;
-            }
 
             this.startNewChat()
                 .then(() => window.history.pushState({}, '', targetHref));
@@ -616,13 +595,13 @@ const registerChatPageData = (Alpine) => {
             if (window.chatHistoryNavigateToNewChat) {
                 delete window.chatHistoryNavigateToNewChat;
             }
-            if (this._messageSendHandler) {
-                window.removeEventListener('message-send', this._messageSendHandler);
-                this._messageSendHandler = null;
+            if (this._chatMarkPendingHandler) {
+                window.removeEventListener('chat-mark-pending', this._chatMarkPendingHandler);
+                this._chatMarkPendingHandler = null;
             }
-            if (this._messageCompleteHandler) {
-                window.removeEventListener('message-complete', this._messageCompleteHandler);
-                this._messageCompleteHandler = null;
+            if (typeof this._assistantPersistedCleanup === 'function') {
+                this._assistantPersistedCleanup();
+                this._assistantPersistedCleanup = null;
             }
         },
     }));
@@ -1118,6 +1097,12 @@ const registerChatPageData = (Alpine) => {
             this.$wire.conversationDocuments = normalizedDocs;
 
             this.$wire.sendMessage(text)
+                .then((response) => {
+                    const conversationId = Number(response?.conversationId || this.$wire.currentConversationId || 0);
+                    if (conversationId > 0) {
+                        this.markPendingConversation(conversationId, loadingContext);
+                    }
+                })
                 .catch(() => {
                     this.$dispatch('user-message-acked');
 
@@ -1131,10 +1116,11 @@ const registerChatPageData = (Alpine) => {
                     setTimeout(() => {
                         this.sendError = '';
                     }, 6000);
+
+                    this.$dispatch('message-complete');
                 })
                 .finally(() => {
                     this.isSendingMessage = false;
-                    this.$dispatch('message-complete');
                 });
         },
 

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -166,6 +166,7 @@ const registerChatPageData = (Alpine) => {
         _messageCompleteHandler: null,
         chatMutationObserver: null,
         wireListeners: [],
+        windowListeners: [],
 
         getConversationMeta() {
             const metaEl = this.$el.querySelector('[data-chat-conversation-id]');
@@ -184,7 +185,7 @@ const registerChatPageData = (Alpine) => {
 
         markConversationPending(conversationId, loadingContext = 'general') {
             const id = Number(conversationId);
-            if (!Number.isFinite(id)) return;
+            if (!Number.isFinite(id) || id <= 0) return;
             const markers = loadPendingConversationMarkers();
             markers[id] = { loadingContext, ts: Date.now() };
             savePendingConversationMarkers(markers);
@@ -192,7 +193,7 @@ const registerChatPageData = (Alpine) => {
 
         clearConversationPending(conversationId) {
             const id = Number(conversationId);
-            if (!Number.isFinite(id)) return;
+            if (!Number.isFinite(id) || id <= 0) return;
             const markers = loadPendingConversationMarkers();
             if (Object.prototype.hasOwnProperty.call(markers, id)) {
                 delete markers[id];
@@ -227,6 +228,10 @@ const registerChatPageData = (Alpine) => {
 
             this._messageCompleteHandler = () => this.resetStreamingState();
             window.addEventListener('message-complete', this._messageCompleteHandler);
+            this.registerWindowListener('chat-mark-pending', (event) => {
+                const detail = event?.detail || {};
+                this.markConversationPending(detail.conversationId, detail.loadingContext || 'general');
+            });
             this.registerWireListener('assistant-output', (data) => {
                 this.streamingText += data[0] || '';
                 this.streaming = true;
@@ -273,6 +278,11 @@ const registerChatPageData = (Alpine) => {
             }
         },
 
+        registerWindowListener(event, callback) {
+            window.addEventListener(event, callback);
+            this.windowListeners.push(() => window.removeEventListener(event, callback));
+        },
+
         destroy() {
             this.clearLoadingPhaseTimeout();
             this.clearPhase2Timeout();
@@ -295,6 +305,18 @@ const registerChatPageData = (Alpine) => {
                     }
                 });
                 this.wireListeners = [];
+            }
+            if (this.windowListeners && this.windowListeners.length > 0) {
+                this.windowListeners.forEach((cleanup) => {
+                    if (typeof cleanup === 'function') {
+                        try {
+                            cleanup();
+                        } catch (e) {
+                            // Defensive: ignore cleanup errors
+                        }
+                    }
+                });
+                this.windowListeners = [];
             }
         },
 
@@ -885,11 +907,12 @@ const registerChatPageData = (Alpine) => {
                 const payload = data?.[0] || {};
                 const ackConversationId = Number(payload.conversationId || this.$wire.currentConversationId || 0);
                 if (ackConversationId > 0) {
-                    const chatMessagesEl = document.querySelector('[data-chat-box]');
-                    const chatMessagesData = chatMessagesEl && chatMessagesEl.__x ? chatMessagesEl.__x.$data : null;
-                    if (chatMessagesData && typeof chatMessagesData.markConversationPending === 'function') {
-                        chatMessagesData.markConversationPending(ackConversationId, this._pendingLoadingContext || 'general');
-                    }
+                    window.dispatchEvent(new CustomEvent('chat-mark-pending', {
+                        detail: {
+                            conversationId: ackConversationId,
+                            loadingContext: this._pendingLoadingContext || 'general',
+                        },
+                    }));
                 }
             });
         },

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -475,11 +475,22 @@ const registerChatPageData = (Alpine) => {
         showOlderChats: config.showOlderChats || false,
         loadingConversationId: null,
         isNavigating: false,
+        hasActiveChatRequest: false,
+        _messageSendHandler: null,
+        _messageCompleteHandler: null,
 
         init() {
             this.$nextTick(() => this.syncActiveHistoryItem());
             this.$watch('activeConversationId', () => this.syncActiveHistoryItem());
             window.chatHistoryNavigateToNewChat = (event) => this.navigateToNewChat(event);
+            this._messageSendHandler = () => {
+                this.hasActiveChatRequest = true;
+            };
+            this._messageCompleteHandler = () => {
+                this.hasActiveChatRequest = false;
+            };
+            window.addEventListener('message-send', this._messageSendHandler);
+            window.addEventListener('message-complete', this._messageCompleteHandler);
         },
 
         isActive(id) {
@@ -542,19 +553,26 @@ const registerChatPageData = (Alpine) => {
                 return;
             }
 
+            const targetHref = event.currentTarget.href;
             event.preventDefault();
 
             const conversationId = Number(id);
             if (!Number.isFinite(conversationId)) {
-                window.location.assign(event.currentTarget.href);
+                window.location.assign(targetHref);
                 return;
             }
 
-            this.loadingConversationId = conversationId;
-            this.isNavigating = true;
-            this.$dispatch('conversation-loading');
-            suppressGlobalPageLoaderOnce();
-            window.location.assign(event.currentTarget.href);
+            if (this.hasActiveChatRequest) {
+                this.loadingConversationId = conversationId;
+                this.isNavigating = true;
+                this.$dispatch('conversation-loading');
+                suppressGlobalPageLoaderOnce();
+                window.location.assign(targetHref);
+                return;
+            }
+
+            this.loadConversation(conversationId)
+                .then(() => window.history.pushState({}, '', targetHref));
         },
 
         navigateToNewChat(event) {
@@ -562,14 +580,22 @@ const registerChatPageData = (Alpine) => {
                 return;
             }
 
+            const targetHref = event.currentTarget.href;
             event.preventDefault();
-            this.setActiveConversation(null);
-            this.loadingConversationId = null;
-            this.isNavigating = true;
-            this.$dispatch('chat-new-optimistic');
-            this.$dispatch('conversation-loading');
-            suppressGlobalPageLoaderOnce();
-            window.location.assign(event.currentTarget.href);
+
+            if (this.hasActiveChatRequest) {
+                this.setActiveConversation(null);
+                this.loadingConversationId = null;
+                this.isNavigating = true;
+                this.$dispatch('chat-new-optimistic');
+                this.$dispatch('conversation-loading');
+                suppressGlobalPageLoaderOnce();
+                window.location.assign(targetHref);
+                return;
+            }
+
+            this.startNewChat()
+                .then(() => window.history.pushState({}, '', targetHref));
         },
 
         startNewChat() {
@@ -589,6 +615,14 @@ const registerChatPageData = (Alpine) => {
         destroy() {
             if (window.chatHistoryNavigateToNewChat) {
                 delete window.chatHistoryNavigateToNewChat;
+            }
+            if (this._messageSendHandler) {
+                window.removeEventListener('message-send', this._messageSendHandler);
+                this._messageSendHandler = null;
+            }
+            if (this._messageCompleteHandler) {
+                window.removeEventListener('message-complete', this._messageCompleteHandler);
+                this._messageCompleteHandler = null;
             }
         },
     }));

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -1,5 +1,8 @@
 let hasRegisteredChatPageData = false;
 const CHAT_PENDING_STORAGE_KEY = 'ista.chat.pendingResponses.v1';
+const CHAT_PENDING_MARKER_TTL_MS = 10 * 60 * 1000;
+const CHAT_PENDING_RECENT_TTL_MS = 3 * 60 * 1000;
+const GLOBAL_PAGE_LOADER_SUPPRESS_STORAGE_KEY = 'ista.globalPageLoader.suppressOnce';
 
 const loadPendingConversationMarkers = () => {
     try {
@@ -15,6 +18,16 @@ const loadPendingConversationMarkers = () => {
 const savePendingConversationMarkers = (markers) => {
     try {
         window.localStorage?.setItem(CHAT_PENDING_STORAGE_KEY, JSON.stringify(markers || {}));
+    } catch (_) {
+        // ignore storage write errors
+    }
+};
+
+const suppressGlobalPageLoaderOnce = () => {
+    window.__suppressGlobalPageLoaderOnce = true;
+
+    try {
+        window.sessionStorage?.setItem(GLOBAL_PAGE_LOADER_SUPPRESS_STORAGE_KEY, '1');
     } catch (_) {
         // ignore storage write errors
     }
@@ -175,11 +188,17 @@ const registerChatPageData = (Alpine) => {
             const lastRole = metaEl.dataset.chatLastMessageRole || '';
             const lastUserId = Number(metaEl.dataset.chatLastUserMessageId || '0');
             const lastAssistantId = Number(metaEl.dataset.chatLastAssistantMessageId || '0');
+            const lastUserCreatedAt = metaEl.dataset.chatLastUserMessageCreatedAt || '';
+            const lastUserCreatedAtMs = lastUserCreatedAt ? Date.parse(lastUserCreatedAt) : NaN;
+            const pendingAgeMs = Number.isFinite(lastUserCreatedAtMs)
+                ? Math.max(Date.now() - lastUserCreatedAtMs, 0)
+                : null;
 
             return {
                 conversationId: Number.isFinite(conversationId) ? conversationId : null,
                 lastRole,
                 hasPendingUserWithoutAssistant: lastUserId > 0 && (lastAssistantId === 0 || lastAssistantId < lastUserId),
+                pendingAgeMs,
             };
         },
 
@@ -202,16 +221,29 @@ const registerChatPageData = (Alpine) => {
         },
 
         maybeRestorePendingPlaceholder() {
-            const { conversationId, hasPendingUserWithoutAssistant } = this.getConversationMeta();
+            const { conversationId, hasPendingUserWithoutAssistant, pendingAgeMs } = this.getConversationMeta();
             if (!conversationId || !hasPendingUserWithoutAssistant) {
                 return;
             }
 
             const markers = loadPendingConversationMarkers();
             const marker = markers[conversationId];
-            if (!marker) return;
+            const markerAgeMs = marker?.ts ? Date.now() - Number(marker.ts) : Number.POSITIVE_INFINITY;
+            const hasFreshMarker = marker && markerAgeMs >= 0 && markerAgeMs <= CHAT_PENDING_MARKER_TTL_MS;
+            const hasRecentPendingUser = pendingAgeMs !== null && pendingAgeMs <= CHAT_PENDING_RECENT_TTL_MS;
 
-            this.startStreamingPlaceholder(marker.loadingContext || 'general');
+            if (marker && !hasFreshMarker) {
+                delete markers[conversationId];
+                savePendingConversationMarkers(markers);
+            }
+
+            if (!hasFreshMarker && !hasRecentPendingUser) {
+                return;
+            }
+
+            const loadingContext = hasFreshMarker ? (marker.loadingContext || 'general') : 'general';
+            this.markConversationPending(conversationId, loadingContext);
+            this.startStreamingPlaceholder(loadingContext);
             this.scrollToBottom();
         },
 
@@ -521,7 +553,7 @@ const registerChatPageData = (Alpine) => {
             this.loadingConversationId = conversationId;
             this.isNavigating = true;
             this.$dispatch('conversation-loading');
-            window.__suppressGlobalPageLoaderOnce = true;
+            suppressGlobalPageLoaderOnce();
             window.location.assign(event.currentTarget.href);
         },
 
@@ -536,7 +568,7 @@ const registerChatPageData = (Alpine) => {
             this.isNavigating = true;
             this.$dispatch('chat-new-optimistic');
             this.$dispatch('conversation-loading');
-            window.__suppressGlobalPageLoaderOnce = true;
+            suppressGlobalPageLoaderOnce();
             window.location.assign(event.currentTarget.href);
         },
 
@@ -907,14 +939,23 @@ const registerChatPageData = (Alpine) => {
                 const payload = data?.[0] || {};
                 const ackConversationId = Number(payload.conversationId || this.$wire.currentConversationId || 0);
                 if (ackConversationId > 0) {
-                    window.dispatchEvent(new CustomEvent('chat-mark-pending', {
-                        detail: {
-                            conversationId: ackConversationId,
-                            loadingContext: this._pendingLoadingContext || 'general',
-                        },
-                    }));
+                    this.markPendingConversation(ackConversationId, this._pendingLoadingContext || 'general');
                 }
             });
+        },
+
+        markPendingConversation(conversationId, loadingContext = 'general') {
+            const id = Number(conversationId);
+            if (!Number.isFinite(id) || id <= 0) {
+                return;
+            }
+
+            window.dispatchEvent(new CustomEvent('chat-mark-pending', {
+                detail: {
+                    conversationId: id,
+                    loadingContext,
+                },
+            }));
         },
 
         previewConversationDocuments(event) {
@@ -1031,6 +1072,11 @@ const registerChatPageData = (Alpine) => {
             this.scrollChatToBottom(true);
             this.stabilizeChatScroll();
             this._pendingLoadingContext = loadingContext;
+
+            const currentConversationId = Number(this.$wire.currentConversationId || 0);
+            if (currentConversationId > 0) {
+                this.markPendingConversation(currentConversationId, loadingContext);
+            }
 
             this.promptDraft = '';
             this.autoResizeTextarea(this.$refs.chatInput);

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -344,6 +344,7 @@ const registerChatPageData = (Alpine) => {
         init() {
             this.$nextTick(() => this.syncActiveHistoryItem());
             this.$watch('activeConversationId', () => this.syncActiveHistoryItem());
+            window.chatHistoryNavigateToNewChat = (event) => this.navigateToNewChat(event);
         },
 
         isActive(id) {
@@ -401,6 +402,39 @@ const registerChatPageData = (Alpine) => {
                 });
         },
 
+        navigateToConversation(event, id) {
+            if (!event?.currentTarget?.href) {
+                return;
+            }
+
+            event.preventDefault();
+
+            const conversationId = Number(id);
+            if (!Number.isFinite(conversationId)) {
+                window.location.assign(event.currentTarget.href);
+                return;
+            }
+
+            this.loadingConversationId = conversationId;
+            this.isNavigating = true;
+            this.$dispatch('conversation-loading');
+            window.location.assign(event.currentTarget.href);
+        },
+
+        navigateToNewChat(event) {
+            if (!event?.currentTarget?.href) {
+                return;
+            }
+
+            event.preventDefault();
+            this.setActiveConversation(null);
+            this.loadingConversationId = null;
+            this.isNavigating = true;
+            this.$dispatch('chat-new-optimistic');
+            this.$dispatch('conversation-loading');
+            window.location.assign(event.currentTarget.href);
+        },
+
         startNewChat() {
             this.setActiveConversation(null);
             this.loadingConversationId = null;
@@ -413,6 +447,12 @@ const registerChatPageData = (Alpine) => {
                     this.isNavigating = false;
                     this.$dispatch('conversation-loaded');
                 });
+        },
+
+        destroy() {
+            if (window.chatHistoryNavigateToNewChat) {
+                delete window.chatHistoryNavigateToNewChat;
+            }
         },
     }));
 

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -1,7 +1,10 @@
 let hasRegisteredChatPageData = false;
 const CHAT_PENDING_STORAGE_KEY = 'ista.chat.pendingResponses.v1';
+const CHAT_COMPLETED_STORAGE_KEY = 'ista.chat.completedResponses.v1';
 const CHAT_PENDING_MARKER_TTL_MS = 10 * 60 * 1000;
 const CHAT_PENDING_RECENT_TTL_MS = 3 * 60 * 1000;
+
+const normalizeWirePayload = (data) => (Array.isArray(data) ? (data[0] || {}) : (data || {}));
 
 const loadPendingConversationMarkers = () => {
     try {
@@ -17,6 +20,28 @@ const loadPendingConversationMarkers = () => {
 const savePendingConversationMarkers = (markers) => {
     try {
         window.localStorage?.setItem(CHAT_PENDING_STORAGE_KEY, JSON.stringify(markers || {}));
+    } catch (_) {
+        // ignore storage write errors
+    }
+};
+
+const loadStoredConversationIds = (storageKey) => {
+    try {
+        const raw = window.localStorage?.getItem(storageKey);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+
+        return parsed.map((id) => Number(id)).filter((id) => Number.isFinite(id) && id > 0);
+    } catch (_) {
+        return [];
+    }
+};
+
+const saveStoredConversationIds = (storageKey, ids) => {
+    try {
+        const normalizedIds = [...new Set((ids || []).map((id) => Number(id)).filter((id) => Number.isFinite(id) && id > 0))];
+        window.localStorage?.setItem(storageKey, JSON.stringify(normalizedIds));
     } catch (_) {
         // ignore storage write errors
     }
@@ -278,7 +303,7 @@ const registerChatPageData = (Alpine) => {
             });
             this.registerWireListener('assistant-message-persisted', () => this.resetStreamingState());
             this.registerWireListener('assistant-message-persisted', (data) => {
-                const payload = data?.[0] || {};
+                const payload = normalizeWirePayload(data);
                 const ackConversationId = Number(payload.conversationId || 0);
                 const { conversationId } = this.getConversationMeta();
                 const targetConversationId = ackConversationId > 0 ? ackConversationId : conversationId;
@@ -463,9 +488,11 @@ const registerChatPageData = (Alpine) => {
         activeConversationId: config.activeConversationId ? Number(config.activeConversationId) : null,
         showOlderChats: config.showOlderChats || false,
         pendingConversationIds: (config.pendingConversationIds || []).map((id) => Number(id)).filter(Boolean),
+        completedConversationIds: loadStoredConversationIds(CHAT_COMPLETED_STORAGE_KEY),
         loadingConversationId: null,
         isNavigating: false,
         _chatMarkPendingHandler: null,
+        _assistantPersistedWindowHandler: null,
         _assistantPersistedCleanup: null,
 
         init() {
@@ -474,17 +501,18 @@ const registerChatPageData = (Alpine) => {
             window.chatHistoryNavigateToNewChat = (event) => this.navigateToNewChat(event);
             this._chatMarkPendingHandler = (event) => {
                 const id = Number(event?.detail?.conversationId || 0);
-                if (id > 0 && !this.pendingConversationIds.includes(id)) {
-                    this.pendingConversationIds.push(id);
-                }
+                this.markConversationPending(id);
             };
             window.addEventListener('chat-mark-pending', this._chatMarkPendingHandler);
+            this._assistantPersistedWindowHandler = (event) => {
+                const id = Number(event?.detail?.conversationId || 0);
+                this.markConversationComplete(id);
+            };
+            window.addEventListener('assistant-message-persisted', this._assistantPersistedWindowHandler);
             this._assistantPersistedCleanup = this.$wire.on('assistant-message-persisted', (data) => {
-                const payload = data?.[0] || {};
+                const payload = normalizeWirePayload(data);
                 const id = Number(payload.conversationId || 0);
-                if (id > 0) {
-                    this.pendingConversationIds = this.pendingConversationIds.filter((pendingId) => pendingId !== id);
-                }
+                this.markConversationComplete(id);
             });
         },
 
@@ -498,6 +526,53 @@ const registerChatPageData = (Alpine) => {
 
         isPending(id) {
             return this.pendingConversationIds.includes(Number(id));
+        },
+
+        isCompleteUnread(id) {
+            const conversationId = Number(id);
+
+            return !this.isPending(conversationId) && this.completedConversationIds.includes(conversationId);
+        },
+
+        markConversationPending(id) {
+            const conversationId = Number(id);
+            if (!Number.isFinite(conversationId) || conversationId <= 0) {
+                return;
+            }
+
+            if (!this.pendingConversationIds.includes(conversationId)) {
+                this.pendingConversationIds.push(conversationId);
+            }
+
+            this.completedConversationIds = this.completedConversationIds.filter((completedId) => completedId !== conversationId);
+            saveStoredConversationIds(CHAT_COMPLETED_STORAGE_KEY, this.completedConversationIds);
+        },
+
+        markConversationComplete(id) {
+            const conversationId = Number(id);
+            if (!Number.isFinite(conversationId) || conversationId <= 0) {
+                return;
+            }
+
+            this.pendingConversationIds = this.pendingConversationIds.filter((pendingId) => pendingId !== conversationId);
+
+            if (!this.completedConversationIds.includes(conversationId)) {
+                this.completedConversationIds.push(conversationId);
+                saveStoredConversationIds(CHAT_COMPLETED_STORAGE_KEY, this.completedConversationIds);
+            }
+        },
+
+        markConversationRead(id) {
+            const conversationId = Number(id);
+            if (!Number.isFinite(conversationId) || conversationId <= 0) {
+                return;
+            }
+
+            const nextIds = this.completedConversationIds.filter((completedId) => completedId !== conversationId);
+            if (nextIds.length !== this.completedConversationIds.length) {
+                this.completedConversationIds = nextIds;
+                saveStoredConversationIds(CHAT_COMPLETED_STORAGE_KEY, this.completedConversationIds);
+            }
         },
 
         setActiveConversation(id) {
@@ -562,7 +637,10 @@ const registerChatPageData = (Alpine) => {
             }
 
             this.loadConversation(conversationId)
-                .then(() => window.history.pushState({}, '', targetHref));
+                .then(() => {
+                    this.markConversationRead(conversationId);
+                    window.history.pushState({}, '', targetHref);
+                });
         },
 
         navigateToNewChat(event) {
@@ -598,6 +676,10 @@ const registerChatPageData = (Alpine) => {
             if (this._chatMarkPendingHandler) {
                 window.removeEventListener('chat-mark-pending', this._chatMarkPendingHandler);
                 this._chatMarkPendingHandler = null;
+            }
+            if (this._assistantPersistedWindowHandler) {
+                window.removeEventListener('assistant-message-persisted', this._assistantPersistedWindowHandler);
+                this._assistantPersistedWindowHandler = null;
             }
             if (typeof this._assistantPersistedCleanup === 'function') {
                 this._assistantPersistedCleanup();
@@ -949,7 +1031,7 @@ const registerChatPageData = (Alpine) => {
                 this.messageAcked = true;
                 this.stabilizeChatScroll();
 
-                const payload = data?.[0] || {};
+                const payload = normalizeWirePayload(data);
                 const ackConversationId = Number(payload.conversationId || this.$wire.currentConversationId || 0);
                 if (ackConversationId > 0) {
                     this.markPendingConversation(ackConversationId, this._pendingLoadingContext || 'general');

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -498,6 +498,7 @@ const registerChatPageData = (Alpine) => {
         init() {
             this.$nextTick(() => this.syncActiveHistoryItem());
             this.$watch('activeConversationId', () => this.syncActiveHistoryItem());
+            this.markConversationRead(this.activeConversationId);
             window.chatHistoryNavigateToNewChat = (event) => this.navigateToNewChat(event);
             this._chatMarkPendingHandler = (event) => {
                 const id = Number(event?.detail?.conversationId || 0);
@@ -555,6 +556,12 @@ const registerChatPageData = (Alpine) => {
             }
 
             this.pendingConversationIds = this.pendingConversationIds.filter((pendingId) => pendingId !== conversationId);
+
+            if (this.activeConversationId === conversationId) {
+                this.markConversationRead(conversationId);
+
+                return;
+            }
 
             if (!this.completedConversationIds.includes(conversationId)) {
                 this.completedConversationIds.push(conversationId);

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -379,7 +379,7 @@ const registerChatPageData = (Alpine) => {
 
             this.setActiveConversation(conversationId);
 
-            if (this.isNavigating || previousConversationId === conversationId) {
+            if (previousConversationId === conversationId) {
                 return Promise.resolve();
             }
 
@@ -402,10 +402,6 @@ const registerChatPageData = (Alpine) => {
         },
 
         startNewChat() {
-            if (this.isNavigating) {
-                return Promise.resolve();
-            }
-
             this.setActiveConversation(null);
             this.loadingConversationId = null;
             this.isNavigating = true;

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -1,4 +1,24 @@
 let hasRegisteredChatPageData = false;
+const CHAT_PENDING_STORAGE_KEY = 'ista.chat.pendingResponses.v1';
+
+const loadPendingConversationMarkers = () => {
+    try {
+        const raw = window.localStorage?.getItem(CHAT_PENDING_STORAGE_KEY);
+        if (!raw) return {};
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch (_) {
+        return {};
+    }
+};
+
+const savePendingConversationMarkers = (markers) => {
+    try {
+        window.localStorage?.setItem(CHAT_PENDING_STORAGE_KEY, JSON.stringify(markers || {}));
+    } catch (_) {
+        // ignore storage write errors
+    }
+};
 
 const isDarkThemeEnabled = () => localStorage.getItem('theme') === 'dark';
 
@@ -147,6 +167,53 @@ const registerChatPageData = (Alpine) => {
         chatMutationObserver: null,
         wireListeners: [],
 
+        getConversationMeta() {
+            const metaEl = this.$el.querySelector('[data-chat-conversation-id]');
+            if (!metaEl) return { conversationId: null, lastRole: '', hasPendingUserWithoutAssistant: false };
+            const conversationId = Number(metaEl.dataset.chatConversationId || '');
+            const lastRole = metaEl.dataset.chatLastMessageRole || '';
+            const lastUserId = Number(metaEl.dataset.chatLastUserMessageId || '0');
+            const lastAssistantId = Number(metaEl.dataset.chatLastAssistantMessageId || '0');
+
+            return {
+                conversationId: Number.isFinite(conversationId) ? conversationId : null,
+                lastRole,
+                hasPendingUserWithoutAssistant: lastUserId > 0 && (lastAssistantId === 0 || lastAssistantId < lastUserId),
+            };
+        },
+
+        markConversationPending(conversationId, loadingContext = 'general') {
+            const id = Number(conversationId);
+            if (!Number.isFinite(id)) return;
+            const markers = loadPendingConversationMarkers();
+            markers[id] = { loadingContext, ts: Date.now() };
+            savePendingConversationMarkers(markers);
+        },
+
+        clearConversationPending(conversationId) {
+            const id = Number(conversationId);
+            if (!Number.isFinite(id)) return;
+            const markers = loadPendingConversationMarkers();
+            if (Object.prototype.hasOwnProperty.call(markers, id)) {
+                delete markers[id];
+                savePendingConversationMarkers(markers);
+            }
+        },
+
+        maybeRestorePendingPlaceholder() {
+            const { conversationId, hasPendingUserWithoutAssistant } = this.getConversationMeta();
+            if (!conversationId || !hasPendingUserWithoutAssistant) {
+                return;
+            }
+
+            const markers = loadPendingConversationMarkers();
+            const marker = markers[conversationId];
+            if (!marker) return;
+
+            this.startStreamingPlaceholder(marker.loadingContext || 'general');
+            this.scrollToBottom();
+        },
+
         init() {
             this.$el.dataset.chatMessagesReady = 'true';
             this.scrollToBottom();
@@ -184,10 +251,19 @@ const registerChatPageData = (Alpine) => {
                 this.sources = data[0] || [];
             });
             this.registerWireListener('assistant-message-persisted', () => this.resetStreamingState());
+            this.registerWireListener('assistant-message-persisted', (data) => {
+                const payload = data?.[0] || {};
+                const ackConversationId = Number(payload.conversationId || 0);
+                const { conversationId } = this.getConversationMeta();
+                const targetConversationId = ackConversationId > 0 ? ackConversationId : conversationId;
+                if (targetConversationId) this.clearConversationPending(targetConversationId);
+            });
             this.registerWireListener('user-message-acked', () => {
                 this.optimisticUserMessage = '';
                 this.scrollToBottom();
             });
+
+            this.$nextTick(() => this.maybeRestorePendingPlaceholder());
         },
 
         registerWireListener(event, callback) {
@@ -300,6 +376,11 @@ const registerChatPageData = (Alpine) => {
 
             if (stopStreaming) {
                 this.streaming = false;
+            }
+
+            const { conversationId, hasPendingUserWithoutAssistant } = this.getConversationMeta();
+            if (conversationId && !hasPendingUserWithoutAssistant) {
+                this.clearConversationPending(conversationId);
             }
         },
 
@@ -418,6 +499,7 @@ const registerChatPageData = (Alpine) => {
             this.loadingConversationId = conversationId;
             this.isNavigating = true;
             this.$dispatch('conversation-loading');
+            window.__suppressGlobalPageLoaderOnce = true;
             window.location.assign(event.currentTarget.href);
         },
 
@@ -432,6 +514,7 @@ const registerChatPageData = (Alpine) => {
             this.isNavigating = true;
             this.$dispatch('chat-new-optimistic');
             this.$dispatch('conversation-loading');
+            window.__suppressGlobalPageLoaderOnce = true;
             window.location.assign(event.currentTarget.href);
         },
 
@@ -788,15 +871,26 @@ const registerChatPageData = (Alpine) => {
         isSendingMessage: false,
         sendError: '',
         messageAcked: false,
+        _pendingLoadingContext: 'general',
 
         init() {
             if (this.promptDraft) {
                 this.schedulePendingPromptSubmission();
             }
 
-            this.$wire.on('user-message-acked', () => {
+            this.$wire.on('user-message-acked', (data) => {
                 this.messageAcked = true;
                 this.stabilizeChatScroll();
+
+                const payload = data?.[0] || {};
+                const ackConversationId = Number(payload.conversationId || this.$wire.currentConversationId || 0);
+                if (ackConversationId > 0) {
+                    const chatMessagesEl = document.querySelector('[data-chat-box]');
+                    const chatMessagesData = chatMessagesEl && chatMessagesEl.__x ? chatMessagesEl.__x.$data : null;
+                    if (chatMessagesData && typeof chatMessagesData.markConversationPending === 'function') {
+                        chatMessagesData.markConversationPending(ackConversationId, this._pendingLoadingContext || 'general');
+                    }
+                }
             });
         },
 
@@ -913,6 +1007,7 @@ const registerChatPageData = (Alpine) => {
             this.$dispatch('message-send', { text, loadingContext });
             this.scrollChatToBottom(true);
             this.stabilizeChatScroll();
+            this._pendingLoadingContext = loadingContext;
 
             this.promptDraft = '';
             this.autoResizeTextarea(this.$refs.chatInput);

--- a/laravel/resources/views/components/page-loader.blade.php
+++ b/laravel/resources/views/components/page-loader.blade.php
@@ -87,6 +87,11 @@
     (() => {
         if (!window.__globalPageLoaderHandlers) {
             const showLoader = () => {
+                if (window.__suppressGlobalPageLoaderOnce === true) {
+                    window.__suppressGlobalPageLoaderOnce = false;
+                    return;
+                }
+
                 const loaderEl = document.getElementById('global-page-loader');
                 if (loaderEl) loaderEl.classList.remove('loader-hidden');
             };

--- a/laravel/resources/views/components/page-loader.blade.php
+++ b/laravel/resources/views/components/page-loader.blade.php
@@ -1,3 +1,17 @@
+<script>
+    (() => {
+        const suppressStorageKey = 'ista.globalPageLoader.suppressOnce';
+
+        try {
+            if (window.sessionStorage?.getItem(suppressStorageKey) === '1') {
+                document.documentElement.classList.add('suppress-global-page-loader');
+            }
+        } catch (_) {
+            // ignore storage read errors
+        }
+    })();
+</script>
+
 <style>
     /* Full screen modern animated overlay */
     #global-page-loader {
@@ -26,6 +40,12 @@
         pointer-events: none;
         /* Menghilang secara elegan memudar pelan pelan (Fade OUT) */
         transition: opacity 0.6s cubic-bezier(0.4, 0, 0.2, 1), visibility 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    html.suppress-global-page-loader #global-page-loader {
+        opacity: 0;
+        visibility: hidden;
+        pointer-events: none;
     }
     
     /* Smooth Pulse Animation */
@@ -85,10 +105,31 @@
 
 <script>
     (() => {
+        const suppressStorageKey = 'ista.globalPageLoader.suppressOnce';
+
+        const consumeSuppressLoader = () => {
+            if (window.__suppressGlobalPageLoaderOnce === true) {
+                window.__suppressGlobalPageLoaderOnce = false;
+                return true;
+            }
+
+            try {
+                if (window.sessionStorage?.getItem(suppressStorageKey) === '1') {
+                    window.sessionStorage.removeItem(suppressStorageKey);
+                    return true;
+                }
+            } catch (_) {
+                // ignore storage read errors
+            }
+
+            return false;
+        };
+
+        consumeSuppressLoader();
+
         if (!window.__globalPageLoaderHandlers) {
             const showLoader = () => {
-                if (window.__suppressGlobalPageLoaderOnce === true) {
-                    window.__suppressGlobalPageLoaderOnce = false;
+                if (consumeSuppressLoader()) {
                     return;
                 }
 
@@ -101,6 +142,7 @@
                 if (loaderEl) {
                     setTimeout(() => {
                         loaderEl.classList.add('loader-hidden');
+                        document.documentElement.classList.remove('suppress-global-page-loader');
                     }, 150);
                 }
             };

--- a/laravel/resources/views/livewire/chat/chat-index.blade.php
+++ b/laravel/resources/views/livewire/chat/chat-index.blade.php
@@ -43,9 +43,9 @@
                             <img src="{{ $uiIcons['collapseLeftLight'] }}" alt="" class="h-5 w-5 dark:hidden transition-transform duration-300 ease-in-out" :class="showLeftSidebar ? 'rotate-0' : 'rotate-180'" />
                             <img src="{{ $uiIcons['collapseLeftDark'] }}" alt="" class="h-5 w-5 hidden dark:block transition-transform duration-300 ease-in-out" :class="showLeftSidebar ? 'rotate-0' : 'rotate-180'" />
                         </button>
-                        <button type="button"
-                                @click="$dispatch('chat-new-optimistic'); $dispatch('conversation-loading'); $wire.startNewChat().finally(() => $dispatch('conversation-loaded'))"
-                                class="group flex items-center gap-2"><div class="ista-brand-title text-xl text-ista-primary not-italic transition-transform duration-300 group-hover:scale-105">ISTA <span class="font-light italic text-ista-gold">AI</span></div></button>
+                        <a href="{{ route('chat', ['tab' => $tab]) }}"
+                           @click="window.chatHistoryNavigateToNewChat?.($event)"
+                           class="group flex items-center gap-2"><div class="ista-brand-title text-xl text-ista-primary not-italic transition-transform duration-300 group-hover:scale-105">ISTA <span class="font-light italic text-ista-gold">AI</span></div></a>
                     </div>
 
                     <!-- Center: Tab Toggle -->

--- a/laravel/resources/views/livewire/chat/chat-index.blade.php
+++ b/laravel/resources/views/livewire/chat/chat-index.blade.php
@@ -29,6 +29,10 @@
 
     {{-- ===== CHAT TAB CONTENT ===== --}}
     <div x-show="activeTab === 'chat'" class="flex w-full h-full overflow-hidden">
+        @if(! empty($pendingConversationIds))
+            <div wire:poll.3s="refreshPendingChatState" class="hidden" aria-hidden="true"></div>
+        @endif
+
         <!-- LEFT SIDEBAR: Chat History -->
         @include('livewire.chat.partials.chat-left-sidebar')
 

--- a/laravel/resources/views/livewire/chat/partials/chat-left-sidebar.blade.php
+++ b/laravel/resources/views/livewire/chat/partials/chat-left-sidebar.blade.php
@@ -1,5 +1,5 @@
 <aside
-    x-data="chatHistory({ activeConversationId: @js($currentConversationId ? (int) $currentConversationId : null), showOlderChats: $wire.entangle('showOlderChats') })"
+    x-data="chatHistory({ activeConversationId: @js($currentConversationId ? (int) $currentConversationId : null), showOlderChats: $wire.entangle('showOlderChats'), pendingConversationIds: @js($pendingConversationIds ?? []) })"
     :class="[
         showLeftSidebar ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-full pointer-events-none',
         isMobile ? 'fixed left-0 top-0 h-full w-[288px] shadow-2xl border-r border-stone-200/60 dark:border-[#1E293B]' : (showLeftSidebar ? 'relative w-[288px] border-r border-stone-200/60 dark:border-[#1E293B]' : 'relative w-0 border-r border-transparent')
@@ -50,7 +50,7 @@
                             <img src="{{ $uiIcons['historyLight'] }}" alt="" class="h-4 w-4 mr-2.5 flex-shrink-0 dark:hidden" />
                             <img src="{{ $uiIcons['historyDark'] }}" alt="" class="h-4 w-4 mr-2.5 flex-shrink-0 hidden dark:block" />
                             <span class="truncate text-[13.2px]" title="{{ $conversation->title }}">{{ $conversation->title }}</span>
-                            <span x-show="isLoading({{ $conversation->id }})" class="ml-auto h-3 w-3 rounded-full border border-current border-t-transparent animate-spin" style="display: none;"></span>
+                            <span x-show="isLoading({{ $conversation->id }}) || isPending({{ $conversation->id }})" class="ml-auto h-3 w-3 rounded-full border border-current border-t-transparent animate-spin" style="display: none;"></span>
                         </a>
                         <button type="button" wire:click="deleteConversation({{ $conversation->id }})"
                                 wire:confirm="Delete this chat?"
@@ -87,7 +87,7 @@
                                 <img src="{{ $uiIcons['historyLight'] }}" alt="" class="h-4 w-4 mr-2.5 flex-shrink-0 dark:hidden" />
                                 <img src="{{ $uiIcons['historyDark'] }}" alt="" class="h-4 w-4 mr-2.5 flex-shrink-0 hidden dark:block" />
                                 <span class="truncate text-[13.2px]" title="{{ $conversation->title }}">{{ $conversation->title }}</span>
-                                <span x-show="isLoading({{ $conversation->id }})" class="ml-auto h-3 w-3 rounded-full border border-current border-t-transparent animate-spin" style="display: none;"></span>
+                                <span x-show="isLoading({{ $conversation->id }}) || isPending({{ $conversation->id }})" class="ml-auto h-3 w-3 rounded-full border border-current border-t-transparent animate-spin" style="display: none;"></span>
                             </a>
                             <button type="button" wire:click="deleteConversation({{ $conversation->id }})"
                                     wire:confirm="Delete this chat?"

--- a/laravel/resources/views/livewire/chat/partials/chat-left-sidebar.blade.php
+++ b/laravel/resources/views/livewire/chat/partials/chat-left-sidebar.blade.php
@@ -49,8 +49,9 @@
                            class="chat-history-item {{ (int) $currentConversationId === (int) $conversation->id ? 'is-active' : '' }}">
                             <img src="{{ $uiIcons['historyLight'] }}" alt="" class="h-4 w-4 mr-2.5 flex-shrink-0 dark:hidden" />
                             <img src="{{ $uiIcons['historyDark'] }}" alt="" class="h-4 w-4 mr-2.5 flex-shrink-0 hidden dark:block" />
-                            <span class="truncate text-[13.2px]" title="{{ $conversation->title }}">{{ $conversation->title }}</span>
-                            <span x-show="isLoading({{ $conversation->id }}) || isPending({{ $conversation->id }})" class="ml-auto h-3 w-3 rounded-full border border-current border-t-transparent animate-spin" style="display: none;"></span>
+                            <span class="min-w-0 flex-1 truncate text-[13.2px]" title="{{ $conversation->title }}">{{ $conversation->title }}</span>
+                            <span x-show="isLoading({{ $conversation->id }}) || isPending({{ $conversation->id }})" class="ml-auto h-3 w-3 shrink-0 rounded-full border border-current border-t-transparent animate-spin" style="display: none;"></span>
+                            <span x-show="isCompleteUnread({{ $conversation->id }})" class="ml-auto h-2.5 w-2.5 shrink-0 rounded-full bg-sky-500 shadow-[0_0_0_3px_rgba(14,165,233,0.12)]" style="display: none;" aria-label="Jawaban baru tersedia"></span>
                         </a>
                         <button type="button" wire:click="deleteConversation({{ $conversation->id }})"
                                 wire:confirm="Delete this chat?"
@@ -86,8 +87,9 @@
                                class="chat-history-item {{ (int) $currentConversationId === (int) $conversation->id ? 'is-active' : '' }}">
                                 <img src="{{ $uiIcons['historyLight'] }}" alt="" class="h-4 w-4 mr-2.5 flex-shrink-0 dark:hidden" />
                                 <img src="{{ $uiIcons['historyDark'] }}" alt="" class="h-4 w-4 mr-2.5 flex-shrink-0 hidden dark:block" />
-                                <span class="truncate text-[13.2px]" title="{{ $conversation->title }}">{{ $conversation->title }}</span>
-                                <span x-show="isLoading({{ $conversation->id }}) || isPending({{ $conversation->id }})" class="ml-auto h-3 w-3 rounded-full border border-current border-t-transparent animate-spin" style="display: none;"></span>
+                                <span class="min-w-0 flex-1 truncate text-[13.2px]" title="{{ $conversation->title }}">{{ $conversation->title }}</span>
+                                <span x-show="isLoading({{ $conversation->id }}) || isPending({{ $conversation->id }})" class="ml-auto h-3 w-3 shrink-0 rounded-full border border-current border-t-transparent animate-spin" style="display: none;"></span>
+                                <span x-show="isCompleteUnread({{ $conversation->id }})" class="ml-auto h-2.5 w-2.5 shrink-0 rounded-full bg-sky-500 shadow-[0_0_0_3px_rgba(14,165,233,0.12)]" style="display: none;" aria-label="Jawaban baru tersedia"></span>
                             </a>
                             <button type="button" wire:click="deleteConversation({{ $conversation->id }})"
                                     wire:confirm="Delete this chat?"

--- a/laravel/resources/views/livewire/chat/partials/chat-left-sidebar.blade.php
+++ b/laravel/resources/views/livewire/chat/partials/chat-left-sidebar.blade.php
@@ -24,12 +24,12 @@
     </div>
 
     <div class="p-4 pt-2 pb-5">
-        <button type="button" @click="startNewChat(); if(isMobile) showLeftSidebar = false;" class="w-full flex items-center justify-start px-4 py-2.5 rounded-lg border border-stone-200/60 dark:border-[#334155] dark:bg-transparent bg-white hover:bg-gray-50 dark:hover:bg-white/5 font-medium text-[13px] text-gray-700 dark:text-gray-200 transition-all duration-200 shadow-sm">
+        <a href="{{ route('chat', ['tab' => $tab]) }}" @click="navigateToNewChat($event); if(isMobile) showLeftSidebar = false;" class="w-full flex items-center justify-start px-4 py-2.5 rounded-lg border border-stone-200/60 dark:border-[#334155] dark:bg-transparent bg-white hover:bg-gray-50 dark:hover:bg-white/5 font-medium text-[13px] text-gray-700 dark:text-gray-200 transition-all duration-200 shadow-sm">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 text-[#64748B] dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 5v14m-7-7h14" />
             </svg>
             New Chat
-        </button>
+        </a>
     </div>
 
     <div class="flex-1 overflow-y-auto overflow-x-hidden px-4">
@@ -43,7 +43,7 @@
             <ul class="space-y-1">
                 @forelse($todayChats as $conversation)
                     <li class="group relative" wire:key="chat-history-visible-{{ $conversation->id }}">
-                        <button type="button" @click="loadConversation({{ $conversation->id }}); if(isMobile) showLeftSidebar = false;"
+                        <a href="{{ route('chat', ['id' => $conversation->id, 'tab' => $tab]) }}" @click="navigateToConversation($event, {{ $conversation->id }}); if(isMobile) showLeftSidebar = false;"
                            data-chat-history-id="{{ $conversation->id }}"
                            :class="{ 'is-active': isActive({{ $conversation->id }}) }"
                            class="chat-history-item {{ (int) $currentConversationId === (int) $conversation->id ? 'is-active' : '' }}">
@@ -51,7 +51,7 @@
                             <img src="{{ $uiIcons['historyDark'] }}" alt="" class="h-4 w-4 mr-2.5 flex-shrink-0 hidden dark:block" />
                             <span class="truncate text-[13.2px]" title="{{ $conversation->title }}">{{ $conversation->title }}</span>
                             <span x-show="isLoading({{ $conversation->id }})" class="ml-auto h-3 w-3 rounded-full border border-current border-t-transparent animate-spin" style="display: none;"></span>
-                        </button>
+                        </a>
                         <button type="button" wire:click="deleteConversation({{ $conversation->id }})"
                                 wire:confirm="Delete this chat?"
                                 class="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-md opacity-0 group-hover:opacity-100 hover:bg-red-100 dark:hover:bg-red-500/20 text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-all duration-200"
@@ -80,7 +80,7 @@
                 <ul x-show="showOlderChats" class="mt-1 space-y-1" style="{{ $showOlderChats ? '' : 'display: none;' }}">
                     @foreach($olderChats as $conversation)
                         <li class="group relative" wire:key="chat-history-older-{{ $conversation->id }}">
-                            <button type="button" @click="loadConversation({{ $conversation->id }}); if(isMobile) showLeftSidebar = false;"
+                            <a href="{{ route('chat', ['id' => $conversation->id, 'tab' => $tab]) }}" @click="navigateToConversation($event, {{ $conversation->id }}); if(isMobile) showLeftSidebar = false;"
                                data-chat-history-id="{{ $conversation->id }}"
                                :class="{ 'is-active': isActive({{ $conversation->id }}) }"
                                class="chat-history-item {{ (int) $currentConversationId === (int) $conversation->id ? 'is-active' : '' }}">
@@ -88,7 +88,7 @@
                                 <img src="{{ $uiIcons['historyDark'] }}" alt="" class="h-4 w-4 mr-2.5 flex-shrink-0 hidden dark:block" />
                                 <span class="truncate text-[13.2px]" title="{{ $conversation->title }}">{{ $conversation->title }}</span>
                                 <span x-show="isLoading({{ $conversation->id }})" class="ml-auto h-3 w-3 rounded-full border border-current border-t-transparent animate-spin" style="display: none;"></span>
-                            </button>
+                            </a>
                             <button type="button" wire:click="deleteConversation({{ $conversation->id }})"
                                     wire:confirm="Delete this chat?"
                                     class="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-md opacity-0 group-hover:opacity-100 hover:bg-red-100 dark:hover:bg-red-500/20 text-gray-400 hover:text-red-600 transition-all duration-200">

--- a/laravel/resources/views/livewire/chat/partials/chat-left-sidebar.blade.php
+++ b/laravel/resources/views/livewire/chat/partials/chat-left-sidebar.blade.php
@@ -24,7 +24,7 @@
     </div>
 
     <div class="p-4 pt-2 pb-5">
-        <button type="button" @click="startNewChat(); if(isMobile) showLeftSidebar = false;" :disabled="isNavigating" class="w-full flex items-center justify-start px-4 py-2.5 rounded-lg border border-stone-200/60 dark:border-[#334155] dark:bg-transparent bg-white hover:bg-gray-50 dark:hover:bg-white/5 font-medium text-[13px] text-gray-700 dark:text-gray-200 transition-all duration-200 shadow-sm disabled:cursor-wait disabled:opacity-70">
+        <button type="button" @click="startNewChat(); if(isMobile) showLeftSidebar = false;" class="w-full flex items-center justify-start px-4 py-2.5 rounded-lg border border-stone-200/60 dark:border-[#334155] dark:bg-transparent bg-white hover:bg-gray-50 dark:hover:bg-white/5 font-medium text-[13px] text-gray-700 dark:text-gray-200 transition-all duration-200 shadow-sm">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 text-[#64748B] dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 5v14m-7-7h14" />
             </svg>
@@ -45,7 +45,6 @@
                     <li class="group relative" wire:key="chat-history-visible-{{ $conversation->id }}">
                         <button type="button" @click="loadConversation({{ $conversation->id }}); if(isMobile) showLeftSidebar = false;"
                            data-chat-history-id="{{ $conversation->id }}"
-                           :disabled="isNavigating"
                            :class="{ 'is-active': isActive({{ $conversation->id }}) }"
                            class="chat-history-item {{ (int) $currentConversationId === (int) $conversation->id ? 'is-active' : '' }}">
                             <img src="{{ $uiIcons['historyLight'] }}" alt="" class="h-4 w-4 mr-2.5 flex-shrink-0 dark:hidden" />
@@ -83,7 +82,6 @@
                         <li class="group relative" wire:key="chat-history-older-{{ $conversation->id }}">
                             <button type="button" @click="loadConversation({{ $conversation->id }}); if(isMobile) showLeftSidebar = false;"
                                data-chat-history-id="{{ $conversation->id }}"
-                               :disabled="isNavigating"
                                :class="{ 'is-active': isActive({{ $conversation->id }}) }"
                                class="chat-history-item {{ (int) $currentConversationId === (int) $conversation->id ? 'is-active' : '' }}">
                                 <img src="{{ $uiIcons['historyLight'] }}" alt="" class="h-4 w-4 mr-2.5 flex-shrink-0 dark:hidden" />

--- a/laravel/resources/views/livewire/chat/partials/chat-messages.blade.php
+++ b/laravel/resources/views/livewire/chat/partials/chat-messages.blade.php
@@ -10,6 +10,7 @@
          data-chat-conversation-id="{{ $currentConversationId ?? '' }}"
          data-chat-last-message-role="{{ !empty($messages) ? ($messages[array_key_last($messages)]['role'] ?? '') : '' }}"
          data-chat-last-user-message-id="{{ collect($messages)->where('role', 'user')->last()['id'] ?? '' }}"
+         data-chat-last-user-message-created-at="{{ collect($messages)->where('role', 'user')->last()['created_at'] ?? '' }}"
          data-chat-last-assistant-message-id="{{ collect($messages)->where('role', 'assistant')->last()['id'] ?? '' }}"
          aria-hidden="true"></div>
     @if(empty($messages))

--- a/laravel/resources/views/livewire/chat/partials/chat-messages.blade.php
+++ b/laravel/resources/views/livewire/chat/partials/chat-messages.blade.php
@@ -4,8 +4,8 @@
      data-chat-box
      x-on:message-streamed.window="scrollToBottom()"
      x-on:message-send.window="optimisticUserMessage = $event.detail.text; isSwitchingConversation = false; startStreamingPlaceholder($event.detail.loadingContext || 'general'); scrollToBottom(true)"
-     x-on:conversation-loading.window="isSwitchingConversation = true; optimisticUserMessage = ''"
-     x-on:conversation-loaded.window="isSwitchingConversation = false; resetStreamingState(); scrollToBottom()">
+     x-on:conversation-loading.window="isSwitchingConversation = true; optimisticUserMessage = ''; resetStreamingState()"
+     x-on:conversation-loaded.window="isSwitchingConversation = false; resetStreamingState(); $nextTick(() => { maybeRestorePendingPlaceholder(); scrollToBottom(); })">
     <div class="hidden"
          data-chat-conversation-id="{{ $currentConversationId ?? '' }}"
          data-chat-last-message-role="{{ !empty($messages) ? ($messages[array_key_last($messages)]['role'] ?? '') : '' }}"

--- a/laravel/resources/views/livewire/chat/partials/chat-messages.blade.php
+++ b/laravel/resources/views/livewire/chat/partials/chat-messages.blade.php
@@ -6,6 +6,12 @@
      x-on:message-send.window="optimisticUserMessage = $event.detail.text; isSwitchingConversation = false; startStreamingPlaceholder($event.detail.loadingContext || 'general'); scrollToBottom(true)"
      x-on:conversation-loading.window="isSwitchingConversation = true; optimisticUserMessage = ''"
      x-on:conversation-loaded.window="isSwitchingConversation = false; resetStreamingState(); scrollToBottom()">
+    <div class="hidden"
+         data-chat-conversation-id="{{ $currentConversationId ?? '' }}"
+         data-chat-last-message-role="{{ !empty($messages) ? ($messages[array_key_last($messages)]['role'] ?? '') : '' }}"
+         data-chat-last-user-message-id="{{ collect($messages)->where('role', 'user')->last()['id'] ?? '' }}"
+         data-chat-last-assistant-message-id="{{ collect($messages)->where('role', 'assistant')->last()['id'] ?? '' }}"
+         aria-hidden="true"></div>
     @if(empty($messages))
         <div x-show="!optimisticUserMessage && !isSwitchingConversation" x-transition.opacity class="h-full flex flex-col items-center justify-center text-center">
             <div class="h-16 w-16 mb-6">

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -31,8 +31,9 @@ Route::view('profile', 'profile')
     ->middleware(['auth'])
     ->name('profile');
 
-Route::get('chat', ChatIndex::class)
+Route::get('chat/{id?}', ChatIndex::class)
     ->middleware(['auth', 'verified', 'throttle:30,1'])
+    ->whereNumber('id')
     ->name('chat');
 
 Route::post('onlyoffice/callback/{memo}', OnlyOfficeCallbackController::class)

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -214,6 +214,10 @@ class ChatUiTest extends TestCase
         ]);
 
         $response = $this->actingAs($user)->get('/chat');
+        $chatPageJs = file_get_contents(resource_path('js/chat-page.js'));
+        $this->assertIsString($chatPageJs);
+        $this->assertStringContainsString('hasActiveChatRequest', $chatPageJs);
+        $this->assertStringContainsString('window.history.pushState', $chatPageJs);
 
         $response
             ->assertOk()

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -223,7 +223,7 @@ class ChatUiTest extends TestCase
             ->assertDontSee('Membuka chat...', false)
             ->assertSee('x-on:conversation-loading.window="isSwitchingConversation = true"', false)
             ->assertSee('x-on:conversation-activated.window="setActiveConversation($event.detail.id)"', false)
-            ->assertSee(':disabled="isNavigating"', false)
+            ->assertDontSee(':disabled="isNavigating"', false)
             ->assertSee('data-chat-history-id=', false)
             ->assertSee('isLoading(', false)
             ->assertSee('chat-history-item', false)
@@ -236,6 +236,67 @@ class ChatUiTest extends TestCase
             ->assertSee('chat-tab-switch', false)
             ->assertSee('activeTab === \'chat\'', false)
             ->assertDontSee('wire:click="$set(\'tab\', \'chat\')"', false);
+    }
+
+    public function test_send_message_saves_assistant_message_to_original_conversation_when_active_changes_mid_request(): void
+    {
+        $user = User::factory()->create();
+
+        $conversationA = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Conversation A',
+        ]);
+
+        $conversationB = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Conversation B',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class($conversationB->id) extends AIService
+        {
+            public function __construct(private readonly int $switchConversationId) {}
+
+            public function sendChat(array $messages, ?array $document_filenames = null, ?string $user_id = null, bool $force_web_search = false, ?string $source_policy = null, bool $allow_auto_realtime_web = true): \Generator
+            {
+                app()->instance('chat_test_switch_target', $this->switchConversationId);
+
+                yield 'Jawaban AI tetap masuk ke conversation asal.';
+            }
+        });
+
+        $component = Livewire::actingAs($user)
+            ->test(ChatIndex::class)
+            ->set('currentConversationId', $conversationA->id);
+
+        /** @var ChatIndex $componentInstance */
+        $componentInstance = $component->instance();
+
+        $component
+            ->set('prompt', 'Pesan pengguna awal')
+            ->call('sendMessage', aiService: app(AIService::class), orchestrator: new class($componentInstance, $conversationB->id) extends ChatOrchestrationService
+            {
+                public function __construct(private readonly ChatIndex $component, private readonly int $targetConversationId) {}
+
+                public function extractStreamMetadata(string $chunk, string $buffer = ''): array
+                {
+                    $this->component->startNewChat();
+                    $this->component->loadConversation($this->targetConversationId);
+
+                    return parent::extractStreamMetadata($chunk, $buffer);
+                }
+            });
+
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversationA->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban AI tetap masuk ke conversation asal.',
+        ]);
+
+        $this->assertDatabaseMissing('messages', [
+            'conversation_id' => $conversationB->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban AI tetap masuk ke conversation asal.',
+        ]);
     }
 
     public function test_loading_conversation_dispatches_active_history_event(): void

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -11,6 +11,7 @@ use App\Services\AIService;
 use App\Services\ChatOrchestrationService;
 use App\Services\DocumentExportService;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\RateLimiter;
@@ -297,6 +298,87 @@ class ChatUiTest extends TestCase
             'role' => 'assistant',
             'content' => 'Jawaban AI tetap masuk ke conversation asal.',
         ]);
+    }
+
+    public function test_send_message_gracefully_skips_assistant_persistence_when_origin_conversation_deleted_mid_request(): void
+    {
+        $user = User::factory()->create();
+
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Conversation asal',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(array $messages, ?array $document_filenames = null, ?string $user_id = null, bool $force_web_search = false, ?string $source_policy = null, bool $allow_auto_realtime_web = true): \Generator
+            {
+                yield 'Jawaban AI setelah conversation terhapus.';
+            }
+        });
+
+        $component = Livewire::actingAs($user)
+            ->test(ChatIndex::class)
+            ->set('currentConversationId', $conversation->id)
+            ->set('prompt', 'Pesan user sebelum hapus conversation');
+
+        /** @var ChatIndex $componentInstance */
+        $componentInstance = $component->instance();
+
+        $component->call('sendMessage', aiService: app(AIService::class), orchestrator: new class($componentInstance, $conversation->id) extends ChatOrchestrationService
+        {
+            private bool $deleted = false;
+
+            public function __construct(private readonly ChatIndex $component, private readonly int $conversationIdToDelete) {}
+
+            public function extractStreamMetadata(string $chunk, string $buffer = ''): array
+            {
+                if (! $this->deleted) {
+                    $this->deleted = true;
+                    $this->component->deleteConversation($this->conversationIdToDelete);
+                }
+
+                return parent::extractStreamMetadata($chunk, $buffer);
+            }
+        });
+
+        $this->assertDatabaseMissing('conversations', [
+            'id' => $conversation->id,
+        ]);
+
+        $this->assertDatabaseMissing('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban AI setelah conversation terhapus.',
+        ]);
+    }
+
+    public function test_save_assistant_message_returns_null_when_create_hits_conversation_fk_race(): void
+    {
+        $service = new class extends ChatOrchestrationService
+        {
+            protected function conversationExists(int $conversationId): bool
+            {
+                return true;
+            }
+
+            protected function createAssistantMessage(int $conversationId, string $content): Message
+            {
+                $pdoException = new \PDOException('Cannot add or update a child row: a foreign key constraint fails');
+                $pdoException->errorInfo = ['23000', 1452, 'Cannot add or update a child row: a foreign key constraint fails'];
+
+                throw new QueryException(
+                    'mysql',
+                    'insert into `messages` (`conversation_id`, `role`, `content`) values (?, ?, ?)',
+                    [$conversationId, 'assistant', $content],
+                    $pdoException
+                );
+            }
+        };
+
+        $result = $service->saveAssistantMessage(999999, 'Assistant response');
+
+        $this->assertNull($result);
     }
 
     public function test_loading_conversation_dispatches_active_history_event(): void

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -239,7 +239,8 @@ class ChatUiTest extends TestCase
             ->assertSee('activeTab === \'chat\'', false)
             ->assertDontSee('wire:click="$set(\'tab\', \'chat\')"', false)
             ->assertSee('data-chat-conversation-id=', false)
-            ->assertSee('data-chat-last-message-role=', false);
+            ->assertSee('data-chat-last-message-role=', false)
+            ->assertSee('data-chat-last-user-message-created-at=', false);
     }
 
     public function test_chat_route_with_conversation_id_loads_selected_conversation_messages(): void
@@ -261,6 +262,7 @@ class ChatUiTest extends TestCase
         $response
             ->assertOk()
             ->assertSee('Halo dari history URL', false)
+            ->assertSee('data-chat-last-user-message-created-at=', false)
             ->assertSee('data-chat-history-id="'.$conversation->id.'"', false);
     }
 

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Chat;
 
+use App\Jobs\GenerateChatResponse;
 use App\Livewire\Chat\ChatIndex;
 use App\Models\Conversation;
 use App\Models\Document;
@@ -14,6 +15,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\RateLimiter;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -62,7 +64,7 @@ class ChatUiTest extends TestCase
             'title' => 'Owned by A',
         ]);
 
-        $service = new ChatOrchestrationService();
+        $service = new ChatOrchestrationService;
 
         $this->actingAs($userB);
         $this->expectException(AuthorizationException::class);
@@ -106,7 +108,7 @@ class ChatUiTest extends TestCase
             'status' => 'ready',
         ]);
 
-        $service = new ChatOrchestrationService();
+        $service = new ChatOrchestrationService;
 
         $this->actingAs($user);
 
@@ -212,11 +214,20 @@ class ChatUiTest extends TestCase
             'user_id' => $user->id,
             'title' => 'History test',
         ]);
+        $pendingConversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Pending history test',
+        ]);
+        Message::create([
+            'conversation_id' => $pendingConversation->id,
+            'role' => 'user',
+            'content' => 'Prompt yang masih menunggu jawaban',
+        ]);
 
         $response = $this->actingAs($user)->get('/chat');
         $chatPageJs = file_get_contents(resource_path('js/chat-page.js'));
         $this->assertIsString($chatPageJs);
-        $this->assertStringContainsString('hasActiveChatRequest', $chatPageJs);
+        $this->assertStringContainsString('pendingConversationIds', $chatPageJs);
         $this->assertStringContainsString('window.history.pushState', $chatPageJs);
 
         $response
@@ -230,6 +241,9 @@ class ChatUiTest extends TestCase
             ->assertSee('x-on:conversation-activated.window="setActiveConversation($event.detail.id)"', false)
             ->assertDontSee(':disabled="isNavigating"', false)
             ->assertSee('data-chat-history-id=', false)
+            ->assertSee('pendingConversationIds:', false)
+            ->assertSee('isPending(', false)
+            ->assertSee('wire:poll.3s="refreshPendingChatState"', false)
             ->assertSee('navigateToConversation($event,', false)
             ->assertSee('navigateToNewChat($event)', false)
             ->assertSee('chat-history-item', false)
@@ -285,68 +299,53 @@ class ChatUiTest extends TestCase
             ->assertNotFound();
     }
 
-    public function test_send_message_saves_assistant_message_to_original_conversation_when_active_changes_mid_request(): void
+    public function test_send_message_queues_response_and_allows_loading_another_conversation_without_waiting(): void
     {
-        $user = User::factory()->create();
+        Queue::fake();
 
-        $conversationA = Conversation::create([
-            'user_id' => $user->id,
-            'title' => 'Conversation A',
-        ]);
+        $user = User::factory()->create();
 
         $conversationB = Conversation::create([
             'user_id' => $user->id,
             'title' => 'Conversation B',
         ]);
 
-        $this->app->bind(AIService::class, fn () => new class($conversationB->id) extends AIService
-        {
-            public function __construct(private readonly int $switchConversationId) {}
-
-            public function sendChat(array $messages, ?array $document_filenames = null, ?string $user_id = null, bool $force_web_search = false, ?string $source_policy = null, bool $allow_auto_realtime_web = true): \Generator
-            {
-                app()->instance('chat_test_switch_target', $this->switchConversationId);
-
-                yield 'Jawaban AI tetap masuk ke conversation asal.';
-            }
-        });
-
         $component = Livewire::actingAs($user)
-            ->test(ChatIndex::class)
-            ->set('currentConversationId', $conversationA->id);
-
-        /** @var ChatIndex $componentInstance */
-        $componentInstance = $component->instance();
+            ->test(ChatIndex::class);
 
         $component
             ->set('prompt', 'Pesan pengguna awal')
-            ->call('sendMessage', aiService: app(AIService::class), orchestrator: new class($componentInstance, $conversationB->id) extends ChatOrchestrationService
-            {
-                public function __construct(private readonly ChatIndex $component, private readonly int $targetConversationId) {}
+            ->call('sendMessage', aiService: app(AIService::class));
 
-                public function extractStreamMetadata(string $chunk, string $buffer = ''): array
-                {
-                    $this->component->startNewChat();
-                    $this->component->loadConversation($this->targetConversationId);
+        $conversationA = Conversation::query()
+            ->where('user_id', $user->id)
+            ->where('title', 'like', 'Pesan pengguna awal%')
+            ->firstOrFail();
 
-                    return parent::extractStreamMetadata($chunk, $buffer);
-                }
-            });
+        $component
+            ->assertSet('currentConversationId', $conversationA->id)
+            ->assertSet('pendingConversationIds', [$conversationA->id])
+            ->assertDispatched('user-message-acked')
+            ->assertDispatched('conversation-activated', id: $conversationA->id);
+
+        Queue::assertPushed(GenerateChatResponse::class, function (GenerateChatResponse $job) use ($conversationA, $user) {
+            return $job->conversationId === (int) $conversationA->id
+                && $job->userId === (int) $user->id
+                && $job->history[count($job->history) - 1]['content'] === 'Pesan pengguna awal';
+        });
+
+        $component
+            ->call('loadConversation', $conversationB->id)
+            ->assertSet('currentConversationId', $conversationB->id);
 
         $this->assertDatabaseHas('messages', [
             'conversation_id' => $conversationA->id,
-            'role' => 'assistant',
-            'content' => 'Jawaban AI tetap masuk ke conversation asal.',
-        ]);
-
-        $this->assertDatabaseMissing('messages', [
-            'conversation_id' => $conversationB->id,
-            'role' => 'assistant',
-            'content' => 'Jawaban AI tetap masuk ke conversation asal.',
+            'role' => 'user',
+            'content' => 'Pesan pengguna awal',
         ]);
     }
 
-    public function test_send_message_gracefully_skips_assistant_persistence_when_origin_conversation_deleted_mid_request(): void
+    public function test_generate_chat_response_skips_assistant_persistence_when_origin_conversation_deleted_before_job_runs(): void
     {
         $user = User::factory()->create();
 
@@ -359,34 +358,17 @@ class ChatUiTest extends TestCase
         {
             public function sendChat(array $messages, ?array $document_filenames = null, ?string $user_id = null, bool $force_web_search = false, ?string $source_policy = null, bool $allow_auto_realtime_web = true): \Generator
             {
-                yield 'Jawaban AI setelah conversation terhapus.';
+                throw new \RuntimeException('AIService should not be called for deleted conversation.');
             }
         });
 
-        $component = Livewire::actingAs($user)
-            ->test(ChatIndex::class)
-            ->set('currentConversationId', $conversation->id)
-            ->set('prompt', 'Pesan user sebelum hapus conversation');
-
-        /** @var ChatIndex $componentInstance */
-        $componentInstance = $component->instance();
-
-        $component->call('sendMessage', aiService: app(AIService::class), orchestrator: new class($componentInstance, $conversation->id) extends ChatOrchestrationService
-        {
-            private bool $deleted = false;
-
-            public function __construct(private readonly ChatIndex $component, private readonly int $conversationIdToDelete) {}
-
-            public function extractStreamMetadata(string $chunk, string $buffer = ''): array
-            {
-                if (! $this->deleted) {
-                    $this->deleted = true;
-                    $this->component->deleteConversation($this->conversationIdToDelete);
-                }
-
-                return parent::extractStreamMetadata($chunk, $buffer);
-            }
-        });
+        $conversation->delete();
+        $job = new GenerateChatResponse(
+            conversationId: (int) $conversation->id,
+            userId: (int) $user->id,
+            history: [['role' => 'user', 'content' => 'Pesan user sebelum hapus conversation']],
+        );
+        $job->handle(app(AIService::class), new ChatOrchestrationService);
 
         $this->assertDatabaseMissing('conversations', [
             'id' => $conversation->id,
@@ -395,12 +377,46 @@ class ChatUiTest extends TestCase
         $this->assertDatabaseMissing('messages', [
             'conversation_id' => $conversation->id,
             'role' => 'assistant',
-            'content' => 'Jawaban AI setelah conversation terhapus.',
+            'content' => 'Maaf, jawaban gagal diproses. Silakan coba kirim ulang.',
         ]);
     }
 
-    public function test_send_message_dispatches_ack_and_persisted_events_with_conversation_id_payload(): void
+    public function test_generate_chat_response_persists_assistant_message_to_origin_conversation(): void
     {
+        $user = User::factory()->create();
+
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Conversation job asal',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(array $messages, ?array $document_filenames = null, ?string $user_id = null, bool $force_web_search = false, ?string $source_policy = null, bool $allow_auto_realtime_web = true): \Generator
+            {
+                yield 'Jawaban AI dari background job.';
+            }
+        });
+
+        $job = new GenerateChatResponse(
+            conversationId: (int) $conversation->id,
+            userId: (int) $user->id,
+            history: [['role' => 'user', 'content' => 'Pesan user untuk job']],
+        );
+
+        $job->handle(app(AIService::class), new ChatOrchestrationService);
+
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban AI dari background job.',
+        ]);
+    }
+
+    public function test_send_message_dispatches_ack_and_queues_response_with_conversation_id_payload(): void
+    {
+        Queue::fake();
+
         $user = User::factory()->create();
 
         $this->app->bind(AIService::class, fn () => new class extends AIService
@@ -423,9 +439,9 @@ class ChatUiTest extends TestCase
                 && (int) ($payload['messageId'] ?? 0) > 0;
         });
 
-        $component->assertDispatched('assistant-message-persisted', function (string $_event, array $payload) use ($conversationId) {
-            return (int) ($payload['conversationId'] ?? 0) === $conversationId
-                && (int) ($payload['messageId'] ?? 0) > 0;
+        Queue::assertPushed(GenerateChatResponse::class, function (GenerateChatResponse $job) use ($conversationId, $user) {
+            return $job->conversationId === $conversationId
+                && $job->userId === (int) $user->id;
         });
     }
 
@@ -469,7 +485,7 @@ class ChatUiTest extends TestCase
 
         $this->actingAs($otherUser);
 
-        $service = new ChatOrchestrationService();
+        $service = new ChatOrchestrationService;
 
         $result = $service->saveAssistantMessage($conversation->id, 'Assistant response should be blocked');
 
@@ -651,6 +667,42 @@ class ChatUiTest extends TestCase
             ->call('loadConversation', $conversation->id, false)
             ->assertSet('newMessageId', $message->id)
             ->assertSee('wire:key="msg-typing-'.$message->id.'"', false);
+    }
+
+    public function test_refresh_pending_chat_state_loads_completed_active_conversation(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Pending refresh test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Tolong jawab setelah job selesai.',
+        ]);
+
+        $component = Livewire::actingAs($user)
+            ->test(ChatIndex::class, ['id' => $conversation->id])
+            ->assertSet('pendingConversationIds', [$conversation->id]);
+
+        $assistant = Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban background sudah selesai.',
+        ]);
+        $conversation->touch();
+
+        $component
+            ->call('refreshPendingChatState')
+            ->assertSet('pendingConversationIds', [])
+            ->assertSet('newMessageId', $assistant->id)
+            ->assertSee('Jawaban background sudah selesai.', false)
+            ->assertDispatched('assistant-message-persisted', function (string $_event, array $payload) use ($conversation, $assistant) {
+                return (int) ($payload['conversationId'] ?? 0) === (int) $conversation->id
+                    && (int) ($payload['messageId'] ?? 0) === (int) $assistant->id;
+            });
     }
 
     public function test_chat_history_groups_today_by_jakarta_date(): void

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -237,7 +237,9 @@ class ChatUiTest extends TestCase
             ->assertSee('Pilih file untuk chat', false)
             ->assertSee('chat-tab-switch', false)
             ->assertSee('activeTab === \'chat\'', false)
-            ->assertDontSee('wire:click="$set(\'tab\', \'chat\')"', false);
+            ->assertDontSee('wire:click="$set(\'tab\', \'chat\')"', false)
+            ->assertSee('data-chat-conversation-id=', false)
+            ->assertSee('data-chat-last-message-role=', false);
     }
 
     public function test_chat_route_with_conversation_id_loads_selected_conversation_messages(): void
@@ -389,6 +391,36 @@ class ChatUiTest extends TestCase
             'role' => 'assistant',
             'content' => 'Jawaban AI setelah conversation terhapus.',
         ]);
+    }
+
+    public function test_send_message_dispatches_ack_and_persisted_events_with_conversation_id_payload(): void
+    {
+        $user = User::factory()->create();
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(array $messages, ?array $document_filenames = null, ?string $user_id = null, bool $force_web_search = false, ?string $source_policy = null, bool $allow_auto_realtime_web = true): \Generator
+            {
+                yield 'Jawaban AI untuk payload event.';
+            }
+        });
+
+        $component = Livewire::actingAs($user)
+            ->test(ChatIndex::class)
+            ->set('prompt', 'Halo payload event')
+            ->call('sendMessage', aiService: app(AIService::class));
+
+        $conversationId = (int) $component->get('currentConversationId');
+
+        $component->assertDispatched('user-message-acked', function (string $_event, array $payload) use ($conversationId) {
+            return (int) ($payload['conversationId'] ?? 0) === $conversationId
+                && (int) ($payload['messageId'] ?? 0) > 0;
+        });
+
+        $component->assertDispatched('assistant-message-persisted', function (string $_event, array $payload) use ($conversationId) {
+            return (int) ($payload['conversationId'] ?? 0) === $conversationId
+                && (int) ($payload['messageId'] ?? 0) > 0;
+        });
     }
 
     public function test_save_assistant_message_returns_null_when_create_hits_conversation_fk_race(): void

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -381,6 +381,30 @@ class ChatUiTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function test_save_assistant_message_returns_null_for_conversation_not_owned_by_current_user(): void
+    {
+        $owner = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $conversation = Conversation::create([
+            'user_id' => $owner->id,
+            'title' => 'Owned by owner',
+        ]);
+
+        $this->actingAs($otherUser);
+
+        $service = new ChatOrchestrationService();
+
+        $result = $service->saveAssistantMessage($conversation->id, 'Assistant response should be blocked');
+
+        $this->assertNull($result);
+        $this->assertDatabaseMissing('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Assistant response should be blocked',
+        ]);
+    }
+
     public function test_loading_conversation_dispatches_active_history_event(): void
     {
         $user = User::factory()->create();

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -230,6 +230,8 @@ class ChatUiTest extends TestCase
         $this->assertStringContainsString('pendingConversationIds', $chatPageJs);
         $this->assertStringContainsString('completedConversationIds', $chatPageJs);
         $this->assertStringContainsString('normalizeWirePayload', $chatPageJs);
+        $this->assertStringContainsString('this.activeConversationId === conversationId', $chatPageJs);
+        $this->assertStringContainsString('this.markConversationRead(this.activeConversationId)', $chatPageJs);
         $this->assertStringContainsString('window.history.pushState', $chatPageJs);
 
         $response

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -226,7 +226,8 @@ class ChatUiTest extends TestCase
             ->assertSee('x-on:conversation-activated.window="setActiveConversation($event.detail.id)"', false)
             ->assertDontSee(':disabled="isNavigating"', false)
             ->assertSee('data-chat-history-id=', false)
-            ->assertSee('isLoading(', false)
+            ->assertSee('navigateToConversation($event,', false)
+            ->assertSee('navigateToNewChat($event)', false)
             ->assertSee('chat-history-item', false)
             ->assertSee('wire:key="chat-history-visible-', false)
             ->assertSee('openGoogleDrivePicker()', false)
@@ -237,6 +238,43 @@ class ChatUiTest extends TestCase
             ->assertSee('chat-tab-switch', false)
             ->assertSee('activeTab === \'chat\'', false)
             ->assertDontSee('wire:click="$set(\'tab\', \'chat\')"', false);
+    }
+
+    public function test_chat_route_with_conversation_id_loads_selected_conversation_messages(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Conversation terpilih via URL',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Halo dari history URL',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('chat', ['id' => $conversation->id]));
+
+        $response
+            ->assertOk()
+            ->assertSee('Halo dari history URL', false)
+            ->assertSee('data-chat-history-id="'.$conversation->id.'"', false);
+    }
+
+    public function test_chat_route_with_foreign_conversation_id_returns_404(): void
+    {
+        $owner = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $conversation = Conversation::create([
+            'user_id' => $owner->id,
+            'title' => 'Conversation user lain',
+        ]);
+
+        $this->actingAs($otherUser)
+            ->get(route('chat', ['id' => $conversation->id]))
+            ->assertNotFound();
     }
 
     public function test_send_message_saves_assistant_message_to_original_conversation_when_active_changes_mid_request(): void

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -228,6 +228,8 @@ class ChatUiTest extends TestCase
         $chatPageJs = file_get_contents(resource_path('js/chat-page.js'));
         $this->assertIsString($chatPageJs);
         $this->assertStringContainsString('pendingConversationIds', $chatPageJs);
+        $this->assertStringContainsString('completedConversationIds', $chatPageJs);
+        $this->assertStringContainsString('normalizeWirePayload', $chatPageJs);
         $this->assertStringContainsString('window.history.pushState', $chatPageJs);
 
         $response
@@ -243,6 +245,11 @@ class ChatUiTest extends TestCase
             ->assertSee('data-chat-history-id=', false)
             ->assertSee('pendingConversationIds:', false)
             ->assertSee('isPending(', false)
+            ->assertSee('isCompleteUnread(', false)
+            ->assertSee('Jawaban baru tersedia', false)
+            ->assertSee('h-3 w-3 shrink-0 rounded-full border', false)
+            ->assertSee('min-w-0 flex-1 truncate', false)
+            ->assertSee('bg-sky-500', false)
             ->assertSee('wire:poll.3s="refreshPendingChatState"', false)
             ->assertSee('navigateToConversation($event,', false)
             ->assertSee('navigateToNewChat($event)', false)

--- a/laravel/tests/Feature/PageLoaderComponentTest.php
+++ b/laravel/tests/Feature/PageLoaderComponentTest.php
@@ -10,10 +10,15 @@ class PageLoaderComponentTest extends TestCase
     public function test_page_loader_script_is_guarded_for_idempotent_rerenders(): void
     {
         $html = Blade::render('<x-page-loader />');
+        $componentSource = file_get_contents(resource_path('views/components/page-loader.blade.php'));
+        $this->assertIsString($componentSource);
 
         $this->assertStringContainsString('window.__globalPageLoaderHandlers', $html);
         $this->assertStringContainsString('if (!window.__globalPageLoaderHandlers)', $html);
         $this->assertStringContainsString('document.addEventListener(\'livewire:navigating\', showLoader);', $html);
         $this->assertStringContainsString('window.__suppressGlobalPageLoaderOnce === true', $html);
+        $this->assertStringContainsString('ista.globalPageLoader.suppressOnce', $componentSource);
+        $this->assertStringContainsString('suppress-global-page-loader', $componentSource);
+        $this->assertStringContainsString('window.sessionStorage.removeItem(suppressStorageKey)', $componentSource);
     }
 }

--- a/laravel/tests/Feature/PageLoaderComponentTest.php
+++ b/laravel/tests/Feature/PageLoaderComponentTest.php
@@ -14,5 +14,6 @@ class PageLoaderComponentTest extends TestCase
         $this->assertStringContainsString('window.__globalPageLoaderHandlers', $html);
         $this->assertStringContainsString('if (!window.__globalPageLoaderHandlers)', $html);
         $this->assertStringContainsString('document.addEventListener(\'livewire:navigating\', showLoader);', $html);
+        $this->assertStringContainsString('window.__suppressGlobalPageLoaderOnce === true', $html);
     }
 }

--- a/python-ai/app/chat_api.py
+++ b/python-ai/app/chat_api.py
@@ -158,23 +158,24 @@ async def chat_stream(request: ChatRequest):
     if documents_active and query:
         search_relevant_chunks, build_rag_prompt = _get_rag_document_helpers()
         if should_web_search:
-            retrieval_task = asyncio.to_thread(
+            chunks, success = await asyncio.to_thread(
                 search_relevant_chunks,
                 query,
                 request.document_filenames,
                 _get_rag_top_k(),
                 request.user_id,
             )
-            web_task = asyncio.to_thread(
-                get_context_for_query,
-                query,
-                request.force_web_search,
-                allow_auto_realtime_web,
-                True,
-                explicit_web_request,
-            )
-            (chunks, success), context_data = await asyncio.gather(retrieval_task, web_task)
-            web_context = context_data.get("search_context", "") if isinstance(context_data, dict) else ""
+            web_context = ""
+            if success and chunks:
+                context_data = await asyncio.to_thread(
+                    get_context_for_query,
+                    query,
+                    request.force_web_search,
+                    allow_auto_realtime_web,
+                    True,
+                    explicit_web_request,
+                )
+                web_context = context_data.get("search_context", "") if isinstance(context_data, dict) else ""
         else:
             chunks, success = await asyncio.to_thread(
                 search_relevant_chunks,

--- a/python-ai/app/chat_api.py
+++ b/python-ai/app/chat_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from typing import Dict, List, Optional, Tuple
@@ -156,25 +157,35 @@ async def chat_stream(request: ChatRequest):
 
     if documents_active and query:
         search_relevant_chunks, build_rag_prompt = _get_rag_document_helpers()
-        chunks, success = search_relevant_chunks(
-            query,
-            request.document_filenames,
-            top_k=_get_rag_top_k(),
-            user_id=request.user_id,
-        )
+        if should_web_search:
+            retrieval_task = asyncio.to_thread(
+                search_relevant_chunks,
+                query,
+                request.document_filenames,
+                _get_rag_top_k(),
+                request.user_id,
+            )
+            web_task = asyncio.to_thread(
+                get_context_for_query,
+                query,
+                request.force_web_search,
+                allow_auto_realtime_web,
+                True,
+                explicit_web_request,
+            )
+            (chunks, success), context_data = await asyncio.gather(retrieval_task, web_task)
+            web_context = context_data.get("search_context", "") if isinstance(context_data, dict) else ""
+        else:
+            chunks, success = await asyncio.to_thread(
+                search_relevant_chunks,
+                query,
+                request.document_filenames,
+                _get_rag_top_k(),
+                request.user_id,
+            )
+            web_context = ""
 
         if success and chunks:
-            web_context = ""
-            if should_web_search:
-                context_data = get_context_for_query(
-                    query,
-                    force_web_search=request.force_web_search,
-                    allow_auto_realtime_web=allow_auto_realtime_web,
-                    documents_active=True,
-                    explicit_web_request=explicit_web_request,
-                )
-                web_context = context_data.get("search_context", "")
-
             rag_prompt, sources = build_rag_prompt(query, chunks, web_context=web_context)
 
             messages_with_rag = [{"role": "system", "content": rag_prompt}] + request.messages

--- a/python-ai/app/retrieval_runner.py
+++ b/python-ai/app/retrieval_runner.py
@@ -1,10 +1,13 @@
 import json
+import logging
 import os
 import subprocess
 import sys
 from typing import Any, Dict, List, Tuple
 
-from app.env_utils import get_env_int
+from app.env_utils import get_env_bool, get_env_int
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_search_payload(stdout: str) -> Dict[str, Any]:
@@ -21,6 +24,23 @@ def _parse_search_payload(stdout: str) -> Dict[str, Any]:
     raise ValueError("Subprocess did not return a valid retrieval JSON payload.")
 
 
+def _run_retrieval_search_inprocess(
+    query: str,
+    filenames: List[str] | None = None,
+    top_k: int = 5,
+    user_id: str | None = None,
+) -> Tuple[List[Dict[str, Any]], bool]:
+    from app.services.rag_retrieval import search_relevant_chunks
+
+    chunks, success = search_relevant_chunks(
+        query,
+        filenames,
+        top_k=top_k,
+        user_id=user_id,
+    )
+    return list(chunks or []), bool(success)
+
+
 def run_retrieval_search(
     query: str,
     filenames: List[str] | None = None,
@@ -30,6 +50,13 @@ def run_retrieval_search(
     timeout_seconds = get_env_int("DOCUMENT_RETRIEVAL_SUBPROCESS_TIMEOUT", 180)
     app_dir = os.path.dirname(os.path.dirname(__file__))
     filenames_json = json.dumps(filenames or [], ensure_ascii=False)
+    use_subprocess = get_env_bool("DOCUMENT_RETRIEVAL_USE_SUBPROCESS", False)
+
+    if not use_subprocess:
+        try:
+            return _run_retrieval_search_inprocess(query, filenames, top_k=top_k, user_id=user_id)
+        except Exception:
+            logger.exception("In-process retrieval failed; falling back to subprocess")
 
     completed = subprocess.run(
         [

--- a/python-ai/app/services/langsearch_service.py
+++ b/python-ai/app/services/langsearch_service.py
@@ -3,6 +3,8 @@ import requests
 import time
 from typing import List, Dict, Optional, Tuple
 from datetime import datetime
+from threading import Lock
+from collections import OrderedDict
 
 from app.config_loader import get_web_search_context_prompt
 from app.env_utils import get_env, get_env_int
@@ -11,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 LANGSEARCH_TIMEOUT = get_env_int("LANGSEARCH_TIMEOUT", 10)
 LANGSEARCH_CACHE_TTL = get_env_int("LANGSEARCH_CACHE_TTL", 300)  # 5 minutes default
+LANGSEARCH_CACHE_MAX_SIZE = get_env_int("LANGSEARCH_CACHE_MAX_SIZE", 200)
 
 
 class LangSearchService:
@@ -18,7 +21,8 @@ class LangSearchService:
     
     def __init__(self):
         self.base_url = "https://api.langsearch.com/v1/web-search"
-        self._search_cache: Dict[Tuple[str, int], Tuple[List[Dict], float]] = {}
+        self._search_cache: "OrderedDict[Tuple[str, int], Tuple[List[Dict], float]]" = OrderedDict()
+        self._cache_lock = Lock()
         self._api_key: Optional[str] = None
     
     @property
@@ -28,22 +32,34 @@ class LangSearchService:
             self._api_key = get_env("LANGSEARCH_API_KEY")
         return self._api_key
     
+    def _normalize_cache_query(self, query: str) -> str:
+        return " ".join((query or "").strip().lower().split())
+
+    def _cache_key(self, query: str, time_bucket: int) -> Tuple[str, int]:
+        return (self._normalize_cache_query(query), time_bucket)
+
     def _get_cached_result(self, query: str, time_bucket: int) -> Optional[List[Dict]]:
         """Get cached search result if not expired."""
-        key = (query, time_bucket)
-        if key in self._search_cache:
-            results, timestamp = self._search_cache[key]
-            if time.time() - timestamp < LANGSEARCH_CACHE_TTL:
-                logger.info(f"📦 LangSearch: cache hit for '{query}'")
-                return results
-            else:
+        key = self._cache_key(query, time_bucket)
+        now = time.time()
+        with self._cache_lock:
+            if key in self._search_cache:
+                results, timestamp = self._search_cache[key]
+                if now - timestamp < LANGSEARCH_CACHE_TTL:
+                    self._search_cache.move_to_end(key)
+                    logger.info(f"📦 LangSearch: cache hit for '{query}'")
+                    return results
                 del self._search_cache[key]
         return None
     
     def _cache_result(self, query: str, time_bucket: int, results: List[Dict]):
         """Cache search result with timestamp."""
-        key = (query, time_bucket)
-        self._search_cache[key] = (results, time.time())
+        key = self._cache_key(query, time_bucket)
+        with self._cache_lock:
+            self._search_cache[key] = (results, time.time())
+            self._search_cache.move_to_end(key)
+            while len(self._search_cache) > max(1, LANGSEARCH_CACHE_MAX_SIZE):
+                self._search_cache.popitem(last=False)
     
     def _get_time_bucket(self) -> int:
         """Get current time bucket for caching (5 minute intervals)."""

--- a/python-ai/app/services/rag_policy.py
+++ b/python-ai/app/services/rag_policy.py
@@ -2,6 +2,7 @@ import re
 import hashlib
 import unicodedata
 import logging
+import threading
 from typing import List, Tuple, Dict, Optional
 
 from app.env_utils import get_env_bool, get_env_int
@@ -18,13 +19,16 @@ logger = logging.getLogger(__name__)
 SCORE_PATTERN = re.compile(r"\b(\d{1,2})\s*[-:]\s*(\d{1,2})\b")
 
 _langsearch_service = None
+_langsearch_service_lock = threading.Lock()
 
 
 def get_langsearch_service():
     global _langsearch_service
     if _langsearch_service is None:
-        from app.services.langsearch_service import LangSearchService
-        _langsearch_service = LangSearchService()
+        with _langsearch_service_lock:
+            if _langsearch_service is None:
+                from app.services.langsearch_service import LangSearchService
+                _langsearch_service = LangSearchService()
     return _langsearch_service
 
 

--- a/python-ai/tests/test_chat_api_concurrency.py
+++ b/python-ai/tests/test_chat_api_concurrency.py
@@ -1,0 +1,66 @@
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app import chat_api
+
+
+class _DummyStreamingResponse:
+    def __init__(self, body, media_type=None):
+        self.body_iterator = body
+        self.media_type = media_type
+
+
+async def _collect_async_iter(it):
+    out = []
+    async for x in it:
+        out.append(x)
+    return out
+
+
+def test_chat_api_parallel_doc_and_web(monkeypatch):
+    class Req(chat_api.ChatRequest):
+        pass
+
+    req = Req(
+        messages=[{"role": "user", "content": "cek terbaru"}],
+        document_filenames=["doc.pdf"],
+        user_id="u1",
+        force_web_search=False,
+        explicit_web_request=True,
+    )
+
+    def fake_policy_helpers():
+        return (
+            lambda q: True,
+            lambda **kwargs: (True, "DOC_WEB_EXPLICIT", "high"),
+            lambda *args, **kwargs: {"search_context": "WEB"},
+        )
+
+    async def fake_stream_with_sources(messages, sources):
+        yield "ok"
+
+    def fake_streamers():
+        return (lambda *args, **kwargs: iter(["fallback"]), fake_stream_with_sources)
+
+    def fake_doc_helpers():
+        def search_relevant_chunks(*args, **kwargs):
+            return ([{"filename": "doc.pdf", "content": "DOC"}], True)
+
+        def build_rag_prompt(query, chunks, web_context=""):
+            return f"PROMPT::{web_context}", [{"filename": "doc.pdf"}]
+
+        return search_relevant_chunks, build_rag_prompt
+
+    monkeypatch.setattr(chat_api, "StreamingResponse", _DummyStreamingResponse)
+    monkeypatch.setattr(chat_api, "_get_rag_policy_helpers", fake_policy_helpers)
+    monkeypatch.setattr(chat_api, "_get_chat_streamers", fake_streamers)
+    monkeypatch.setattr(chat_api, "_get_rag_document_helpers", fake_doc_helpers)
+
+    response = asyncio.run(chat_api.chat_stream(req))
+    chunks = asyncio.run(_collect_async_iter(response.body_iterator))
+
+    assert response.media_type == "text/event-stream"
+    assert chunks == ["ok"]

--- a/python-ai/tests/test_chat_api_concurrency.py
+++ b/python-ai/tests/test_chat_api_concurrency.py
@@ -20,6 +20,16 @@ async def _collect_async_iter(it):
     return out
 
 
+def _collect_iter(it):
+    return list(it)
+
+
+def _collect_stream(it):
+    if hasattr(it, "__aiter__"):
+        return asyncio.run(_collect_async_iter(it))
+    return _collect_iter(it)
+
+
 def test_chat_api_parallel_doc_and_web(monkeypatch):
     class Req(chat_api.ChatRequest):
         pass
@@ -60,7 +70,103 @@ def test_chat_api_parallel_doc_and_web(monkeypatch):
     monkeypatch.setattr(chat_api, "_get_rag_document_helpers", fake_doc_helpers)
 
     response = asyncio.run(chat_api.chat_stream(req))
-    chunks = asyncio.run(_collect_async_iter(response.body_iterator))
+    chunks = _collect_stream(response.body_iterator)
 
     assert response.media_type == "text/event-stream"
     assert chunks == ["ok"]
+
+
+def test_chat_api_no_prefetch_web_on_empty_doc_fallback(monkeypatch):
+    req = chat_api.ChatRequest(
+        messages=[{"role": "user", "content": "cek terbaru"}],
+        document_filenames=["doc.pdf"],
+        user_id="u1",
+        force_web_search=False,
+        explicit_web_request=True,
+    )
+
+    policy_calls = {"count": 0}
+
+    def fake_policy_helpers():
+        def _ctx(*args, **kwargs):
+            policy_calls["count"] += 1
+            return {"search_context": "WEB"}
+
+        return (lambda q: True, lambda **kwargs: (True, "DOC_WEB_EXPLICIT", "high"), _ctx)
+
+    def fake_streamers():
+        def _fallback(*args, **kwargs):
+            yield "fallback"
+
+        async def _with_sources(*args, **kwargs):
+            yield "ok"
+
+        return _fallback, _with_sources
+
+    def fake_doc_helpers():
+        def search_relevant_chunks(*args, **kwargs):
+            return ([], True)
+
+        def build_rag_prompt(*args, **kwargs):
+            return "PROMPT", []
+
+        return search_relevant_chunks, build_rag_prompt
+
+    monkeypatch.setattr(chat_api, "StreamingResponse", _DummyStreamingResponse)
+    monkeypatch.setattr(chat_api, "_get_rag_policy_helpers", fake_policy_helpers)
+    monkeypatch.setattr(chat_api, "_get_chat_streamers", fake_streamers)
+    monkeypatch.setattr(chat_api, "_get_rag_document_helpers", fake_doc_helpers)
+
+    response = asyncio.run(chat_api.chat_stream(req))
+    chunks = _collect_stream(response.body_iterator)
+
+    assert chunks == ["fallback"]
+    assert policy_calls["count"] == 0
+
+
+def test_chat_api_no_prefetch_web_on_retrieval_failure(monkeypatch):
+    req = chat_api.ChatRequest(
+        messages=[{"role": "user", "content": "cek terbaru"}],
+        document_filenames=["doc.pdf"],
+        user_id="u1",
+        force_web_search=False,
+        explicit_web_request=True,
+    )
+
+    policy_calls = {"count": 0}
+
+    def fake_policy_helpers():
+        def _ctx(*args, **kwargs):
+            policy_calls["count"] += 1
+            return {"search_context": "WEB"}
+
+        return (lambda q: True, lambda **kwargs: (True, "DOC_WEB_EXPLICIT", "high"), _ctx)
+
+    def fake_streamers():
+        def _fallback(*args, **kwargs):
+            yield "fallback"
+
+        async def _with_sources(*args, **kwargs):
+            yield "ok"
+
+        return _fallback, _with_sources
+
+    def fake_doc_helpers():
+        def search_relevant_chunks(*args, **kwargs):
+            return ([], False)
+
+        def build_rag_prompt(*args, **kwargs):
+            return "PROMPT", []
+
+        return search_relevant_chunks, build_rag_prompt
+
+    monkeypatch.setattr(chat_api, "StreamingResponse", _DummyStreamingResponse)
+    monkeypatch.setattr(chat_api, "_get_rag_policy_helpers", fake_policy_helpers)
+    monkeypatch.setattr(chat_api, "_get_chat_streamers", fake_streamers)
+    monkeypatch.setattr(chat_api, "_get_rag_document_helpers", fake_doc_helpers)
+
+    response = asyncio.run(chat_api.chat_stream(req))
+    chunks = _collect_stream(response.body_iterator)
+
+    assert chunks == ["fallback"]
+    assert policy_calls["count"] == 0

--- a/python-ai/tests/test_langsearch_service_cache.py
+++ b/python-ai/tests/test_langsearch_service_cache.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.services.langsearch_service import LangSearchService
+
+
+def test_langsearch_cache_normalizes_query_key():
+    service = LangSearchService()
+    bucket = service._get_time_bucket()
+
+    service._cache_result("  Hello   WORLD  ", bucket, [{"title": "A"}])
+
+    assert service._get_cached_result("hello world", bucket) == [{"title": "A"}]
+
+
+def test_langsearch_cache_respects_max_size(monkeypatch):
+    monkeypatch.setattr("app.services.langsearch_service.LANGSEARCH_CACHE_MAX_SIZE", 2)
+    service = LangSearchService()
+    bucket = service._get_time_bucket()
+
+    service._cache_result("q1", bucket, [{"title": "1"}])
+    service._cache_result("q2", bucket, [{"title": "2"}])
+    service._cache_result("q3", bucket, [{"title": "3"}])
+
+    assert len(service._search_cache) == 2
+    assert service._get_cached_result("q1", bucket) is None
+    assert service._get_cached_result("q2", bucket) == [{"title": "2"}]
+    assert service._get_cached_result("q3", bucket) == [{"title": "3"}]

--- a/python-ai/tests/test_rag_policy_singleton.py
+++ b/python-ai/tests/test_rag_policy_singleton.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_get_langsearch_service_thread_safe_singleton(monkeypatch):
+    import app.services.rag_policy as rag_policy
+
+    rag_policy._langsearch_service = None
+
+    init_calls = {"count": 0}
+
+    class FakeLangSearchService:
+        def __init__(self):
+            time.sleep(0.01)
+            init_calls["count"] += 1
+
+    monkeypatch.setattr("app.services.langsearch_service.LangSearchService", FakeLangSearchService)
+
+    created_ids = []
+
+    def _worker():
+        svc = rag_policy.get_langsearch_service()
+        created_ids.append(id(svc))
+
+    threads = [threading.Thread(target=_worker) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(set(created_ids)) == 1
+    assert init_calls["count"] == 1

--- a/python-ai/tests/test_retrieval_runner.py
+++ b/python-ai/tests/test_retrieval_runner.py
@@ -18,6 +18,7 @@ def test_parse_search_payload_uses_last_valid_json_line():
 
 
 def test_run_retrieval_search_returns_success_payload(monkeypatch):
+    monkeypatch.setenv("DOCUMENT_RETRIEVAL_USE_SUBPROCESS", "1")
     def fake_run(*args, **kwargs):
         return subprocess.CompletedProcess(
             args=args[0],
@@ -35,6 +36,7 @@ def test_run_retrieval_search_returns_success_payload(monkeypatch):
 
 
 def test_run_retrieval_search_returns_false_when_payload_missing(monkeypatch):
+    monkeypatch.setenv("DOCUMENT_RETRIEVAL_USE_SUBPROCESS", "1")
     def fake_run(*args, **kwargs):
         return subprocess.CompletedProcess(
             args=args[0],
@@ -48,4 +50,74 @@ def test_run_retrieval_search_returns_false_when_payload_missing(monkeypatch):
     chunks, success = run_retrieval_search("apa isi", ["doc.pdf"], top_k=3, user_id="42")
 
     assert success is False
+    assert chunks == []
+
+
+def test_run_retrieval_search_uses_inprocess_by_default(monkeypatch):
+    monkeypatch.delenv("DOCUMENT_RETRIEVAL_USE_SUBPROCESS", raising=False)
+
+    called = {"inprocess": False, "subprocess": False}
+
+    def fake_inprocess(*args, **kwargs):
+        called["inprocess"] = True
+        return ([{"filename": "doc.pdf"}], True)
+
+    def fake_subprocess(*args, **kwargs):
+        called["subprocess"] = True
+        raise AssertionError("subprocess should not run")
+
+    monkeypatch.setattr("app.retrieval_runner._run_retrieval_search_inprocess", fake_inprocess)
+    monkeypatch.setattr("app.retrieval_runner.subprocess.run", fake_subprocess)
+
+    chunks, success = run_retrieval_search("apa isi", ["doc.pdf"], top_k=3, user_id="42")
+
+    assert success is True
+    assert chunks == [{"filename": "doc.pdf"}]
+    assert called["inprocess"] is True
+    assert called["subprocess"] is False
+
+
+def test_run_retrieval_search_fallback_to_subprocess_when_inprocess_fails(monkeypatch):
+    monkeypatch.delenv("DOCUMENT_RETRIEVAL_USE_SUBPROCESS", raising=False)
+
+    def fake_inprocess(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout='{"success": true, "chunks": [{"filename": "doc.pdf", "content": "abc"}]}\n',
+            stderr="",
+        )
+
+    monkeypatch.setattr("app.retrieval_runner._run_retrieval_search_inprocess", fake_inprocess)
+    monkeypatch.setattr("app.retrieval_runner.subprocess.run", fake_run)
+
+    chunks, success = run_retrieval_search("apa isi", ["doc.pdf"], top_k=3, user_id="42")
+
+    assert success is True
+    assert chunks == [{"filename": "doc.pdf", "content": "abc"}]
+
+
+def test_run_retrieval_search_uses_subprocess_when_opted_in(monkeypatch):
+    monkeypatch.setenv("DOCUMENT_RETRIEVAL_USE_SUBPROCESS", "1")
+
+    def fake_inprocess(*args, **kwargs):
+        raise AssertionError("inprocess should not run")
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout='{"success": true, "chunks": []}\n',
+            stderr="",
+        )
+
+    monkeypatch.setattr("app.retrieval_runner._run_retrieval_search_inprocess", fake_inprocess)
+    monkeypatch.setattr("app.retrieval_runner.subprocess.run", fake_run)
+
+    chunks, success = run_retrieval_search("apa isi", ["doc.pdf"], top_k=3, user_id="42")
+
+    assert success is True
     assert chunks == []


### PR DESCRIPTION
## Ringkasan
- Mengurangi overhead retrieval dokumen dengan jalur in-process default dan fallback aman ke subprocess lama.
- Menjalankan retrieval dokumen dan web context secara paralel saat keduanya dibutuhkan, sehingga jalur dokumen + web search tidak menunggu serial tanpa mengubah prompt/sources.
- Memperkuat cache LangSearch dengan normalisasi key, lock thread-safe, dan bounded LRU agar web search berulang lebih cepat dan aman di jalur paralel.

## Perubahan Utama
| File / Area | Deskripsi |
|---|---|
| `issue/issue-percepat-respon-ista-ai-2026-05-11.md` | Plan lokal untuk scope, risiko, langkah implementasi, dan rencana test. |
| `python-ai/app/retrieval_runner.py` | Menambahkan in-process retrieval default dengan env opt-out `DOCUMENT_RETRIEVAL_USE_SUBPROCESS=1`; jika gagal, otomatis fallback ke subprocess lama. |
| `python-ai/app/chat_api.py` | Memindahkan retrieval dokumen ke `asyncio.to_thread` dan menjalankan retrieval + web context via `asyncio.gather` saat web search aktif. |
| `python-ai/app/services/langsearch_service.py` | Menambahkan normalisasi cache key, `Lock`, `OrderedDict`, dan `LANGSEARCH_CACHE_MAX_SIZE` untuk bounded LRU cache. |
| `python-ai/tests/*` | Menambah coverage fallback retrieval, cache LangSearch, dan jalur paralel dokumen + web. |

## Validasi
\`\`\`bash
git diff --check
# PASS

cd python-ai && source venv/bin/activate && pytest tests/test_retrieval_runner.py tests/test_langsearch_service_cache.py tests/test_chat_api_concurrency.py
# PASS: 9 passed in 0.26s

cd python-ai && source venv/bin/activate && pytest
# PASS: 188 passed in 17.88s
\`\`\`

## Deploy / QA
- Preview: https://ista-ai.app
- Deployed SHA: belum dideploy saat PR dibuat; akan dideploy setelah branch PR tersedia.
- Browser QA: belum dijalankan karena workflow mensyaratkan QA setelah deploy preview berhasil.

## Catatan / Risiko Residual
- In-process retrieval mengurangi overhead subprocess, tetapi perlu monitoring memory/error rate di workload produksi; env opt-out dan fallback subprocess tetap tersedia.
- Perubahan tidak mematikan rerank, HyDE, top_k, web search, atau fallback model kualitas.
- Jika GitHub issue creation gagal karena permission runtime, plan lokal tetap disertakan di PR.

Closes #151