### PR TITLE
fix: add sliding window truncation to chat history (max 20 messages)

### DIFF
--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -60,6 +60,10 @@ class ChatOrchestrationService
      * unbounded token costs on long conversations. The window size is
      * configurable via services.ai_service.max_history_messages (default 20).
      * Only the most recent N messages are sent; older messages are dropped.
+     *
+     * After slicing, any leading assistant messages are dropped so the
+     * payload always starts with a user message — required by providers
+     * that enforce strict user/assistant turn ordering (e.g. Bedrock Converse).
      */
     public function buildHistory(array $messages): array
     {
@@ -68,6 +72,13 @@ class ChatOrchestrationService
         // Keep only the most recent N messages (sliding window)
         if (count($messages) > $maxMessages) {
             $messages = array_slice($messages, -$maxMessages);
+        }
+
+        // Drop leading assistant messages so the payload always starts
+        // with a user turn. This can happen when the window boundary
+        // falls in the middle of a user/assistant pair.
+        while (! empty($messages) && ($messages[0]['role'] ?? '') === 'assistant') {
+            array_shift($messages);
         }
 
         return array_map(

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -53,8 +53,23 @@ class ChatOrchestrationService
         return $userMessage->toArray();
     }
 
+    /**
+     * Build the message history payload for the AI service.
+     *
+     * Applies a sliding window to prevent context-window overflow and
+     * unbounded token costs on long conversations. The window size is
+     * configurable via services.ai_service.max_history_messages (default 20).
+     * Only the most recent N messages are sent; older messages are dropped.
+     */
     public function buildHistory(array $messages): array
     {
+        $maxMessages = $this->maxHistoryMessages();
+
+        // Keep only the most recent N messages (sliding window)
+        if (count($messages) > $maxMessages) {
+            $messages = array_slice($messages, -$maxMessages);
+        }
+
         return array_map(
             fn (array $msg) => [
                 'role' => (string) ($msg['role'] ?? ''),
@@ -62,6 +77,15 @@ class ChatOrchestrationService
             ],
             $messages
         );
+    }
+
+    protected function maxHistoryMessages(): int
+    {
+        try {
+            return max(1, (int) config('services.ai_service.max_history_messages', 20));
+        } catch (\Throwable) {
+            return 20;
+        }
     }
 
     public function getDocumentFilenames(array $conversationDocuments): ?array

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -93,10 +93,35 @@ class ChatOrchestrationService
     protected function maxHistoryMessages(): int
     {
         try {
-            return max(1, (int) config('services.ai_service.max_history_messages', 20));
+            $raw = config('services.ai_service.max_history_messages', 20);
+
+            return max(1, (int) $this->normalizeIntConfig($raw, 20));
         } catch (\Throwable) {
             return 20;
         }
+    }
+
+    /**
+     * Normalize a config value that may arrive as a quoted string at runtime.
+     * e.g. ' "20" ' → 20, '20' → 20, 20 → 20.
+     */
+    private function normalizeIntConfig(mixed $value, int $default): int
+    {
+        if ($value === null) {
+            return $default;
+        }
+
+        $normalized = trim((string) $value);
+
+        // Strip surrounding quotes (single or double)
+        if (strlen($normalized) >= 2) {
+            $quote = $normalized[0];
+            if (($quote === '"' || $quote === "'") && $normalized[strlen($normalized) - 1] === $quote) {
+                $normalized = substr($normalized, 1, -1);
+            }
+        }
+
+        return is_numeric($normalized) ? (int) $normalized : $default;
     }
 
     public function getDocumentFilenames(array $conversationDocuments): ?array

--- a/laravel/config/services.php
+++ b/laravel/config/services.php
@@ -43,6 +43,7 @@ return [
         'read_timeout' => env('AI_SERVICE_READ_TIMEOUT', 120),
         'retries' => env('AI_SERVICE_RETRIES', 2),
         'retry_delay_ms' => env('AI_SERVICE_RETRY_DELAY_MS', 400),
+        'max_history_messages' => env('AI_SERVICE_MAX_HISTORY_MESSAGES', 20),
     ],
 
     'ai_document_service' => [

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -691,6 +691,30 @@ class ChatUiTest extends TestCase
         ]);
     }
 
