### PR TITLE
fix: propagate explicit userId in saveAssistantMessage to prevent silent answer loss

### DIFF
--- a/issue/issue-bug-156-auth-queue-userid-2026-05-13.md
+++ b/issue/issue-bug-156-auth-queue-userid-2026-05-13.md
@@ -1,0 +1,72 @@
+# Bug #156: Jawaban AI bisa hilang diam-diam saat Auth::loginUsingId gagal di queue
+
+## Latar Belakang
+
+`GenerateChatResponse` adalah queue job yang memproses respons AI di background. Di awal `handle()`, job memanggil `Auth::loginUsingId($this->userId)` untuk set konteks auth. Namun method ini return `false` (tidak throw) jika user tidak ditemukan.
+
+Setelah itu, `ChatOrchestrationService::saveAssistantMessage` memanggil `conversationExists()` yang menggunakan `Auth::id()` — bukan `$this->userId`. Jika `loginUsingId` gagal, `Auth::id()` menjadi `null`, `conversationExists` return false, dan jawaban AI tidak tersimpan. User tidak mendapat balasan dan tidak ada pesan error.
+
+Inkonsistensi ini juga terlihat di `conversationStillExists()` di job yang sama — method itu sudah benar menggunakan `$this->userId`, tapi `saveAssistantMessage` tidak.
+
+## Tujuan
+
+Hilangkan ketergantungan `ChatOrchestrationService::saveAssistantMessage` dan `conversationExists` pada `Auth::id()`. Propagate `userId` eksplisit dari job ke service sehingga jawaban selalu tersimpan ke conversation yang benar, terlepas dari state auth di queue worker.
+
+## Ruang Lingkup
+
+- Update signature `ChatOrchestrationService::saveAssistantMessage(int $conversationId, string $content, int $userId)`.
+- Update `conversationExists` menjadi `protected` dengan parameter `userId` eksplisit.
+- Update `createAssistantMessage` untuk tidak bergantung pada `Auth::id()`.
+- Update `GenerateChatResponse::handle` untuk pass `$this->userId`.
+- Update semua caller `saveAssistantMessage` yang ada.
+- Tambah/update test.
+
+## Di Luar Scope
+
+- Perubahan pada alur chat UI/Livewire.
+- Perubahan pada Python service.
+- Bug lain dari audit (#155, #157-#164).
+- Refactor `Auth::loginUsingId` di job (tetap dipertahankan untuk keperluan lain yang mungkin butuh auth context).
+
+## Area / File Terkait
+
+- `laravel/app/Services/ChatOrchestrationService.php` — perubahan utama: `saveAssistantMessage`, `conversationExists`, `createAssistantMessage`.
+- `laravel/app/Jobs/GenerateChatResponse.php` — update call ke `saveAssistantMessage`.
+- `laravel/tests/Feature/Chat/ChatUiTest.php` — update/tambah test.
+- `laravel/tests/Unit/Services/ChatOrchestrationServiceTest.php` — update/tambah test.
+
+## Risiko
+
+- Perubahan signature `saveAssistantMessage` bisa break caller lain. Perlu audit semua pemanggil.
+- `conversationExists` saat ini juga dipakai di `createConversationIfNeeded` via `Auth::id()` — perlu dicek apakah perlu diubah juga atau cukup scope ke `saveAssistantMessage`.
+- Perubahan minimal: hanya ubah path yang bermasalah, jangan refactor seluruh service.
+
+## Langkah Implementasi
+
+1. Audit semua caller `saveAssistantMessage` di codebase.
+2. Update `ChatOrchestrationService`:
+   - `saveAssistantMessage(int $conversationId, string $content, int $userId)` — tambah param `$userId`.
+   - `conversationExists(int $conversationId, int $userId)` — tambah param `$userId`, hapus `Auth::id()`.
+   - `createAssistantMessage` tidak perlu diubah (tidak pakai Auth).
+3. Update `GenerateChatResponse::handle` — pass `$this->userId` ke `saveAssistantMessage`.
+4. Update test yang memanggil `saveAssistantMessage` secara langsung.
+
+## Rencana Test
+
+```
+php artisan test --filter ChatUiTest
+php artisan test --filter ChatOrchestrationServiceTest
+```
+
+Test baru/update:
+- `test_save_assistant_message_returns_null_for_conversation_not_owned_by_caller` — update untuk pass userId eksplisit.
+- `test_generate_chat_response_persists_assistant_message_to_origin_conversation` — verifikasi dengan userId eksplisit.
+- Tambah: `test_save_assistant_message_uses_explicit_user_id_not_auth_facade`.
+
+## Kriteria Selesai
+
+- [ ] `saveAssistantMessage` tidak bergantung `Auth::id()` lagi
+- [ ] `conversationExists` menerima `userId` eksplisit
+- [ ] `GenerateChatResponse` pass `$this->userId` ke service
+- [ ] Semua test pass tanpa regresi
+- [ ] PR dibuat dan siap review

--- a/laravel/app/Jobs/GenerateChatResponse.php
+++ b/laravel/app/Jobs/GenerateChatResponse.php
@@ -89,7 +89,7 @@ class GenerateChatResponse implements ShouldQueue
             $cleanContent = 'Maaf, ISTA AI belum menerima jawaban yang bisa ditampilkan. Silakan coba lagi.';
         }
 
