### PR TITLE
fix: 3 LOW findings — rate limit order, explicit disk, conversation sort tiebreaker

### DIFF
--- a/laravel/app/Livewire/Chat/ChatIndex.php
+++ b/laravel/app/Livewire/Chat/ChatIndex.php
@@ -113,6 +113,7 @@ class ChatIndex extends Component
         $this->conversations = $user->conversations()
             ->with('latestMessage')
             ->orderBy('updated_at', 'desc')
+            ->orderBy('id', 'desc')
             ->get();
         $this->pendingConversationIds = $this->conversations
             ->filter(fn (Conversation $conversation) => $this->conversationHasPendingResponse($conversation))

--- a/laravel/app/Livewire/Memos/MemoCanvas.php
+++ b/laravel/app/Livewire/Memos/MemoCanvas.php
@@ -38,13 +38,13 @@ class MemoCanvas extends Component
 
     public function generate(MemoGenerationService $generationService): void
     {
-        $this->enforceRateLimit('generate', 5, 60, 'Terlalu banyak generate memo. Coba lagi sebentar.');
-
         $data = $this->validate([
             'memoType' => ['required', 'in:'.implode(',', array_keys(Memo::TYPES))],
             'title' => ['required', 'string', 'max:160'],
             'context' => ['required', 'string', 'max:12000'],
         ]);
+
+        $this->enforceRateLimit('generate', 5, 60, 'Terlalu banyak generate memo. Coba lagi sebentar.');
 
         $this->isGenerating = true;
 

--- a/laravel/app/Livewire/Memos/MemoWorkspace.php
+++ b/laravel/app/Livewire/Memos/MemoWorkspace.php
@@ -134,11 +134,11 @@ class MemoWorkspace extends Component
 
     public function generateConfiguredMemo(): void
     {
-        $this->enforceRateLimit('generateConfiguredMemo', 5, 60, 'Terlalu banyak generate memo. Coba lagi sebentar.');
-
         if (! $this->validateMemoConfiguration()) {
             return;
         }
+
+        $this->enforceRateLimit('generateConfiguredMemo', 5, 60, 'Terlalu banyak generate memo. Coba lagi sebentar.');
 
         $this->memoChatMessages[] = [
             'role' => 'user',

--- a/laravel/app/Services/DocumentLifecycleService.php
+++ b/laravel/app/Services/DocumentLifecycleService.php
@@ -267,8 +267,8 @@ class DocumentLifecycleService
 
     private function deleteDocumentFile(Document $document): void
     {
-        if ($document->file_path && Storage::exists($document->file_path)) {
-            Storage::delete($document->file_path);
+        if ($document->file_path && Storage::disk('local')->exists($document->file_path)) {
+            Storage::disk('local')->delete($document->file_path);
         }
     }
 }

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -1017,4 +1017,30 @@ class ChatUiTest extends TestCase
             ->assertSet('conversationDocuments', [])
             ->assertDispatched('conversation-documents-preview');
     }
+
+    public function test_load_conversations_uses_id_desc_as_tiebreaker_for_same_updated_at(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $sameTimestamp = now()->subMinutes(5);
+
+        $conv1 = Conversation::create(['user_id' => $user->id, 'title' => 'Conv 1']);
+        $conv2 = Conversation::create(['user_id' => $user->id, 'title' => 'Conv 2']);
+        $conv3 = Conversation::create(['user_id' => $user->id, 'title' => 'Conv 3']);
+
+        // Set all three to the same updated_at — without tiebreaker, order is non-deterministic
+        Conversation::withoutTimestamps(function () use ($conv1, $conv2, $conv3, $sameTimestamp) {
+            $conv1->forceFill(['updated_at' => $sameTimestamp])->save();
+            $conv2->forceFill(['updated_at' => $sameTimestamp])->save();
+            $conv3->forceFill(['updated_at' => $sameTimestamp])->save();
+        });
+
+        $component = Livewire::actingAs($user)->test(ChatIndex::class);
+        $conversations = $component->get('conversations');
+
+        // With id desc tiebreaker, conv3 (highest id) must come first
+        $ids = $conversations->pluck('id')->values()->all();
+        $this->assertSame([(int) $conv3->id, (int) $conv2->id, (int) $conv1->id], $ids,
+            'Conversations with same updated_at must be ordered by id desc as tiebreaker');
+    }
 }

--- a/laravel/tests/Feature/Documents/DocumentDeletionTest.php
+++ b/laravel/tests/Feature/Documents/DocumentDeletionTest.php
@@ -95,4 +95,37 @@ class DocumentDeletionTest extends TestCase
         $component->assertSee('Dokumen terpilih berhasil dihapus.');
         Http::assertSentCount(2);
     }