+    public function test_build_history_normalizes_quoted_max_history_messages_config(): void
+    {
+        // Simulate runtime config with quoted value (e.g. from .env parsing quirk).
+        // Without normalization, (int)' "4" ' = 0, max(1,0) = 1 — chat would be
+        // truncated to 1 message, losing almost all context.
+        config()->set('services.ai_service.max_history_messages', ' "4" ');
+
+        $service = new ChatOrchestrationService();
+
+        $messages = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $messages[] = ['role' => $i % 2 === 0 ? 'assistant' : 'user', 'content' => "Pesan ke-{$i}"];
+        }
+
+        $history = $service->buildHistory($messages);
+
+        // Should truncate to 4 (or fewer after leading-assistant drop), not 1
+        $this->assertGreaterThan(1, count($history),
+            'Quoted config value should normalize to 4, not 1');
+        $this->assertLessThanOrEqual(4, count($history));
+        $this->assertSame('user', $history[0]['role'],
+            'History must start with a user message');
+    }
+
     public function test_loading_conversation_dispatches_active_history_event(): void
     {
         $user = User::factory()->create();

--- a/laravel/tests/Unit/Services/ChatOrchestrationServiceTest.php
+++ b/laravel/tests/Unit/Services/ChatOrchestrationServiceTest.php
@@ -49,6 +49,70 @@ class ChatOrchestrationServiceTest extends TestCase
         ], $history);
     }
 
+    public function test_build_history_drops_leading_assistant_after_truncation(): void
+    {
+        // When window boundary falls mid-pair, result must not start with assistant
+        $service = new class extends ChatOrchestrationService {
+            protected function maxHistoryMessages(): int { return 4; }
+        };
+
+        // 6 messages: u1 a1 u2 a2 u3 a3
+        // After slice(-4): a2 u3 a3 u4 — wait, let's build a clear case:
+        // u1 a1 u2 a2 u3 a3 u4 a4 u5 a5 (10 messages)
+        // slice(-4) = a4 u5 a5 u6... let's use explicit messages
+        $messages = [
+            ['role' => 'user',      'content' => 'u1'],
+            ['role' => 'assistant', 'content' => 'a1'],
+            ['role' => 'user',      'content' => 'u2'],
+            ['role' => 'assistant', 'content' => 'a2'],
+            ['role' => 'user',      'content' => 'u3'],
+            ['role' => 'assistant', 'content' => 'a3'],
+        ];
+
+        // slice(-4) = [a2, u3, a3, u4] — but we only have 6 messages
+        // slice(-4) = [u2, a2, u3, a3] — starts with user, no drop needed
+        // Let's use 5 messages where slice(-4) starts with assistant:
+        // u1 a1 u2 a2 u3 → slice(-4) = [a1, u2, a2, u3] — starts with assistant
+        $messages = [
+            ['role' => 'user',      'content' => 'u1'],
+            ['role' => 'assistant', 'content' => 'a1'],
+            ['role' => 'user',      'content' => 'u2'],
+            ['role' => 'assistant', 'content' => 'a2'],
+            ['role' => 'user',      'content' => 'u3'],
+        ];
+
+        $history = $service->buildHistory($messages);
+
+        // slice(-4) = [a1, u2, a2, u3] → drop leading a1 → [u2, a2, u3]
+        $this->assertSame('user', $history[0]['role'],
+            'History must not start with an assistant message after truncation');
+        $this->assertSame('u2', $history[0]['content']);
+        $this->assertSame('u3', end($history)['content']);
+    }
+
+    public function test_build_history_does_not_drop_leading_user_message(): void
+    {
+        $service = new class extends ChatOrchestrationService {
+            protected function maxHistoryMessages(): int { return 4; }
+        };
+
+        $messages = [
+            ['role' => 'user',      'content' => 'u1'],
+            ['role' => 'assistant', 'content' => 'a1'],
+            ['role' => 'user',      'content' => 'u2'],
+            ['role' => 'assistant', 'content' => 'a2'],
+            ['role' => 'user',      'content' => 'u3'],
+            ['role' => 'assistant', 'content' => 'a3'],
+        ];
+
+        // slice(-4) = [u2, a2, u3, a3] — starts with user, nothing dropped
+        $history = $service->buildHistory($messages);
+
+        $this->assertCount(4, $history);
+        $this->assertSame('user', $history[0]['role']);
+        $this->assertSame('u2', $history[0]['content']);
+    }
+
     public function test_build_history_truncates_to_max_messages_keeping_most_recent(): void
     {
         // Use anonymous subclass to override maxHistoryMessages() without config()

--- a/laravel/tests/Unit/Services/ChatOrchestrationServiceTest.php
+++ b/laravel/tests/Unit/Services/ChatOrchestrationServiceTest.php
@@ -49,6 +49,45 @@ class ChatOrchestrationServiceTest extends TestCase
         ], $history);
     }
 