-        if ($orchestrator->saveAssistantMessage($this->conversationId, $cleanContent) !== null) {
+        if ($orchestrator->saveAssistantMessage($this->conversationId, $cleanContent, $this->userId) !== null) {
             Conversation::query()
                 ->whereKey($this->conversationId)
                 ->where('user_id', $this->userId)

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -180,9 +180,9 @@ class ChatOrchestrationService
         return trim($cleanContent);
     }
 
-    public function saveAssistantMessage(int $conversationId, string $content): ?Message
+    public function saveAssistantMessage(int $conversationId, string $content, int $userId): ?Message
     {
-        if (! $this->conversationExists($conversationId)) {
+        if (! $this->conversationExists($conversationId, $userId)) {
             return null;
         }
 
@@ -197,11 +197,11 @@ class ChatOrchestrationService
         }
     }
 
-    protected function conversationExists(int $conversationId): bool
+    protected function conversationExists(int $conversationId, int $userId): bool
     {
         return Conversation::query()
             ->whereKey($conversationId)
-            ->where('user_id', Auth::id())
+            ->where('user_id', $userId)
             ->exists();
     }
 

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -458,7 +458,7 @@ class ChatUiTest extends TestCase
     {
         $service = new class extends ChatOrchestrationService
         {
-            protected function conversationExists(int $conversationId): bool
+            protected function conversationExists(int $conversationId, int $userId): bool
             {
                 return true;
             }
@@ -477,12 +477,12 @@ class ChatUiTest extends TestCase
             }
         };
 
-        $result = $service->saveAssistantMessage(999999, 'Assistant response');
+        $result = $service->saveAssistantMessage(999999, 'Assistant response', 1);
 
         $this->assertNull($result);
     }
 
-    public function test_save_assistant_message_returns_null_for_conversation_not_owned_by_current_user(): void
+    public function test_save_assistant_message_returns_null_for_conversation_not_owned_by_caller(): void
     {
         $owner = User::factory()->create();
         $otherUser = User::factory()->create();
@@ -492,17 +492,41 @@ class ChatUiTest extends TestCase
             'title' => 'Owned by owner',
         ]);
 
-        $this->actingAs($otherUser);
-
         $service = new ChatOrchestrationService;
 