+
+    public function test_delete_document_uses_explicit_local_disk(): void
+    {
+        // Verifikasi bahwa deleteDocumentFile menggunakan Storage::disk('local')
+        // bukan disk default. Jika FILESYSTEM_DISK diubah, file tetap terhapus.
+        Storage::fake('local');
+        Storage::fake('s3'); // simulate alternate disk
+        config()->set('filesystems.default', 's3');
+
+        Http::fake(['*' => Http::response(['message' => 'success'], 200)]);
+        config()->set('services.ai_document_service.url', 'http://python-ai-docs:8002');
+
+        $user = User::factory()->create();
+        $filePath = 'documents/'.$user->id.'/explicit-disk.pdf';
+        Storage::disk('local')->put($filePath, 'dummy content');
+
+        $document = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'explicit-disk.pdf',
+            'original_name' => 'explicit-disk.pdf',
+            'file_path' => $filePath,
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 123,
+            'status' => 'ready',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(\App\Livewire\Chat\ChatIndex::class)
+            ->call('deleteDocument', $document->id);
+
+        // File harus terhapus dari disk 'local' meski default disk adalah 's3'
+        Storage::disk('local')->assertMissing($filePath);
+    }
 }

--- a/laravel/tests/Feature/Memos/MemoCanvasTest.php
+++ b/laravel/tests/Feature/Memos/MemoCanvasTest.php
@@ -48,6 +48,31 @@ class MemoCanvasTest extends TestCase
         Http::assertNothingSent();
     }
 
+    public function test_generate_invalid_input_does_not_consume_rate_limit(): void
+    {
+        Http::fake([
+            '*' => fn () => throw new \RuntimeException('HTTP should not be called on invalid input.'),
+        ]);
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $key = MemoCanvas::class.':generate:user-'.$user->id.':127.0.0.1';
+
+        // Submit invalid input (empty title) 5 times — should NOT consume rate limit
+        for ($i = 0; $i < 5; $i++) {
+            Livewire::actingAs($user)
+                ->test(MemoCanvas::class)
+                ->set('memoType', 'memo_internal')
+                ->set('title', '') // invalid
+                ->set('context', 'Konteks memo.')
+                ->call('generate')
+                ->assertHasErrors(['title']);
+        }
+
+        // Rate limiter counter must still be 0 — invalid input did not hit it
+        $this->assertSame(0, RateLimiter::attempts($key));
+        Http::assertNothingSent();
+    }
+
     public function test_generate_creates_memo_and_redirects_to_canvas(): void
     {
         Storage::fake('local');

--- a/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
+++ b/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
@@ -52,6 +52,33 @@ class MemoWorkspaceTest extends TestCase
         Http::assertNothingSent();
     }
 
+    public function test_generate_configured_memo_invalid_input_does_not_consume_rate_limit(): void
+    {
+        Http::fake([
+            '*' => fn () => throw new \RuntimeException('HTTP should not be called on invalid input.'),
+        ]);
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $key = MemoWorkspace::class.':generateConfiguredMemo:user-'.$user->id.':127.0.0.1';
+
+        // Submit with empty required fields 5 times — should NOT consume rate limit
+        for ($i = 0; $i < 5; $i++) {
+            Livewire::actingAs($user)
+                ->test(MemoWorkspace::class)
+                ->set('memoNumber', '')  // invalid — required
+                ->set('memoRecipient', '')
+                ->set('title', '')
+                ->set('memoDate', '')
+                ->set('memoContent', '')
+                ->call('generateConfiguredMemo')
+                ->assertHasErrors(['memoNumber']);
+        }
+
+        // Rate limiter counter must still be 0
+        $this->assertSame(0, RateLimiter::attempts($key));
+        Http::assertNothingSent();
+    }
+
     public function test_workspace_renders_parent_driven_toggle_and_home_link(): void
     {
         $user = User::factory()->create(['email_verified_at' => now()]);


### PR DESCRIPTION
## Summary

Closes #174 — 3 temuan LOW dari deep bug audit 2026-05-13.

## Changes

| # | File | Perubahan |
|---|------|-----------|
| 1 | `laravel/app/Livewire/Memos/MemoCanvas.php` | Validate dulu, baru rate limit |
| 2 | `laravel/app/Livewire/Memos/MemoWorkspace.php` | Validate dulu, baru rate limit |
| 3 | `laravel/app/Services/DocumentLifecycleService.php` | `Storage::disk('local')` eksplisit |
| 4 | `laravel/app/Livewire/Chat/ChatIndex.php` | Tambah `->orderBy('id', 'desc')` sebagai tiebreaker |

## Detail

**1 & 2 — Rate limit setelah validasi:**
`enforceRateLimit` sebelumnya dipanggil sebelum `validate`. User dengan input invalid (typo, field kosong) tetap memotong kuota 5/menit. Sekarang validasi jalan dulu — jika gagal, rate limit tidak disentuh.

**3 — Disk eksplisit:**
`Storage::exists()` dan `Storage::delete()` tanpa disk eksplisit menggunakan `FILESYSTEM_DISK` default. Jika disk default diubah, file dokumen tidak akan terhapus. Diganti ke `Storage::disk('local')` konsisten dengan semua tempat lain.

**4 — Secondary sort tiebreaker:**
`loadConversations` hanya sort by `updated_at desc`. Saat banyak conversation di-touch bersamaan (polling), urutan bisa non-deterministik. Tambah `->orderBy('id', 'desc')` sebagai tiebreaker.

## Verification

```
php artisan test --filter "MemoCanvasTest|MemoWorkspaceTest|DocumentDeletionTest|ChatUiTest"
# 59 passed (385 assertions)

php artisan test
# 262 passed, 0 failed
```