+    public function test_build_history_truncates_to_max_messages_keeping_most_recent(): void
+    {
+        // Use anonymous subclass to override maxHistoryMessages() without config()
+        $service = new class extends ChatOrchestrationService {
+            protected function maxHistoryMessages(): int { return 4; }
+        };
+
+        $messages = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $messages[] = ['role' => $i % 2 === 0 ? 'assistant' : 'user', 'content' => "Pesan ke-{$i}"];
+        }
+
+        $history = $service->buildHistory($messages);
+
+        // Only last 4 messages should be returned
+        $this->assertCount(4, $history);
+        $this->assertSame('Pesan ke-7', $history[0]['content']);
+        $this->assertSame('Pesan ke-8', $history[1]['content']);
+        $this->assertSame('Pesan ke-9', $history[2]['content']);
+        $this->assertSame('Pesan ke-10', $history[3]['content']);
+    }
+
+    public function test_build_history_does_not_truncate_when_within_limit(): void
+    {
+        $service = new class extends ChatOrchestrationService {
+            protected function maxHistoryMessages(): int { return 20; }
+        };
+
+        $messages = [
+            ['role' => 'user', 'content' => 'Pesan 1'],
+            ['role' => 'assistant', 'content' => 'Jawaban 1'],
+            ['role' => 'user', 'content' => 'Pesan 2'],
+        ];
+
+        $history = $service->buildHistory($messages);
+
+        $this->assertCount(3, $history);
+    }
+
     public function test_single_document_source_uses_compact_reference_footer(): void
     {
         $service = new ChatOrchestrationService();


### PR DESCRIPTION
## Summary

Fixes #160 — History chat dikirim penuh tanpa truncation.

## Root Cause

`buildHistory()` meneruskan seluruh history conversation ke AI service tanpa batas. Untuk chat panjang, ini bisa melebihi context window GitHub Models (error 400/500 mendadak) dan membengkakkan biaya token.

## Changes

| File | Perubahan |
|------|-----------|
| `laravel/app/Services/ChatOrchestrationService.php` | Tambah sliding window di `buildHistory()`, tambah `maxHistoryMessages()` |
| `laravel/tests/Unit/Services/ChatOrchestrationServiceTest.php` | Tambah 2 test cases |

## How It Works

`buildHistory()` sekarang:
1. Ambil limit dari `config('services.ai_service.max_history_messages', 20)`
2. Jika jumlah pesan > limit, ambil N pesan terakhir (`array_slice($messages, -$maxMessages)`)
3. Pesan lama di-drop — hanya konteks terbaru yang dikirim ke AI

**Default 20 pesan** dipilih sebagai balance antara konteks yang cukup dan token budget yang aman.

## Verification

```
php artisan test --filter ChatOrchestrationServiceTest
# 8 passed (25 assertions)

php artisan test
# 246 passed, 0 failed
```

## Before / After

**Before:** Chat ke-50 → seluruh 50 pesan dikirim → context overflow → error mendadak.

**After:** Chat ke-50 → hanya 20 pesan terakhir dikirim → stabil, biaya terkontrol.