-        $result = $service->saveAssistantMessage($conversation->id, 'Assistant response should be blocked');
+        // Pass otherUser's ID explicitly — should be blocked because conversation belongs to owner
+        $result = $service->saveAssistantMessage($conversation->id, 'Assistant response should be blocked', $otherUser->id);
 
         $this->assertNull($result);
         $this->assertDatabaseMissing('messages', [
             'conversation_id' => $conversation->id,
             'role' => 'assistant',
             'content' => 'Assistant response should be blocked',
+        ]);
+    }
+
+    public function test_save_assistant_message_uses_explicit_user_id_not_auth_facade(): void
+    {
+        // Verifikasi bahwa saveAssistantMessage menggunakan userId eksplisit,
+        // bukan Auth::id(). Ini memastikan job queue tetap bisa menyimpan
+        // jawaban meski Auth facade tidak ter-set dengan benar.
+        $owner = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $owner->id,
+            'title' => 'Owner conversation',
+        ]);
+
+        $service = new ChatOrchestrationService;
+
+        // Tidak ada actingAs — Auth::id() adalah null
+        // Tapi pass userId eksplisit milik owner → harus berhasil simpan
+        $result = $service->saveAssistantMessage($conversation->id, 'Jawaban AI tersimpan', $owner->id);
+
+        $this->assertNotNull($result);
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban AI tersimpan',
         ]);
     }
 


### PR DESCRIPTION
## Summary

Fixes #156 — Jawaban AI bisa hilang diam-diam saat `Auth::loginUsingId` gagal di queue.

- Update `ChatOrchestrationService::saveAssistantMessage` untuk menerima `userId` eksplisit
- Update `conversationExists` untuk menerima `userId` eksplisit, tidak lagi bergantung `Auth::id()`
- Update `GenerateChatResponse::handle` untuk pass `$this->userId` ke service
- Tambah 1 test baru, update 2 test existing di `ChatUiTest`

## Root Cause

`GenerateChatResponse` adalah queue job yang memanggil `Auth::loginUsingId($this->userId)` di awal `handle()`. Method ini return `false` (tidak throw) jika user tidak ditemukan. Setelah itu, `ChatOrchestrationService::conversationExists()` menggunakan `Auth::id()` — bukan `$this->userId`. Jika `loginUsingId` gagal, `Auth::id()` menjadi `null`, `conversationExists` return false, dan jawaban AI tidak tersimpan tanpa error apapun.

Inkonsistensi ini terlihat jelas: `conversationStillExists()` di job yang sama sudah benar menggunakan `$this->userId`, tapi `saveAssistantMessage` tidak.

## Changes

| File | Perubahan |
|------|-----------|
| `laravel/app/Services/ChatOrchestrationService.php` | Update `saveAssistantMessage` + `conversationExists` — tambah param `userId` eksplisit |
| `laravel/app/Jobs/GenerateChatResponse.php` | Pass `$this->userId` ke `saveAssistantMessage` |
| `laravel/tests/Feature/Chat/ChatUiTest.php` | Update 2 caller, rename test, tambah 1 test baru |
| `issue/issue-bug-156-auth-queue-userid-2026-05-13.md` | **Baru** — issue plan |

## Test Coverage

- `test_save_assistant_message_returns_null_when_create_hits_conversation_fk_race` — updated
- `test_save_assistant_message_returns_null_for_conversation_not_owned_by_caller` — renamed + updated (tidak lagi butuh `actingAs`)
- `test_save_assistant_message_uses_explicit_user_id_not_auth_facade` — **baru**: tanpa `actingAs` (Auth::id() = null), pass userId eksplisit → jawaban tetap tersimpan

## Verification

```
php artisan test --filter ChatUiTest
# 26 passed (119 assertions)

php artisan test
# 231 passed, 0 failed
```

## Before / After

**Before:** Worker queue crash / user dihapus → `Auth::loginUsingId` gagal diam-diam → `Auth::id()` null → `conversationExists` false → jawaban AI tidak tersimpan → user menunggu tanpa balasan dan tanpa error.

**After:** `saveAssistantMessage` menggunakan `userId` eksplisit dari job. Jawaban selalu tersimpan ke conversation yang benar selama conversation masih ada, terlepas dari state Auth facade di worker.