### PR TITLE
feat: streaming live end-to-end untuk chat, web search, dan chat dokumen (#189)

### DIFF
--- a/issue/issue-189-streaming-live-chat-2026-05-15.md
+++ b/issue/issue-189-streaming-live-chat-2026-05-15.md
@@ -1,0 +1,120 @@
+# Issue #189 — Streaming Live End-to-End untuk Chat, Web Search, dan Chat Dokumen
+
+## Latar Belakang
+
+Python AI sudah mengirim `StreamingResponse` SSE. Laravel `AIService` sudah membaca chunk via generator. Namun `GenerateChatResponse` job mengakumulasi seluruh chunk ke `$fullResponse` sebelum menyimpan satu pesan final ke DB. UI mengetahui jawaban selesai hanya lewat `wire:poll.3s`, sehingga user melihat layar kosong/placeholder sampai seluruh jawaban selesai.
+
+`chat-page.js` sudah memiliki listener `assistant-output`, `model-name`, `assistant-sources` via `$wire.on()`, tapi tidak ada yang mendispatch event tersebut dari Laravel.
+
+## Tujuan
+
+Aktifkan streaming live sampai UI untuk tiga mode:
+- Chat biasa
+- Web search
+- Chat dengan dokumen
+
+Target: token/chunk mulai terlihat segera setelah diterima dari Python, sementara persistensi final assistant message ke DB tetap dipertahankan.
+
+## Arsitektur Solusi
+
+### Pendekatan: SSE Endpoint Laravel + EventSource di JS
+
+Alur baru:
+1. User kirim pesan → `ChatIndex::sendMessage()` dispatch `GenerateChatResponse` job (tetap sama)
+2. JS membuka `EventSource` ke endpoint SSE baru: `GET /chat/stream/{conversationId}`
+3. Endpoint SSE memanggil `AIService::sendChat()` langsung (bukan via job), stream chunk ke browser sebagai SSE events
+4. Setelah stream selesai, endpoint menyimpan final message ke DB
+5. Polling `wire:poll.3s` tetap sebagai fallback/recovery
+
+### Mengapa SSE endpoint, bukan Livewire broadcast?
+
+- Livewire tidak mendukung server-push native tanpa WebSocket/Reverb
+- SSE adalah HTTP standar, tidak butuh infrastruktur tambahan
+- `DocumentPreviewController` sudah pakai `StreamedResponse` sebagai preseden
+- JS sudah punya `registerWireListener('assistant-output', ...)` — tinggal feed dari SSE
+
+### Alur Detail
+
+```
+Browser                    Laravel                      Python AI
+  |                           |                              |
+  |-- POST /livewire/... ---> |                              |
+  |   (sendMessage)           |-- dispatch job (queue) ----> |
+  |<-- user-message-acked --- |                              |
+  |                           |                              |
+  |-- GET /chat/stream/{id} ->|                              |
+  |   (EventSource)           |-- POST /api/chat ----------->|
+  |                           |<-- SSE chunks ---------------| 
+  |<-- SSE: chunk ----------- |                              |
+  |<-- SSE: chunk ----------- |                              |
+  |<-- SSE: done ------------ |                              |
+  |   (message saved to DB)   |                              |
+  |                           |                              |
+  | (wire:poll detects done)  |                              |
+  |<-- refreshPendingChatState|                              |
+```
+
+## Scope Implementasi
+
+### File Baru
+- `laravel/app/Http/Controllers/Chat/ChatStreamController.php` — SSE endpoint
+- `laravel/tests/Feature/Chat/ChatStreamTest.php` — test untuk endpoint streaming
+
+### File Diubah
+- `laravel/routes/web.php` — tambah route SSE
+- `laravel/resources/js/chat-page.js` — buka EventSource, feed chunk ke `streamingText`
+- `laravel/app/Jobs/GenerateChatResponse.php` — tidak perlu diubah (job tetap sebagai fallback/persistensi)
+
+### Out of Scope
+- Mengubah Python AI
+- Mengubah kualitas RAG/retrieval
+- Refactor besar UI chat
+
+## Rencana Implementasi
+
+### Step 1: ChatStreamController
+- Route: `GET /chat/stream/{conversationId}` (auth + verified)
+- Validasi: conversation harus milik user yang login
+- Baca parameter dari query string: `history` (JSON), `documentIds` (JSON array), `webSearchMode` (bool)
+- Panggil `AIService::sendChat()` langsung
+- Stream chunk sebagai SSE: `data: {chunk}\n\n`
+- Kirim event khusus untuk sources dan model name
+- Setelah stream selesai, simpan final message ke DB via `ChatOrchestrationService`
+- Handle error: kirim SSE error event, jangan duplicate message
+
+### Step 2: Route
+```php
+Route::get('chat/stream/{conversationId}', [ChatStreamController::class, 'stream'])
+    ->middleware(['auth', 'verified'])
+    ->whereNumber('conversationId')
+    ->name('chat.stream');
+```
+
+### Step 3: JS — EventSource
+- Di `chatMessages` Alpine component, setelah `user-message-acked`, buka `EventSource`
+- Listen event `chunk` → append ke `streamingText`
+- Listen event `done` → tutup EventSource, biarkan polling handle final state
+- Listen event `error` → tutup EventSource, tampilkan error
+- Tutup EventSource saat conversation berganti atau component destroy
+
+## Idempotensi & Error Handling
+
+- `ChatStreamController` cek apakah sudah ada assistant message setelah user message terakhir → jika ya, skip (job sudah selesai duluan)
+- Jika stream gagal di tengah jalan, job queue tetap berjalan dan akan menyimpan final message
+- Polling `wire:poll.3s` tetap sebagai recovery path
+- Tidak ada duplicate: controller hanya simpan jika belum ada assistant message untuk conversation tersebut setelah user message terakhir
+
+## Acceptance Criteria
+
+- [ ] Chat biasa menampilkan output bertahap sebelum job/response selesai total
+- [ ] Web search tetap menampilkan jawaban dan sources dengan benar
+- [ ] Chat dokumen tetap menampilkan jawaban dan referensi dokumen dengan benar
+- [ ] Jika stream gagal di tengah jalan, UI bisa recover melalui polling/final DB state
+- [ ] Tidak ada duplicate assistant message pada retry/refresh
+- [ ] Test relevan Laravel ditambahkan/diupdate
+
+## Risiko
+
+- SSE endpoint memanggil Python AI langsung (bukan via job), artinya ada dua jalur ke Python: SSE endpoint dan job queue. Perlu idempotensi ketat agar tidak double-save.
+- Timeout PHP: SSE endpoint butuh `set_time_limit(0)` atau nilai besar
+- Koneksi browser putus: PHP `connection_aborted()` check di loop streaming

--- a/issue/issue-189-streaming-live-chat-2026-05-15.md
+++ b/issue/issue-189-streaming-live-chat-2026-05-15.md
@@ -44,7 +44,7 @@ Browser                    Laravel                      Python AI
   |                           |                              |
   |-- GET /chat/stream/{id} ->|                              |
   |   (EventSource)           |-- POST /api/chat ----------->|
-  |                           |<-- SSE chunks ---------------| 
+  |                           |<-- SSE chunks ---------------|
   |<-- SSE: chunk ----------- |                              |
   |<-- SSE: chunk ----------- |                              |
   |<-- SSE: done ------------ |                              |

--- a/issue/issue-chat-search-document-latency-audit-2026-05-15.md
+++ b/issue/issue-chat-search-document-latency-audit-2026-05-15.md
@@ -1,0 +1,369 @@
+# Audit Latency Chat, Web Search, dan Chat Dokumen
+
+## Latar Belakang
+User merasakan output chat biasa, web search, dan chat dengan dokumen masih lambat, kadang puluhan detik. Audit ini menelusuri alur end-to-end dari Laravel UI/job sampai Python AI, LLM provider, web search, dan RAG/document retrieval untuk mencari bottleneck dan peluang perbaikan tanpa menurunkan kualitas jawaban.
+
+## Tujuan
+- Petakan cara kerja chat biasa, web search, dan chat dokumen saat ini.
+- Temukan penyebab latency yang didukung bukti kode, konfigurasi, atau test.
+- Identifikasi improvement yang menjaga atau meningkatkan kualitas:
+  - ketepatan web search
+  - ketepatan retrieval dokumen/RAG
+  - waktu menuju respons awal dan waktu selesai
+- Bedakan quick wins berisiko rendah dari perubahan besar yang perlu issue terpisah.
+
+## Scope
+- Laravel chat flow: Livewire component, queue job, service orchestration, polling/loading state.
+- Python AI chat API: request classification, LLM manager, streaming/non-streaming path.
+- Web search: intent/policy, LangSearch service, jumlah result, timeout/fallback, prompt injection.
+- Chat dokumen: retrieval, hybrid search, rerank/summarization/context packing, Chroma query.
+- Config dan test yang langsung terkait performa/kualitas.
+
+## Out of Scope
+- Redesign UI besar.
+- Migrasi provider/model besar tanpa bukti kuat.
+- Perubahan security/auth/deploy production kecuali ditemukan sebagai bottleneck langsung.
+- Merge/PR/deploy.
+
+---
+
+## GitHub Master Issue Scope
+
+Issue ini sengaja mencakup seluruh konteks audit agar tidak kehilangan hubungan antar bottleneck. Implementasi tetap disarankan dipecah menjadi beberapa PR kecil, dengan urutan:
+
+1. **PR 1 — Streaming end-to-end ke UI**
+   - Target utama: output chat mulai terlihat saat token/chunk sudah diterima, bukan setelah job selesai.
+   - Pertahankan persistensi final assistant message ke DB.
+   - Polling tetap ada sebagai fallback/recovery, bukan jalur utama.
+   - Wajib mencakup chat biasa, web search, dan chat dokumen.
+
+2. **PR 2 — Tuning latency Python AI risiko rendah**
+   - HyDE `always` → `smart` atau mode selektif berbasis query.
+   - Timeout cascade model lebih ketat untuk slot awal.
+   - Parallel score-query dual search.
+   - Eager import/warm-up modul berat.
+   - Polling UI diturunkan setelah streaming live aktif.
+
+3. **PR 3 — RAG/web search quality-speed tuning berbasis evaluasi**
+   - Evaluasi `top_k` 8 → 5 memakai eval set dokumen.
+   - Tambah metrik latency per tahap.
+   - Pastikan perubahan tidak menurunkan recall dokumen atau ketepatan sumber web.
+
+4. **PR 4 — Infrastruktur produksi bila diperlukan**
+   - Evaluasi `php -S` vs FPM/Octane.
+   - Pisahkan queue chat dari mail/default bila antrean mulai memengaruhi latency.
+   - Tuning worker Python/Horizon berbasis metrik production.
+
+Catatan validasi audit Opus:
+- Audit Opus valid untuk akar masalah utama: stream dari Python/PHP tidak sampai ke UI karena job mengakumulasi jawaban final dan UI bergantung pada polling.
+- Estimasi seperti "300–600 ms", "1–10 s", atau "8–11 s blank" masuk akal sebagai indikasi, tetapi harus diperlakukan sebagai hipotesis sampai ada metrik riil per tahap.
+- Rekomendasi terbaik tetap: selesaikan streaming end-to-end dulu, lalu tuning Python/RAG/web search dengan benchmark agar kualitas tidak turun.
+
+---
+
+## Ringkasan Eksekutif
+
+Sumber utama "puluhan detik" yang dirasakan user **bukan** dari LLM atau retrieval, melainkan dari **arsitektur transport jawaban**:
+
+1. Laravel mendispatch chat ke queued job (Horizon, Redis), bukan request HTTP yang stream.
+2. Job mendrain seluruh stream LLM ke variabel string, baru menyimpan satu kali ke DB pada akhir.
+3. UI Livewire melakukan polling 3 detik (`wire:poll.3s`) untuk mengetahui job sudah selesai.
+4. Event live streaming token (`assistant-output`, `model-name`, `assistant-sources`) **didengar** oleh JS di `chat-page.js` tetapi **tidak pernah didispatch** dari sisi Laravel/Livewire.
+
+Akibatnya time-to-first-token yang dilihat user ≈ `total LLM time + 0–3s polling`. Untuk respons LLM 8 detik, user bisa menunggu 8–11 detik tanpa karakter satu pun. Untuk respons 30 detik, user lihat blank 30+ detik. Streaming sebenarnya sudah ada di Python (`StreamingResponse` SSE) dan AIService PHP membaca chunk; jalur ini berhenti di queue job.
+
+Faktor lain yang memperparah:
+- Cold-start lazy import di tiap request `/api/chat` (`tiktoken`, `litellm`, `langchain_chroma`, `rag_*`).
+- HyDE `mode: always` menambah satu LLM call (300–600 ms target, tetapi timeout 3 s) **sebelum** retrieval.
+- Web search wajib LangSearch search + LangSearch rerank → dua HTTP calls serial sebelum LLM mulai jawab.
+- Cascade fallback model menggunakan `litellm.completion(timeout=30)`. Timeout litellm ini per-attempt dan tidak menjamin time-to-first-token; bila model pertama lambat respond awal, user tetap menunggu sampai TTFB selesai sebelum cascade.
+- Chat policy melakukan dua HTTP search berurutan untuk score query (`query` + `query final score`).
+- Cascade rate limit pada embedding ingest melakukan `time.sleep(2.0)` × hingga 3 retry per batch.
+
+Quick win paling impactful adalah **mengaktifkan stream end-to-end** sehingga user lihat token mengalir dalam <1 detik setelah submit, dan pekerjaan paralelisasi pada web search/RAG.
+
+---
+
+## Flow Map
+
+### A. Chat biasa (tanpa dokumen, tanpa toggle web)
+1. `POST /chat` (Livewire) — `ChatIndex::sendMessage` (`laravel/app/Livewire/Chat/ChatIndex.php:554`).
+2. `GenerateChatResponse::dispatch(...)` ke queue Redis (`laravel/app/Livewire/Chat/ChatIndex.php:628`).
+3. Worker Horizon (`docker-compose.production.yml:148`, `laravel/config/horizon.php:217`) menjalankan `GenerateChatResponse::handle` (`laravel/app/Jobs/GenerateChatResponse.php:39`).
+4. `AIService::sendChat` POST `http://python-ai:8001/api/chat` dengan `stream: true`, baca chunk 1024 byte (`laravel/app/Services/AIService.php:90-104`).
+5. FastAPI `chat_stream` panggil `should_use_web_search` → karena `documents_active=False` & `force_web_search=False` & `realtime_intent=low` → `should_web_search=False` → langsung `get_llm_stream` (`python-ai/app/chat_api.py:244`).
+6. `get_llm_stream` tetap memanggil `get_context_for_query` → di sana `get_langsearch_service()` (lazy init, no-op kalau tidak search) lalu return tanpa search (`python-ai/app/llm_manager.py:117-129`).
+7. `_stream_with_cascade` mencoba model satu per satu; chunk mengalir kembali via SSE (`python-ai/app/services/llm_streaming.py:336`).
+8. PHP job mengakumulasi `$fullResponse`, menyimpan ke DB, set `conversation->touch()` (`laravel/app/Jobs/GenerateChatResponse.php:83-119`).
+9. UI `wire:poll.3s="refreshPendingChatState"` melakukan reload conversation tiap 3 detik (`laravel/resources/views/livewire/chat/chat-index.blade.php:33`, `laravel/app/Livewire/Chat/ChatIndex.php:642`).
+
+### B. Web search (toggle ON atau auto-realtime)
+Sama seperti A sampai langkah 5, tetapi `should_use_web_search` returns `True`:
+1. `LangSearchService.search` panggil `https://api.langsearch.com/v1/web-search`, timeout 10 s (`python-ai/app/services/langsearch_service.py:78-127`).
+2. Bila score query, panggil search **lagi** dengan `f"{query} final score"` (`python-ai/app/services/rag_policy.py:256-260`).
+3. `LangSearchService.rerank_documents` panggil `https://api.langsearch.com/v1/rerank`, timeout 8 s (`python-ai/app/services/langsearch_service.py:233-307`).
+4. Search context disisipkan ke system prompt; `_stream_with_cascade` jalan.
+5. Sumber web dikirim sebagai `[SOURCES:...]` di akhir stream.
+
+### C. Chat dengan dokumen
+Sama seperti A sampai langkah 4, tetapi `documents_active=True`:
+1. Policy decide `should_web_search` (default False kecuali user toggle/explicit).
+2. `search_relevant_chunks` lewat `asyncio.to_thread` (`python-ai/app/chat_api.py:170-197`).
+3. `search_relevant_chunks` jalankan: HyDE LLM call (kalau `mode=always`), embedding query, vector similarity_search, BM25 hybrid, exclude parent, rerank LangSearch, optional PDR parent lookup (`python-ai/app/services/rag_retrieval.py:61`).
+4. Build RAG prompt + sources → `get_llm_stream_with_sources` → cascade.
+
+### D. Upload dokumen + ingest
+1. UI upload via Livewire, `ProcessDocument` job dispatch ke queue.
+2. Job panggil `python-ai-docs:8002 /api/documents/process` (`python-ai/app/routers/documents.py:81`).
+3. `run_document_process` spawn **subprocess `python -m app.document_tasks process`** (`python-ai/app/document_runner.py:24-44`). Subprocess ini bootstrap interpreter Python baru, import langchain/chroma/pdfplumber/docx/openpyxl/tiktoken dari nol.
+4. Subprocess: load text, lightweight chunking, embed dengan cascading fallback, batch upsert ke Chroma.
+
+---
+
+## Bottleneck dan Bukti
+
+### B1. Streaming tidak sampai ke user (paling impactful)
+**Bukti:**
+- `laravel/app/Jobs/GenerateChatResponse.php:61-86` — loop `foreach ($aiService->sendChat(...) as $chunk)` mengakumulasi `$fullResponse` saja, tidak ada `Event` / Livewire dispatch / Reverb broadcast.
+- `laravel/resources/js/chat-page.js:419` — listener `assistant-output`, `model-name`, `assistant-sources` terdaftar di Livewire.
+- `grep -rn "assistant-output" laravel/app laravel/resources/views/` → **0 dispatcher**. Tidak ada code path yang pernah memicu event ini.
+- `laravel/resources/views/livewire/chat/chat-index.blade.php:33` — polling 3 s adalah satu-satunya mekanisme refresh.
+- `python-ai/app/chat_api.py:204-252` — Python sudah `StreamingResponse` SSE.
+
+**Dampak:** Time-to-first-token dari sudut pandang user = (waktu LLM mulai sampai selesai) + (0–3 s polling). Untuk jawaban panjang/lambat ini terasa puluhan detik karena **tidak ada karakter pun yang muncul** sebelum semua selesai. UI menampilkan placeholder "AI sedang berpikir" dengan timer 8 + 8 detik (`chat-page.js:565-580`), yang membuat user lebih cepat berasumsi macet.
+
+**Severity:** Tinggi. Ini sumber utama persepsi "puluhan detik".
+
+### B2. Polling 3 detik untuk refresh state job
+**Bukti:** `laravel/resources/views/livewire/chat/chat-index.blade.php:33`.
+**Dampak:** Tambahan 0–3 detik antara job selesai dan UI menampilkan jawaban; juga membebani Livewire roundtrip (full component diff) tiap 3 s untuk semua user yang membuka tab chat.
+
+### B3. Lazy import per request di Python chat
+**Bukti:** `python-ai/app/chat_api.py:96-120`. `_get_chat_streamers`, `_get_rag_policy_helpers`, `_get_rag_document_helpers` mengimport `app.llm_manager`, `app.services.rag_policy`, `app.retrieval_runner`, `app.services.rag_retrieval` di dalam fungsi. Modul-modul itu menarik `litellm`, `langchain_chroma`, `tiktoken`, `rank_bm25`, `requests`, dan via `rag_retrieval` lagi `chromadb`.
+**Dampak:** Pada cold-start worker uvicorn pertama, request pertama bisa menambah 1–3 detik untuk import. Setelah itu di-cache di module registry, biaya hanya satu kali per worker. Tetap mengorbankan request pertama setelah deploy/restart.
+**Catatan:** `UVICORN_WORKERS=2` di compose, sehingga ada 2 cold paths terpisah.
+
+### B4. HyDE `mode: always` menambah LLM call sebelum retrieval
+**Bukti:** `python-ai/config/ai_config.yaml:273-277` — `enabled: true, mode: always, timeout: 3`. `python-ai/app/services/rag_hybrid.py:54-128` — pakai `litellm.completion(stream=False, timeout=3, max_tokens=100)` ke model chat tier murah pertama. Bila timeout, lanjut attempt kedua.
+**Dampak:** Tambahan ≈ 300–1500 ms (atau 3000 ms × 2 atempt = 6000 ms saat provider lemot) sebelum vector search. Kualitas naik untuk pertanyaan abstrak, tapi banyak query sederhana ("apa isi dokumen X", "tolong rangkum") tidak butuh HyDE.
+
+### B5. Dua call serial ke LangSearch (search + rerank) untuk web
+**Bukti:** `python-ai/app/services/rag_policy.py:252-307`.
+**Dampak:** Search timeout 10 s + rerank timeout 8 s = potensi 18 s **sebelum** LLM jalan. Pada kondisi normal LangSearch ≈ 1–2 s + ≈ 0.7–1.5 s; tetap 2–3.5 s sebelum LLM. Kandidat optimasi: paralel dengan retrieval dokumen, atau drop rerank untuk score query/cache hit, atau lakukan rerank di latar belakang sambil LLM mulai jawab dengan top-k vector.
+
+### B6. Score query memicu dua web search berurutan
+**Bukti:** `python-ai/app/services/rag_policy.py:256-260`.
+```python
+if _is_score_query(query) and score_signal is None:
+    focused_query = f"{query} final score"
+    focused_results = langsearch.search(focused_query)
+```
+**Dampak:** Tambahan 1–10 s saat skor tidak terdeteksi di hasil pertama. Kalau cache hit, gratis. Kandidat optimasi: jalankan paralel dari awal saat `_is_score_query=True`.
+
+### B7. AIService PHP read dengan `$body->read(1024)` blocking
+**Bukti:** `laravel/app/Services/AIService.php:102-104`.
+**Dampak:** Karena `Guzzle` → cURL → blocking read, chunk yang sudah diakumulasi masih harus di-yield ke caller; tidak ada mekanisme streaming ke user, sehingga read 1024 byte yang efisien pun tidak membantu UX. Setelah B1 diperbaiki, ini cukup bagus.
+
+### B8. `set_time_limit(120)` di sendMessage Livewire
+**Bukti:** `laravel/app/Livewire/Chat/ChatIndex.php:569`. Tidak ada efek karena seluruh proses LLM sudah pindah ke job, tetapi `php -S` server (`docker/serve.sh`) tidak ideal untuk produksi karena single-threaded blocking — tiap polling/Livewire request memblok satu PHP process. Walau bukan langsung penyebab "puluhan detik", ini menambah variabilitas latensi UI saat banyak request poll bersamaan.
+
+### B9. Cascade fallback model: timeout litellm 30 s per attempt
+**Bukti:** `python-ai/app/services/llm_streaming.py:323-333`.
+**Dampak:** Bila provider pertama hang, user menunggu sampai timeout 30 s sebelum cascade ke provider kedua. Tidak ada per-token / per-first-byte timeout. Untuk litellm, `timeout` umumnya berlaku untuk total request, tetapi pada streaming, behavior bergantung provider.
+**Catatan:** Daftar model di `ai_config.yaml` panjang (15+ entry) sehingga worst-case sangat besar. Mitigasi: turunkan timeout ke 15 s untuk slot pertama dan 25 s untuk Bedrock heavy, lalu tambahkan `connect_timeout` lebih ketat.
+
+### B10. RAG `top_k`/`doc_candidates` cukup tinggi → context besar
+**Bukti:** `python-ai/config/ai_config.yaml:233-240` — `top_k: 8, top_n: 8, doc_candidates: 25`.
+**Dampak:** Semakin banyak chunk → semakin besar prompt ke LLM → TTFT lebih lambat. Untuk kebanyakan query top_k 5 sudah cukup; rerank top_n 8 wajar untuk dokumen multi-topik. Tradeoff perlu diukur dengan eval set.
+
+### B11. Subprocess `run_document_process` bootstrap interpreter penuh
+**Bukti:** `python-ai/app/document_runner.py:28-44`.
+**Dampak:** Untuk **upload** dokumen (bukan chat), tiap dokumen membuka interpreter baru → import 3–5 s overhead. Bukan penyebab lambat di chat biasa, tetapi terasa di "Sedang membaca dokumen" pertama kali. Sudah memakai `temp_files` dan stream chunk; aman dari memory leak. Tradeoff disengaja agar memori worker FastAPI tidak ditumpuki library berat.
+
+### B12. Embedding cascade `time.sleep(2.0)` × 3 retry per batch
+**Bukti:** `python-ai/app/services/rag_ingest.py:373-421`. Bila `429` muncul → cascade ke model berikutnya → `sleep(retry_delay)` mulai 2.0 s, doubling tiap retry. Worst case 14 s tambahan per batch.
+**Dampak:** Hanya saat upload heavy dokumen + provider rate limit. Tidak menyentuh chat biasa.
+
+### B13. Loading phase 8s + 8s di UI
+**Bukti:** `laravel/resources/js/chat-page.js:565-580`.
+**Dampak:** Tidak menambah latensi nyata, tapi membuat user lihat label "AI sedang berpikir" lama dan tidak ada teks yang mengalir karena B1. Ironis: timer ini dipakai untuk meneduhkan UX, sambil token tidak streaming sama sekali.
+
+### B14. `wire:poll.3s` paralel di sidebar dokumen
+**Bukti:** `laravel/resources/views/livewire/chat/partials/chat-right-sidebar.blade.php:40` — 3 s polling saat ada dokumen processing, 20 s polling saat tidak.
+**Dampak:** Tambahan request Livewire reload + DB hit setiap 3 s (saat ada upload aktif). Akumulatif memperberat container Laravel `php -S` 1 CPU.
+
+### B15. `php -S` sebagai server produksi
+**Bukti:** `laravel/docker/serve.sh`.
+**Dampak:** Single-process built-in PHP server. Tidak ada FPM/Octane. Concurrent request user (poll 3s × N user + livewire submit + livewire updates) bisa antri. Limit memori 1024M & CPU 1.0 di compose.
+
+---
+
+## Faktor yang BUKAN bottleneck utama
+- LangSearch caching sudah ada (`OrderedDict`, TTL 5 menit, max 200 entry) → repeat query cepat (`langsearch_service.py:50-72`).
+- Chroma vector search dengan filter user_id+filename relatif cepat untuk koleksi <100k chunk.
+- BM25 hybrid jalan in-memory atas korpus terbatas (per dokumen) → biasanya <100 ms.
+- Sliding window `max_history_messages=20` mencegah prompt membengkak (`ChatOrchestrationService.php:93-102`).
+- Tiktoken sudah pre-init di module load (`rag_embeddings.py:22`).
+
+---
+
+## Rekomendasi (kualitas tetap atau naik)
+
+### Prioritas 1: Restore live streaming end-to-end (target: TTFT <1.5 s untuk chat biasa)
+
+Pilih salah satu strategi:
+
+**Opsi A (recommended): Streaming langsung dari Livewire ke UI tanpa queue**
+- Ganti dispatch job → endpoint streaming khusus (`Route::get('/chat/stream/{conversation}', ...)` dengan `Symfony\StreamedResponse`).
+- Endpoint ini otentikasi user, panggil `AIService::sendChat`, lakukan SSE/chunked output ke browser (`Cache-Control: no-cache`, `X-Accel-Buffering: no` untuk Caddy).
+- UI buka EventSource setelah `sendMessage` ack; fallback polling tetap dipertahankan untuk recover dari koneksi putus.
+- Persistensi assistant message tetap dilakukan saat stream selesai (di endpoint streaming, bukan di Livewire component).
+- Hapus polling 3 s atau turunkan ke 15 s sebagai safety net.
+
+Risiko: Caddy/Nginx buffering; perlu `flush_threshold_bytes` 0 dan disable gzip pada response stream. PHP `php -S` mendukung chunked output.
+
+**Opsi B: Persist token incremental + Livewire poll dipercepat**
+- Job tetap ada, tetapi simpan partial content ke `messages.content` setiap N token (debounced 300 ms) atau ke Redis pubsub.
+- `wire:poll.500ms` (saat ada pending) hanya read partial buffer dari Redis (cheap).
+- Lebih ringan diimplementasikan tetapi 500 ms latency masih ada per chunk dan lebih boros load.
+
+**Opsi C: Laravel Reverb / Pusher broadcast event per token**
+- Job dispatch `Event::dispatch(new AssistantToken(...))` per chunk; UI mendengar via Echo.
+- Memerlukan Reverb server dan WebSocket — perubahan deploy.
+
+Untuk tim ini, **Opsi A** paling cepat memberi efek dan tidak menyentuh broadcast layer. Opsi B mudah di-implement sebagai stopgap.
+
+### Prioritas 2: Paralelkan web search + retrieval + LLM init
+
+- Saat `documents_active and should_web_search`, jalankan `search_relevant_chunks` dan `get_context_for_query` sebagai dua coroutine (`asyncio.gather`) — sekarang sudah serial (`chat_api.py:170-188`).
+- Saat web search aktif, bisa kirim chunk pertama LLM dengan prompt minimal sambil rerank berjalan; tetapi ini menambah kompleksitas signifikan, tunda dulu.
+- Quick win: jalankan score-query "focused search" paralel dari awal saat detected, bukan setelah parsing pertama gagal (`rag_policy.py:256-260`).
+
+### Prioritas 3: Tuning HyDE
+- Default `mode: always` terlalu agresif. Ubah ke `mode: smart` (kode pendukungnya sudah ada di `_should_use_hyde`).
+- Atau pertahankan `always` dengan `timeout: 1.5` dan max 1 attempt (saat ini 2). Bila gagal, lanjut tanpa HyDE — kualitas tetap terjaga karena BM25 hybrid + rerank sudah aktif.
+
+### Prioritas 4: Tuning cascade timeout dan model order
+- Turunkan `timeout` litellm di `_run_model` dari 30 → 15 untuk slot pertama (`llm_streaming.py:328`). Tambah `connect_timeout` 5 s.
+- Pisahkan model tier "fast" vs "fallback" di `ai_config.yaml`. Slot pertama harus model dengan TTFB rendah konsisten (mis. Groq Llama 3.3 70B atau gemini native).
+- Bedrock dipindahkan ke akhir cascade (sudah, baik).
+
+### Prioritas 5: Tuning RAG retrieval
+- Set `top_k: 5` (turun dari 8) untuk default. Eval kualitas dengan `python-ai/tests/`.
+- `doc_candidates: 25` sudah baik. `bm25_candidates: 25` cukup.
+- Tambah opsi `top_k_per_document` sehingga multi-document tidak dimensi blow up (sudah ada implicit `per_doc_k = doc_candidates // n_docs`, dapat dibuat eksplisit).
+
+### Prioritas 6: Polling UI lebih ringan
+- Setelah B1 fixed, ganti `wire:poll.3s="refreshPendingChatState"` menjadi `wire:poll.10s` sebagai safety net.
+- Sidebar dokumen processing: turunkan ke 5 s saat aktif dan 60 s saat idle, atau pakai broadcast event saat status berubah.
+
+### Prioritas 7: Server PHP
+- Ganti `php -S` dengan `php-fpm` + Nginx/Caddy reverse proxy, atau Octane (Swoole/RoadRunner) bila concurrent user >20.
+- Octane akan memberi keep-alive worker yang juga menghilangkan bootstrap Laravel per request.
+
+### Prioritas 8: Cache warm-up dan eager-load Python
+- Tambah `import` eager untuk modul berat di top-level `chat_api.py` agar import biaya terbayar saat startup container, bukan saat request pertama.
+- Tambah liveness probe sederhana yang menyentuh path retrieval saat container ready, agar `langchain_chroma`, `litellm`, dll. sudah tervalidasi.
+
+### Prioritas 9: Quality-only improvement
+- Web search: pertimbangkan menambahkan `freshness="oneDay"` untuk realtime intent high (saat ini default `oneWeek`).
+- RAG prompt: sudah baik. Pastikan saat web + dokumen aktif keduanya tidak meledakkan token (current cap di `compose_enhanced_system_prompt` belum truncate; perlu hard cap di production).
+- Tambah `request_id` end-to-end (Laravel job id → Python logger) untuk tracing latency tiap fase. Saat ini log Python tidak bisa dihubungkan ke conversation Laravel kecuali via timing.
+
+---
+
+## Rekomendasi Quick Win (urutan eksekusi)
+
+1. **Fix streaming live (Opsi A atau B)** — biggest impact, target di issue terpisah.
+2. **HyDE mode `always` → `smart`** — turunkan median TTFT chat dokumen ≈ 300–600 ms.
+3. **Cascade timeout 30→15 s** untuk slot pertama LLM.
+4. **Score query: paralel dual search dari awal** — turunkan worst case web search sport.
+5. **`top_k` rerank 8→5** — TTFT chat dokumen turun ≈ 300 ms.
+6. **Eager import modul di `chat_api.py`** — request pertama setelah deploy lebih cepat.
+7. **Polling UI 3s → 10s** setelah streaming live aktif.
+
+Item 2–7 berisiko rendah dan dapat di-bundle jadi 1 PR kecil. Item 1 perlu PR sendiri dengan test.
+
+---
+
+## Test Gap
+
+- Tidak ada test E2E yang mengukur TTFT (time to first token) chat. Tambah test integrasi yang verifikasi response stream mulai mengirim chunk dalam <2 s untuk chat biasa.
+- Tidak ada test yang mensimulasikan provider lambat di `_run_model` untuk memvalidasi cascade aman.
+- Test RAG yang ada (di `python-ai/tests/`) — perlu cek apakah ada eval-set untuk kualitas retrieval. Bila tidak, tambah dataset kecil 20–30 query → expected chunks untuk regression test sebelum mengubah `top_k` / HyDE mode.
+
+## Risiko Perubahan
+- Mengaktifkan streaming live menambah surface untuk error ("connection reset", duplicated message saat retry). Wajib idempotent persist (gunakan transaksi DB seperti yang sudah ada di `sendMessage`).
+- Turunkan HyDE & top_k berisiko menurunkan recall. Wajib evaluasi sebelum deploy.
+- Cascade timeout lebih ketat berisiko trigger fallback lebih sering. Pastikan logging detail fallback dan kuota provider memadai.
+
+## Fakta vs Asumsi
+
+Fakta (terbukti dari kode):
+- Polling 3s, queued job, accumulated `$fullResponse`, listener tanpa dispatcher.
+- HyDE `mode: always`, top_k 8, doc_candidates 25.
+- Subprocess untuk ingest dokumen.
+- `php -S` di produksi.
+- Cascade litellm timeout 30 s.
+
+Asumsi (perlu pengukuran):
+- LangSearch median latency 1–2 s + 0.7–1.5 s rerank — perlu metric riil di environment ISTA.
+- Cold-start worker import 1–3 s — perlu profiling dengan `python -X importtime`.
+- TTFT LLM provider GitHub Models GPT-4.1 vs Groq Llama 3.3 — perlu A/B di production.
+- Penurunan recall saat top_k 8→5 — perlu eval set internal.
+
+## Risiko / Catatan
+- Server `php -S` bukan production-grade; bila tidak diganti, penambahan paralel request (poll lebih cepat, banyak user) akan saling memblok.
+- Caddy/Nginx layer perlu konfirmasi tidak buffer SSE response. Caddyfile di `deploy/Caddyfile` perlu cek `flush_interval`.
+- Bila Reverb dipakai untuk broadcast token, container tambahan dan Redis pub/sub jadi dependency baru; pertimbangkan trade-off sebelum komit.
+
+## Kriteria Selesai (audit)
+- ✅ Flow map tiap mode chat (chat biasa, web search, chat dokumen, ingest dokumen).
+- ✅ Daftar bottleneck dengan evidence file/fungsi (B1–B15).
+- ✅ Rekomendasi prioritas dengan trade-off kualitas/risiko.
+- ➡️ Tindak lanjut: bila user setuju, bisa dibuka issue terpisah untuk tiap prioritas (terutama P1 dan P2/P5) dan diimplementasikan bertahap.
+
+---
+
+## Patch Quick Win yang Sudah Diimplementasikan
+
+### Q1. Cache provider embedding untuk chat dokumen
+Sebelum patch, `get_embeddings_with_fallback()` selalu melakukan probe `embed_query("test")` setiap kali retrieval dokumen dimulai. Setelah itu Chroma tetap melakukan embedding untuk query asli, sehingga chat dokumen membayar minimal satu network call embedding tambahan.
+
+Perubahan:
+- `python-ai/app/services/rag_embeddings.py`
+  - Menambahkan cache provider embedding yang sudah lulus probe selama 300 detik.
+  - Cache hanya disimpan jika provider yang sukses adalah provider pada indeks yang diminta.
+  - Jika request primary sementara jatuh ke fallback, fallback tidak dicache sebagai primary. Request berikutnya tetap mencoba primary lagi agar kualitas tidak diam-diam turun permanen.
+
+Dampak:
+- Chat dokumen berikutnya dalam proses Python yang sama tidak perlu probe embedding ekstra.
+- Kualitas retrieval tetap memakai provider primary yang sama saat sehat.
+
+### Q2. Skip web rerank yang tidak memangkas kandidat
+Sebelum patch, default LangSearch mengembalikan 5 hasil dan konfigurasi `web_top_n` juga 5. Rerank pada kondisi ini menambah satu HTTP call ke `/rerank`, tetapi tetap mengirim 5 sumber ke LLM.
+
+Perubahan:
+- `python-ai/app/services/rag_policy.py`
+  - Web rerank hanya dipanggil jika `len(search_results) > web_top_n`.
+
+Dampak:
+- Web search default menghindari satu network call rerank yang tidak menambah konteks.
+- Jika konfigurasi memakai kandidat lebih banyak daripada final top-N, rerank tetap aktif.
+
+### Q3. Cache key dan snippet quality LangSearch
+Sebelum patch, cache LangSearch hanya memakai query + time bucket. Query yang sama dengan `freshness` atau `count` berbeda bisa memakai cache yang tidak sesuai. Selain itu formatter memakai `snippet` apa adanya walaupun kosong dan tidak fallback ke `summary`.
+
+Perubahan:
+- `python-ai/app/services/langsearch_service.py`
+  - Cache key sekarang mencakup query, `freshness`, `count`, dan time bucket.
+  - Formatter memakai `summary` bila `snippet` kosong.
+
+Dampak:
+- Ketepatan web search naik untuk variasi freshness/count.
+- Konteks web lebih kaya ketika API hanya mengisi summary.
+
+## Verifikasi Patch
+- `cd python-ai && source venv/bin/activate && pytest tests/test_rag_embeddings.py tests/test_rag_policy_singleton.py tests/test_langsearch_service_cache.py tests/test_chat_api_concurrency.py tests/test_llm_streaming.py` → 22 passed.
+- `cd python-ai && source venv/bin/activate && pytest` → 213 passed.
+- `git diff --check` → passed.

--- a/laravel/app/Http/Controllers/Chat/ChatStreamController.php
+++ b/laravel/app/Http/Controllers/Chat/ChatStreamController.php
@@ -121,6 +121,14 @@ class ChatStreamController extends Controller
         Conversation $conversation,
         \App\Models\User $user,
     ): void {
+        // Single-runner claim: jika assistant message sudah ada untuk user message
+        // terakhir (job selesai duluan), stream tidak perlu memanggil AI sama sekali.
+        // Ini mencegah user melihat chunk dari jawaban berbeda lalu final DB berubah.
+        if ($orchestrator->assistantAlreadyAnswered($conversationId)) {
+            $this->sendSseEvent('done', '1');
+            return;
+        }
+
         $fullResponse = '';
         $streamBuffer = '';
         $sources = [];

--- a/laravel/app/Http/Controllers/Chat/ChatStreamController.php
+++ b/laravel/app/Http/Controllers/Chat/ChatStreamController.php
@@ -121,6 +121,14 @@ class ChatStreamController extends Controller
         Conversation $conversation,
         \App\Models\User $user,
     ): void {
+        $streamClaimKey = $orchestrator->acquireStreamClaim($conversationId);
+        if ($streamClaimKey === null) {
+            // Runner lain (job/stream lain) sudah claim latest user message.
+            $this->sendSseEvent('done', '1');
+            return;
+        }
+
+        try {
         // Single-runner claim: jika assistant message sudah ada untuk user message
         // terakhir (job selesai duluan), stream tidak perlu memanggil AI sama sekali.
         // Ini mencegah user melihat chunk dari jawaban berbeda lalu final DB berubah.
@@ -217,6 +225,9 @@ class ChatStreamController extends Controller
         }
 
         $this->sendSseEvent('done', '1');
+        } finally {
+            $orchestrator->releaseStreamClaim($streamClaimKey);
+        }
     }
 
     /**

--- a/laravel/app/Http/Controllers/Chat/ChatStreamController.php
+++ b/laravel/app/Http/Controllers/Chat/ChatStreamController.php
@@ -28,13 +28,26 @@ class ChatStreamController extends Controller
             abort(404);
         }
 
-        // Parse request parameters
-        $history = $this->parseHistory($request->input('history', '[]'));
+        // Parse only document IDs and web search mode from query string.
+        // History is reconstructed server-side from DB to avoid:
+        //   - URL length limits (414) with long conversations
+        //   - Chat content leaking into access logs / proxy logs
+        //   - Arbitrary history injection from client
         $documentIds = $this->parseDocumentIds($request->input('document_ids', '[]'));
         $webSearchMode = filter_var($request->input('web_search_mode', false), FILTER_VALIDATE_BOOLEAN);
 
         $aiService = app(AIService::class);
         $orchestrator = app(ChatOrchestrationService::class);
+
+        // Reconstruct history server-side from DB messages
+        $dbMessages = Message::query()
+            ->where('conversation_id', $conversationId)
+            ->orderBy('id', 'asc')
+            ->get(['role', 'content'])
+            ->map(fn ($m) => ['role' => (string) $m->role, 'content' => (string) $m->content])
+            ->all();
+
+        $history = $orchestrator->buildHistory($dbMessages);
 
         // Resolve document context (owned + ready only) — must run before closure
         // so Auth::id() is still set in the request context.
@@ -62,7 +75,8 @@ class ChatStreamController extends Controller
             @ini_set('zlib.output_compression', false);
             set_time_limit(180);
 
-            if (ob_get_level() > 0) {
+            // Flush all output buffer levels (handles PHP-FPM multi-level buffers)
+            while (ob_get_level() > 0) {
                 ob_end_flush();
             }
 
@@ -186,78 +200,32 @@ class ChatStreamController extends Controller
             $cleanContent = 'Maaf, ISTA AI belum menerima jawaban yang bisa ditampilkan. Silakan coba lagi.';
         }
 
-        // Persist final message — idempotent: only save if no assistant message
-        // exists after the latest user message (prevents duplicate on job+stream race)
-        if (! $this->assistantMessageAlreadyExists($conversationId)) {
-            $saved = $orchestrator->saveAssistantMessage($conversationId, $cleanContent, $user->id);
-            if ($saved !== null) {
-                $conversation->touch();
-                $this->sendSseEvent('message-id', (string) $saved->id);
-            }
+        // Persist final message via saveAssistantMessage which now enforces
+        // idempotency under DB lockForUpdate — safe against race with background job.
+        $saved = $orchestrator->saveAssistantMessage($conversationId, $cleanContent, $user->id);
+        if ($saved !== null) {
+            $conversation->touch();
+            $this->sendSseEvent('message-id', (string) $saved->id);
         }
 
         $this->sendSseEvent('done', '1');
     }
 
     /**
-     * Send a single SSE event to the browser.
+     * Send a single SSE event to the browser using multi-line SSE framing.
+     * Each line of data is sent as a separate "data:" line so the browser
+     * automatically joins them with newlines — no lossy escape/unescape needed.
      */
     private function sendSseEvent(string $event, string $data): void
     {
-        // Escape newlines in data so SSE framing is not broken
-        $escaped = str_replace(["\r\n", "\r", "\n"], '\\n', $data);
         echo "event: {$event}\n";
-        echo "data: {$escaped}\n\n";
+        // Split on newlines and emit each as a separate data: line.
+        // The SSE spec says the browser joins multiple data: lines with \n.
+        foreach (explode("\n", str_replace("\r\n", "\n", $data)) as $line) {
+            echo "data: {$line}\n";
+        }
+        echo "\n";
         flush();
-    }
-
-    /**
-     * Check whether an assistant message already exists after the latest user
-     * message in this conversation. Used to prevent duplicate persistence when
-     * both the SSE stream and the background job complete around the same time.
-     */
-    private function assistantMessageAlreadyExists(int $conversationId): bool
-    {
-        $latestUserMessage = Message::query()
-            ->where('conversation_id', $conversationId)
-            ->where('role', 'user')
-            ->latest('id')
-            ->first();
-
-        if ($latestUserMessage === null) {
-            return false;
-        }
-
-        return Message::query()
-            ->where('conversation_id', $conversationId)
-            ->where('role', 'assistant')
-            ->where('id', '>', $latestUserMessage->id)
-            ->exists();
-    }
-
-    /**
-     * Parse JSON history from query string.
-     *
-     * @return array<int, array{role: string, content: string}>
-     */
-    private function parseHistory(string $raw): array
-    {
-        try {
-            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
-            if (! is_array($decoded)) {
-                return [];
-            }
-
-            return array_values(array_filter(
-                array_map(fn ($msg) => is_array($msg) ? [
-                    'role' => (string) ($msg['role'] ?? ''),
-                    'content' => (string) ($msg['content'] ?? ''),
-                ] : null, $decoded),
-                fn ($msg) => $msg !== null && $msg['role'] !== '' && $msg['content'] !== '',
-            ));
-        } catch (\Throwable) {
-            return [];
-        }
     }
 
     /**

--- a/laravel/app/Http/Controllers/Chat/ChatStreamController.php
+++ b/laravel/app/Http/Controllers/Chat/ChatStreamController.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace App\Http\Controllers\Chat;
+
+use App\Http\Controllers\Controller;
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Services\AIService;
+use App\Services\ChatOrchestrationService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ChatStreamController extends Controller
+{
+    public function stream(Request $request, int $conversationId): StreamedResponse
+    {
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+
+        // Validate conversation ownership
+        $conversation = Conversation::query()
+            ->whereKey($conversationId)
+            ->where('user_id', $user->id)
+            ->first();
+
+        if ($conversation === null) {
+            abort(404);
+        }
+
+        // Parse request parameters
+        $history = $this->parseHistory($request->input('history', '[]'));
+        $documentIds = $this->parseDocumentIds($request->input('document_ids', '[]'));
+        $webSearchMode = filter_var($request->input('web_search_mode', false), FILTER_VALIDATE_BOOLEAN);
+
+        $aiService = app(AIService::class);
+        $orchestrator = app(ChatOrchestrationService::class);
+
+        // Resolve document context (owned + ready only) — must run before closure
+        // so Auth::id() is still set in the request context.
+        $docContext = $orchestrator->getActiveDocumentContext($documentIds);
+        $documentFilenames = $docContext['filenames'];
+        $resolvedDocumentIds = $docContext['ids'];
+        $sourcePolicy = $orchestrator->getSourcePolicy($documentFilenames);
+        $allowAutoRealtimeWeb = $orchestrator->shouldAllowAutoRealtimeWeb($documentFilenames);
+
+        return new StreamedResponse(function () use (
+            $aiService,
+            $orchestrator,
+            $history,
+            $documentFilenames,
+            $resolvedDocumentIds,
+            $sourcePolicy,
+            $allowAutoRealtimeWeb,
+            $webSearchMode,
+            $conversationId,
+            $conversation,
+            $user,
+        ) {
+            // Disable output buffering so chunks reach the browser immediately
+            @ini_set('output_buffering', 'off');
+            @ini_set('zlib.output_compression', false);
+            set_time_limit(180);
+
+            if (ob_get_level() > 0) {
+                ob_end_flush();
+            }
+
+            $this->executeStream(
+                $aiService,
+                $orchestrator,
+                $history,
+                $documentFilenames,
+                $resolvedDocumentIds,
+                $sourcePolicy,
+                $allowAutoRealtimeWeb,
+                $webSearchMode,
+                $conversationId,
+                $conversation,
+                $user,
+            );
+        }, 200, [
+            'Content-Type' => 'text/event-stream',
+            'Cache-Control' => 'no-cache, no-store',
+            'X-Accel-Buffering' => 'no',
+            'Connection' => 'keep-alive',
+        ]);
+    }
+
+    /**
+     * Core streaming logic — extracted so it can be called directly in tests
+     * without needing to execute a StreamedResponse closure.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Conversation  $conversation
+     */
+    public function executeStream(
+        AIService $aiService,
+        ChatOrchestrationService $orchestrator,
+        array $history,
+        ?array $documentFilenames,
+        array $resolvedDocumentIds,
+        string $sourcePolicy,
+        bool $allowAutoRealtimeWeb,
+        bool $webSearchMode,
+        int $conversationId,
+        Conversation $conversation,
+        \App\Models\User $user,
+    ): void {
+        $fullResponse = '';
+        $streamBuffer = '';
+        $sources = [];
+
+        try {
+            foreach (
+                $aiService->sendChat(
+                    $history,
+                    $documentFilenames,
+                    (string) $user->id,
+                    $webSearchMode,
+                    $sourcePolicy,
+                    $allowAutoRealtimeWeb,
+                    $resolvedDocumentIds,
+                ) as $rawChunk
+            ) {
+                // Abort if browser disconnected
+                if (connection_aborted()) {
+                    return;
+                }
+
+                [$chunk, $streamBuffer, $parsedModelName, $parsedSources] = $orchestrator->extractStreamMetadata(
+                    (string) $rawChunk,
+                    $streamBuffer
+                );
+
+                if ($parsedModelName !== null) {
+                    $this->sendSseEvent('model-name', $parsedModelName);
+                }
+
+                if (! empty($parsedSources)) {
+                    $sources = $parsedSources;
+                    $this->sendSseEvent('sources', json_encode($sources));
+                }
+
+                $chunk = $orchestrator->sanitizeAssistantOutput((string) $chunk);
+
+                if ($chunk !== '') {
+                    $fullResponse .= $chunk;
+                    $this->sendSseEvent('chunk', $chunk);
+                }
+            }
+        } catch (\Throwable $e) {
+            Log::error('ChatStreamController: stream error', [
+                'conversation_id' => $conversationId,
+                'user_id' => $user->id,
+                'message' => $e->getMessage(),
+            ]);
+            $this->sendSseEvent('error', 'Maaf, terjadi kesalahan saat streaming jawaban.');
+            $this->sendSseEvent('done', '1');
+
+            return;
+        }
+
+        // Detect error sentinel from AIService
+        if (str_starts_with($fullResponse, AIService::ERROR_SENTINEL)) {
+            $errorContent = substr($fullResponse, strlen(AIService::ERROR_SENTINEL));
+            $errorContent = trim($errorContent) !== '' ? trim($errorContent) : 'Maaf, ISTA AI gagal merespon. Silakan coba lagi.';
+
+            $orchestrator->saveErrorMessage($conversationId, $errorContent, $user->id);
+            $conversation->touch();
+
+            $this->sendSseEvent('error', $errorContent);
+            $this->sendSseEvent('done', '1');
+
+            return;
+        }
+
+        // Build final content with sources
+        $cleanContent = $orchestrator->cleanResponseContent($fullResponse);
+
+        if (! empty($sources)) {
+            $cleanContent .= $orchestrator->sanitizeAndFormatSources($sources);
+        }
+
+        if ($cleanContent === '') {
+            $cleanContent = 'Maaf, ISTA AI belum menerima jawaban yang bisa ditampilkan. Silakan coba lagi.';
+        }
+
+        // Persist final message — idempotent: only save if no assistant message
+        // exists after the latest user message (prevents duplicate on job+stream race)
+        if (! $this->assistantMessageAlreadyExists($conversationId)) {
+            $saved = $orchestrator->saveAssistantMessage($conversationId, $cleanContent, $user->id);
+            if ($saved !== null) {
+                $conversation->touch();
+                $this->sendSseEvent('message-id', (string) $saved->id);
+            }
+        }
+
+        $this->sendSseEvent('done', '1');
+    }
+
+    /**
+     * Send a single SSE event to the browser.
+     */
+    private function sendSseEvent(string $event, string $data): void
+    {
+        // Escape newlines in data so SSE framing is not broken
+        $escaped = str_replace(["\r\n", "\r", "\n"], '\\n', $data);
+        echo "event: {$event}\n";
+        echo "data: {$escaped}\n\n";
+        flush();
+    }
+
+    /**
+     * Check whether an assistant message already exists after the latest user
+     * message in this conversation. Used to prevent duplicate persistence when
+     * both the SSE stream and the background job complete around the same time.
+     */
+    private function assistantMessageAlreadyExists(int $conversationId): bool
+    {
+        $latestUserMessage = Message::query()
+            ->where('conversation_id', $conversationId)
+            ->where('role', 'user')
+            ->latest('id')
+            ->first();
+
+        if ($latestUserMessage === null) {
+            return false;
+        }
+
+        return Message::query()
+            ->where('conversation_id', $conversationId)
+            ->where('role', 'assistant')
+            ->where('id', '>', $latestUserMessage->id)
+            ->exists();
+    }
+
+    /**
+     * Parse JSON history from query string.
+     *
+     * @return array<int, array{role: string, content: string}>
+     */
+    private function parseHistory(string $raw): array
+    {
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+            if (! is_array($decoded)) {
+                return [];
+            }
+
+            return array_values(array_filter(
+                array_map(fn ($msg) => is_array($msg) ? [
+                    'role' => (string) ($msg['role'] ?? ''),
+                    'content' => (string) ($msg['content'] ?? ''),
+                ] : null, $decoded),
+                fn ($msg) => $msg !== null && $msg['role'] !== '' && $msg['content'] !== '',
+            ));
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * Parse JSON document IDs from query string.
+     *
+     * @return array<int, int>
+     */
+    private function parseDocumentIds(string $raw): array
+    {
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+            if (! is_array($decoded)) {
+                return [];
+            }
+
+            return array_values(array_filter(
+                array_map(fn ($id) => is_numeric($id) ? (int) $id : null, $decoded),
+                fn ($id) => $id !== null && $id > 0,
+            ));
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+}

--- a/laravel/app/Jobs/GenerateChatResponse.php
+++ b/laravel/app/Jobs/GenerateChatResponse.php
@@ -65,6 +65,13 @@ class GenerateChatResponse implements ShouldQueue
             return;
         }
 
+        // Guard: jika stream sudah sukses menyimpan assistant message sebelum
+        // job retry ini berjalan, tidak perlu memanggil AI lagi. Ini mencegah
+        // double AI call pada happy path stream + job fallback.
+        if ($orchestrator->assistantAlreadyAnswered($this->conversationId)) {
+            return;
+        }
+
         $fullResponse = '';
         $streamBuffer = '';
         $sources = [];

--- a/laravel/app/Jobs/GenerateChatResponse.php
+++ b/laravel/app/Jobs/GenerateChatResponse.php
@@ -18,7 +18,7 @@ class GenerateChatResponse implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public int $tries = 5;
+    public int $tries = 10;
 
     public int $timeout = 180;
 
@@ -58,7 +58,10 @@ class GenerateChatResponse implements ShouldQueue
         // job jangan ikut menjadi runner paralel. Requeue sebagai fallback
         // tertunda agar tetap bisa recover bila stream gagal sebelum persist.
         if ($orchestrator->hasActiveStreamClaim($this->conversationId)) {
-            $this->release(5);
+            // Stream claim aktif (intent atau active) — defer 30 detik.
+            // Dengan tries=10 dan release(30), job punya ~300 detik coverage
+            // untuk menunggu claim TTL (240 detik) stale sebelum fallback jalan.
+            $this->release(30);
             return;
         }
 

--- a/laravel/app/Jobs/GenerateChatResponse.php
+++ b/laravel/app/Jobs/GenerateChatResponse.php
@@ -54,6 +54,12 @@ class GenerateChatResponse implements ShouldQueue
         $sourcePolicy = $orchestrator->getSourcePolicy($documentFilenames);
         $allowAutoRealtimeWeb = $orchestrator->shouldAllowAutoRealtimeWeb($documentFilenames);
 
+        // Jika stream sedang memegang claim untuk latest user message,
+        // job tidak boleh menjalankan AI runner paralel.
+        if ($orchestrator->hasActiveStreamClaim($this->conversationId)) {
+            return;
+        }
+
         $fullResponse = '';
         $streamBuffer = '';
         $sources = [];

--- a/laravel/app/Jobs/GenerateChatResponse.php
+++ b/laravel/app/Jobs/GenerateChatResponse.php
@@ -18,7 +18,7 @@ class GenerateChatResponse implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public int $tries = 1;
+    public int $tries = 5;
 
     public int $timeout = 180;
 
@@ -55,8 +55,10 @@ class GenerateChatResponse implements ShouldQueue
         $allowAutoRealtimeWeb = $orchestrator->shouldAllowAutoRealtimeWeb($documentFilenames);
 
         // Jika stream sedang memegang claim untuk latest user message,
-        // job tidak boleh menjalankan AI runner paralel.
+        // job jangan ikut menjadi runner paralel. Requeue sebagai fallback
+        // tertunda agar tetap bisa recover bila stream gagal sebelum persist.
         if ($orchestrator->hasActiveStreamClaim($this->conversationId)) {
+            $this->release(5);
             return;
         }
 

--- a/laravel/app/Jobs/GenerateChatResponse.php
+++ b/laravel/app/Jobs/GenerateChatResponse.php
@@ -123,6 +123,7 @@ class GenerateChatResponse implements ShouldQueue
     public function failed(?\Throwable $exception): void
     {
         Auth::loginUsingId($this->userId);
+        $orchestrator = app(ChatOrchestrationService::class);
 
         Log::error('Background chat response failed', [
             'conversation_id' => $this->conversationId,
@@ -134,17 +135,18 @@ class GenerateChatResponse implements ShouldQueue
             return;
         }
 
-        Message::create([
-            'conversation_id' => $this->conversationId,
-            'role' => 'assistant',
-            'content' => 'Maaf, jawaban gagal diproses. Silakan coba kirim ulang.',
-            'is_error' => true,
-        ]);
+        $saved = $orchestrator->saveErrorMessage(
+            $this->conversationId,
+            'Maaf, jawaban gagal diproses. Silakan coba kirim ulang.',
+            $this->userId,
+        );
 
-        Conversation::query()
-            ->whereKey($this->conversationId)
-            ->where('user_id', $this->userId)
-            ->touch();
+        if ($saved !== null) {
+            Conversation::query()
+                ->whereKey($this->conversationId)
+                ->where('user_id', $this->userId)
+                ->touch();
+        }
     }
 
     private function conversationStillExists(): bool

--- a/laravel/app/Livewire/Chat/ChatIndex.php
+++ b/laravel/app/Livewire/Chat/ChatIndex.php
@@ -625,6 +625,11 @@ class ChatIndex extends Component
         $this->loadConversations();
         $this->dispatch('conversation-activated', id: $conversationIdForRequest);
 
+        // Acquire stream claim as early as possible (right after user message is
+        // persisted) so background job fallback can observe active stream intent
+        // even before EventSource is fully connected.
+        $orchestrator->acquireStreamClaim($conversationIdForRequest);
+
         GenerateChatResponse::dispatch(
             $conversationIdForRequest,
             (int) Auth::id(),

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -316,16 +316,31 @@ class ChatOrchestrationService
                     ->lockForUpdate()
                     ->first();
 
-                // Jika sudah ada assistant message setelah user message terakhir, skip
+                // Jika sudah ada assistant message setelah user message terakhir:
+                // - jika sukses (is_error=false): skip (idempotent)
+                // - jika error (is_error=true): upgrade menjadi jawaban sukses
                 if ($latestUserMessage !== null) {
-                    $alreadyExists = \App\Models\Message::query()
+                    $latestAssistant = \App\Models\Message::query()
                         ->where('conversation_id', $conversationId)
                         ->where('role', 'assistant')
                         ->where('id', '>', $latestUserMessage->id)
-                        ->exists();
+                        ->latest('id')
+                        ->lockForUpdate()
+                        ->first();
 
-                    if ($alreadyExists) {
-                        return null;
+                    if ($latestAssistant !== null) {
+                        if ((bool) $latestAssistant->is_error === false) {
+                            return null;
+                        }
+
+                        // Recovery path: stream error duluan lalu job sukses belakangan.
+                        // Reuse row error yang ada agar tetap satu assistant message.
+                        $latestAssistant->forceFill([
+                            'content' => $content,
+                            'is_error' => false,
+                        ])->save();
+
+                        return $latestAssistant->fresh();
                     }
                 }
 
@@ -360,13 +375,17 @@ class ChatOrchestrationService
                     ->first();
 
                 if ($latestUserMessage !== null) {
-                    $alreadyExists = \App\Models\Message::query()
+                    $latestAssistant = \App\Models\Message::query()
                         ->where('conversation_id', $conversationId)
                         ->where('role', 'assistant')
                         ->where('id', '>', $latestUserMessage->id)
-                        ->exists();
+                        ->latest('id')
+                        ->lockForUpdate()
+                        ->first();
 
-                    if ($alreadyExists) {
+                    // Jika sudah ada jawaban sukses, jangan ditimpa error.
+                    // Jika sudah ada error, tetap idempotent (skip).
+                    if ($latestAssistant !== null) {
                         return null;
                     }
                 }

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -314,6 +314,20 @@ class ChatOrchestrationService
         return sprintf('chat:stream-claim:conversation:%d:user-message:%d', $conversationId, (int) $latestUserMessage->id);
     }
 
+    /**
+     * Acquire or adopt a stream claim for the latest user message.
+     *
+     * Two-state claim lifecycle:
+     *   - 'intent'  : created by sendMessage() before EventSource opens.
+     *                 Signals to the fallback job that a stream is expected.
+     *   - 'active'  : upgraded by executeStream() when it adopts the intent.
+     *                 Duplicate streams that see 'active' are rejected.
+     *
+     * sendMessage() always calls this to create an 'intent' claim.
+     * executeStream() calls this to adopt 'intent' → 'active', or create
+     * 'active' directly if no prior intent exists.
+     * If the claim is already 'active' (duplicate stream), returns null.
+     */
     public function acquireStreamClaim(int $conversationId): ?string
     {
         $claimKey = $this->streamClaimKeyForLatestUserMessage($conversationId);
@@ -321,13 +335,22 @@ class ChatOrchestrationService
             return null;
         }
 
-        if (Cache::has($claimKey)) {
+        $current = Cache::get($claimKey);
+
+        if ($current === null) {
+            // No claim yet — create intent (sendMessage path) or active (direct stream).
+            Cache::add($claimKey, 'intent', now()->addSeconds(self::STREAM_CLAIM_TTL_SECONDS));
             return $claimKey;
         }
 
-        Cache::add($claimKey, 'stream', now()->addSeconds(self::STREAM_CLAIM_TTL_SECONDS));
+        if ($current === 'intent') {
+            // Adopt intent → upgrade to active (stream runner path).
+            Cache::put($claimKey, 'active', now()->addSeconds(self::STREAM_CLAIM_TTL_SECONDS));
+            return $claimKey;
+        }
 
-        return $claimKey;
+        // Already 'active' — duplicate stream, reject.
+        return null;
     }
 
     public function releaseStreamClaim(?string $claimKey): void
@@ -339,10 +362,19 @@ class ChatOrchestrationService
         Cache::forget($claimKey);
     }
 
+    /**
+     * Returns true if a stream claim (intent or active) exists for the latest
+     * user message. The fallback job defers in both states.
+     */
     public function hasActiveStreamClaim(int $conversationId): bool
     {
         $claimKey = $this->streamClaimKeyForLatestUserMessage($conversationId);
-        return $claimKey !== null && Cache::has($claimKey);
+        if ($claimKey === null) {
+            return false;
+        }
+
+        $value = Cache::get($claimKey);
+        return $value === 'intent' || $value === 'active';
     }
 
     public function saveAssistantMessage(int $conversationId, string $content, int $userId): ?Message

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -277,7 +277,33 @@ class ChatOrchestrationService
         }
 
         try {
-            return $this->createAssistantMessage($conversationId, $content);
+            // Idempotensi: gunakan DB transaction + lockForUpdate pada user message
+            // terakhir agar baik SSE stream maupun background job tidak bisa
+            // menyimpan dua assistant message untuk satu user message yang sama.
+            // Ini adalah single source of truth untuk race condition di kedua jalur.
+            return \Illuminate\Support\Facades\DB::transaction(function () use ($conversationId, $content) {
+                $latestUserMessage = \App\Models\Message::query()
+                    ->where('conversation_id', $conversationId)
+                    ->where('role', 'user')
+                    ->latest('id')
+                    ->lockForUpdate()
+                    ->first();
+
+                // Jika sudah ada assistant message setelah user message terakhir, skip
+                if ($latestUserMessage !== null) {
+                    $alreadyExists = \App\Models\Message::query()
+                        ->where('conversation_id', $conversationId)
+                        ->where('role', 'assistant')
+                        ->where('id', '>', $latestUserMessage->id)
+                        ->exists();
+
+                    if ($alreadyExists) {
+                        return null;
+                    }
+                }
+
+                return $this->createAssistantMessage($conversationId, $content);
+            });
         } catch (QueryException $e) {
             if ($this->isConversationFkViolation($e)) {
                 return null;

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -7,10 +7,12 @@ use App\Models\Message;
 use App\Models\Document;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Auth;
 
 class ChatOrchestrationService
 {
+    private const STREAM_CLAIM_TTL_SECONDS = 240;
     private const SANITIZE_REPLACEMENTS = [
         '/\bchunks?\b/i' => 'bagian dokumen',
         '/\bchunk(?:ing|ed)?\b/i' => 'bagian dokumen',
@@ -295,6 +297,47 @@ class ChatOrchestrationService
             ->where('role', 'assistant')
             ->where('id', '>', $latestUserMessage->id)
             ->exists();
+    }
+
+    public function streamClaimKeyForLatestUserMessage(int $conversationId): ?string
+    {
+        $latestUserMessage = Message::query()
+            ->where('conversation_id', $conversationId)
+            ->where('role', 'user')
+            ->latest('id')
+            ->first();
+
+        if ($latestUserMessage === null) {
+            return null;
+        }
+
+        return sprintf('chat:stream-claim:conversation:%d:user-message:%d', $conversationId, (int) $latestUserMessage->id);
+    }
+
+    public function acquireStreamClaim(int $conversationId): ?string
+    {
+        $claimKey = $this->streamClaimKeyForLatestUserMessage($conversationId);
+        if ($claimKey === null) {
+            return null;
+        }
+
+        $acquired = Cache::add($claimKey, 'stream', now()->addSeconds(self::STREAM_CLAIM_TTL_SECONDS));
+        return $acquired ? $claimKey : null;
+    }
+
+    public function releaseStreamClaim(?string $claimKey): void
+    {
+        if ($claimKey === null) {
+            return;
+        }
+
+        Cache::forget($claimKey);
+    }
+
+    public function hasActiveStreamClaim(int $conversationId): bool
+    {
+        $claimKey = $this->streamClaimKeyForLatestUserMessage($conversationId);
+        return $claimKey !== null && Cache::has($claimKey);
     }
 
     public function saveAssistantMessage(int $conversationId, string $content, int $userId): ?Message

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -321,8 +321,13 @@ class ChatOrchestrationService
             return null;
         }
 
-        $acquired = Cache::add($claimKey, 'stream', now()->addSeconds(self::STREAM_CLAIM_TTL_SECONDS));
-        return $acquired ? $claimKey : null;
+        if (Cache::has($claimKey)) {
+            return $claimKey;
+        }
+
+        Cache::add($claimKey, 'stream', now()->addSeconds(self::STREAM_CLAIM_TTL_SECONDS));
+
+        return $claimKey;
     }
 
     public function releaseStreamClaim(?string $claimKey): void

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -270,6 +270,33 @@ class ChatOrchestrationService
         return trim($cleanContent);
     }
 
+    /**
+     * Check whether an assistant message (normal or error) already exists after
+     * the latest user message in this conversation.
+     *
+     * Used by ChatStreamController as a single-runner claim: if the background
+     * job already answered, the stream should skip calling AI entirely to avoid
+     * sending different chunks to the UI than what ends up in the DB.
+     */
+    public function assistantAlreadyAnswered(int $conversationId): bool
+    {
+        $latestUserMessage = Message::query()
+            ->where('conversation_id', $conversationId)
+            ->where('role', 'user')
+            ->latest('id')
+            ->first();
+
+        if ($latestUserMessage === null) {
+            return false;
+        }
+
+        return Message::query()
+            ->where('conversation_id', $conversationId)
+            ->where('role', 'assistant')
+            ->where('id', '>', $latestUserMessage->id)
+            ->exists();
+    }
+
     public function saveAssistantMessage(int $conversationId, string $content, int $userId): ?Message
     {
         if (! $this->conversationExists($conversationId, $userId)) {
@@ -320,12 +347,37 @@ class ChatOrchestrationService
         }
 
         try {
-            return Message::create([
-                'conversation_id' => $conversationId,
-                'role' => 'assistant',
-                'content' => $content,
-                'is_error' => true,
-            ]);
+            // Idempotensi: gunakan DB transaction + lockForUpdate agar error message
+            // tidak duplikat jika stream dan job keduanya gagal bersamaan.
+            // Jika sudah ada assistant message (normal atau error) setelah user message
+            // terakhir, skip — ini mencegah error stream menimpa jawaban sukses dari job.
+            return \Illuminate\Support\Facades\DB::transaction(function () use ($conversationId, $content) {
+                $latestUserMessage = \App\Models\Message::query()
+                    ->where('conversation_id', $conversationId)
+                    ->where('role', 'user')
+                    ->latest('id')
+                    ->lockForUpdate()
+                    ->first();
+
+                if ($latestUserMessage !== null) {
+                    $alreadyExists = \App\Models\Message::query()
+                        ->where('conversation_id', $conversationId)
+                        ->where('role', 'assistant')
+                        ->where('id', '>', $latestUserMessage->id)
+                        ->exists();
+
+                    if ($alreadyExists) {
+                        return null;
+                    }
+                }
+
+                return Message::create([
+                    'conversation_id' => $conversationId,
+                    'role' => 'assistant',
+                    'content' => $content,
+                    'is_error' => true,
+                ]);
+            });
         } catch (QueryException $e) {
             if ($this->isConversationFkViolation($e)) {
                 return null;

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -311,6 +311,8 @@ const registerChatPageData = (Alpine) => {
         chatMutationObserver: null,
         wireListeners: [],
         windowListeners: [],
+        activeEventSource: null,
+        _chatStreamHandler: null,
 
         getConversationMeta() {
             const metaEl = this.$el.querySelector('[data-chat-conversation-id]');
@@ -452,6 +454,19 @@ const registerChatPageData = (Alpine) => {
                 this.scrollToBottom();
             });
 
+            this._chatStreamHandler = (event) => {
+                const detail = event?.detail || {};
+                const conversationId = Number(detail.conversationId || 0);
+                const history = detail.history || [];
+                const documentIds = detail.documentIds || [];
+                const webSearchMode = Boolean(detail.webSearchMode);
+                const loadingContext = detail.loadingContext || 'general';
+                if (conversationId > 0) {
+                    this.openChatStream(conversationId, history, documentIds, webSearchMode, loadingContext);
+                }
+            };
+            window.addEventListener('chat-open-stream', this._chatStreamHandler);
+
             this.$nextTick(() => this.maybeRestorePendingPlaceholder());
         },
 
@@ -467,10 +482,87 @@ const registerChatPageData = (Alpine) => {
             this.windowListeners.push(() => window.removeEventListener(event, callback));
         },
 
+        closeChatStream() {
+            if (this.activeEventSource) {
+                this.activeEventSource.close();
+                this.activeEventSource = null;
+            }
+        },
+
+        openChatStream(conversationId, history, documentIds, webSearchMode, loadingContext) {
+            this.closeChatStream();
+
+            const params = new URLSearchParams({
+                history: JSON.stringify(history),
+                document_ids: JSON.stringify(documentIds),
+                web_search_mode: webSearchMode ? '1' : '0',
+            });
+
+            const url = `/chat/stream/${conversationId}?${params.toString()}`;
+            const es = new EventSource(url);
+            this.activeEventSource = es;
+
+            es.addEventListener('chunk', (e) => {
+                // Unescape newlines encoded by server
+                const text = (e.data || '').replace(/\\n/g, '\n');
+                this.streamingText += text;
+                this.streaming = true;
+                this.hasFirstAssistantChunk = true;
+                this.scrollToBottom();
+
+                if (this.phase2Done) {
+                    this.loadingPhase = 'Menampilkan jawaban';
+                    this.loadingPhaseKey++;
+                    this.shimmerActive = false;
+                }
+            });
+
+            es.addEventListener('model-name', (e) => {
+                this.modelName = (e.data || '').replace(/\\n/g, '\n');
+            });
+
+            es.addEventListener('sources', (e) => {
+                try {
+                    const parsed = JSON.parse((e.data || '').replace(/\\n/g, '\n'));
+                    if (Array.isArray(parsed)) {
+                        this.sources = parsed;
+                    }
+                } catch (_) {
+                    // ignore malformed sources
+                }
+            });
+
+            es.addEventListener('error', (e) => {
+                const msg = (e.data || '').replace(/\\n/g, '\n');
+                if (msg) {
+                    this.stalePendingWarning = msg;
+                }
+                this.closeChatStream();
+                // Polling will recover the final state from DB
+            });
+
+            es.addEventListener('done', () => {
+                this.closeChatStream();
+                // Trigger wire refresh so Livewire loads the persisted message
+                if (this.$wire && typeof this.$wire.refreshPendingChatState === 'function') {
+                    this.$wire.refreshPendingChatState();
+                }
+            });
+
+            es.onerror = () => {
+                this.closeChatStream();
+            };
+        },
+
         destroy() {
             this.clearLoadingPhaseTimeout();
             this.clearPhase2Timeout();
             this.clearPendingStaleTimeout();
+            this.closeChatStream();
+            if (this._chatStreamHandler) {
+                window.removeEventListener('chat-open-stream', this._chatStreamHandler);
+                this._chatStreamHandler = null;
+            }
             if (this._messageCompleteHandler) {
                 window.removeEventListener('message-complete', this._messageCompleteHandler);
                 this._messageCompleteHandler = null;
@@ -1848,6 +1940,23 @@ const registerChatPageData = (Alpine) => {
                             messageId: response?.messageId || null,
                         },
                     }));
+
+                    // Open SSE stream to receive live chunks from Python AI
+                    if (conversationId > 0) {
+                        const history = (this.$wire.messages || []).map((m) => ({
+                            role: m.role || '',
+                            content: m.content || '',
+                        }));
+                        window.dispatchEvent(new CustomEvent('chat-open-stream', {
+                            detail: {
+                                conversationId,
+                                history,
+                                documentIds: normalizedDocs,
+                                webSearchMode: Boolean(this.webSearchMode),
+                                loadingContext,
+                            },
+                        }));
+                    }
                 })
                 .catch(() => {
                     this.$dispatch('user-message-acked');

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -457,12 +457,11 @@ const registerChatPageData = (Alpine) => {
             this._chatStreamHandler = (event) => {
                 const detail = event?.detail || {};
                 const conversationId = Number(detail.conversationId || 0);
-                const history = detail.history || [];
                 const documentIds = detail.documentIds || [];
                 const webSearchMode = Boolean(detail.webSearchMode);
                 const loadingContext = detail.loadingContext || 'general';
                 if (conversationId > 0) {
-                    this.openChatStream(conversationId, history, documentIds, webSearchMode, loadingContext);
+                    this.openChatStream(conversationId, documentIds, webSearchMode, loadingContext);
                 }
             };
             window.addEventListener('chat-open-stream', this._chatStreamHandler);
@@ -489,11 +488,12 @@ const registerChatPageData = (Alpine) => {
             }
         },
 
-        openChatStream(conversationId, history, documentIds, webSearchMode, loadingContext) {
+        openChatStream(conversationId, documentIds, webSearchMode, loadingContext) {
             this.closeChatStream();
 
+            // History tidak dikirim via query string — server reconstruct dari DB
+            // untuk menghindari URL terlalu panjang (414) dan konten chat bocor ke log.
             const params = new URLSearchParams({
-                history: JSON.stringify(history),
                 document_ids: JSON.stringify(documentIds),
                 web_search_mode: webSearchMode ? '1' : '0',
             });
@@ -503,8 +503,8 @@ const registerChatPageData = (Alpine) => {
             this.activeEventSource = es;
 
             es.addEventListener('chunk', (e) => {
-                // Unescape newlines encoded by server
-                const text = (e.data || '').replace(/\\n/g, '\n');
+                // Server menggunakan multi-line SSE framing — browser otomatis join dengan \n
+                const text = e.data || '';
                 this.streamingText += text;
                 this.streaming = true;
                 this.hasFirstAssistantChunk = true;
@@ -518,12 +518,12 @@ const registerChatPageData = (Alpine) => {
             });
 
             es.addEventListener('model-name', (e) => {
-                this.modelName = (e.data || '').replace(/\\n/g, '\n');
+                this.modelName = e.data || '';
             });
 
             es.addEventListener('sources', (e) => {
                 try {
-                    const parsed = JSON.parse((e.data || '').replace(/\\n/g, '\n'));
+                    const parsed = JSON.parse(e.data || '');
                     if (Array.isArray(parsed)) {
                         this.sources = parsed;
                     }
@@ -533,7 +533,7 @@ const registerChatPageData = (Alpine) => {
             });
 
             es.addEventListener('error', (e) => {
-                const msg = (e.data || '').replace(/\\n/g, '\n');
+                const msg = e.data || '';
                 if (msg) {
                     this.stalePendingWarning = msg;
                 }
@@ -1941,16 +1941,12 @@ const registerChatPageData = (Alpine) => {
                         },
                     }));
 
-                    // Open SSE stream to receive live chunks from Python AI
+                    // Open SSE stream to receive live chunks from Python AI.
+                    // History tidak dikirim — server reconstruct dari DB.
                     if (conversationId > 0) {
-                        const history = (this.$wire.messages || []).map((m) => ({
-                            role: m.role || '',
-                            content: m.content || '',
-                        }));
                         window.dispatchEvent(new CustomEvent('chat-open-stream', {
                             detail: {
                                 conversationId,
-                                history,
                                 documentIds: normalizedDocs,
                                 webSearchMode: Boolean(this.webSearchMode),
                                 loadingContext,

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Chat\ChatStreamController;
 use App\Http\Controllers\CloudStorage\GoogleDriveOAuthController;
 use App\Http\Controllers\Documents\DocumentExportController;
 use App\Http\Controllers\Documents\DocumentPreviewController;
@@ -35,6 +36,11 @@ Route::get('chat/{id?}', ChatIndex::class)
     ->middleware(['auth', 'verified', 'throttle:30,1'])
     ->whereNumber('id')
     ->name('chat');
+
+Route::get('chat/stream/{conversationId}', [ChatStreamController::class, 'stream'])
+    ->middleware(['auth', 'verified', 'throttle:60,1'])
+    ->whereNumber('conversationId')
+    ->name('chat.stream');
 
 Route::post('onlyoffice/callback/{memo}', OnlyOfficeCallbackController::class)
     ->name('onlyoffice.callback');

--- a/laravel/tests/Feature/Chat/ChatStreamTest.php
+++ b/laravel/tests/Feature/Chat/ChatStreamTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Chat;
 
 use App\Http\Controllers\Chat\ChatStreamController;
+use App\Jobs\GenerateChatResponse;
 use App\Models\Conversation;
 use App\Models\Document;
 use App\Models\Message;
@@ -68,6 +69,12 @@ class ChatStreamTest extends TestCase
             'title' => 'Header test',
         ]);
 
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Halo',
+        ]);
+
         $this->app->bind(AIService::class, fn () => new class extends AIService
         {
             public function sendChat(
@@ -83,10 +90,8 @@ class ChatStreamTest extends TestCase
             }
         });
 
-        $history = json_encode([['role' => 'user', 'content' => 'Halo']]);
-
         $response = $this->actingAs($user)
-            ->get(route('chat.stream', ['conversationId' => $conversation->id]).'?history='.urlencode($history));
+            ->get(route('chat.stream', ['conversationId' => $conversation->id]));
 
         $response->assertOk();
         $this->assertStringContainsString('text/event-stream', $response->headers->get('Content-Type'));
@@ -98,6 +103,12 @@ class ChatStreamTest extends TestCase
         $conversation = Conversation::create([
             'user_id' => $user->id,
             'title' => 'Streaming test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Halo',
         ]);
 
         $this->app->bind(AIService::class, fn () => new class extends AIService
@@ -116,14 +127,65 @@ class ChatStreamTest extends TestCase
             }
         });
 
-        $body = $this->runExecuteStream($user, $conversation, [
-            ['role' => 'user', 'content' => 'Halo'],
-        ]);
+        $body = $this->runExecuteStream($user, $conversation);
 
         $this->assertStringContainsString('event: chunk', $body);
         $this->assertStringContainsString('Halo ', $body);
         $this->assertStringContainsString('dunia!', $body);
         $this->assertStringContainsString('event: done', $body);
+    }
+
+    // -------------------------------------------------------------------------
+    // History reconstructed from DB
+    // -------------------------------------------------------------------------
+
+    public function test_stream_uses_history_from_db_not_query_string(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'History from DB test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan dari DB',
+        ]);
+
+        $capturedMessages = null;
+
+        $this->app->bind(AIService::class, function () use (&$capturedMessages) {
+            return new class($capturedMessages) extends AIService
+            {
+                public function __construct(private mixed &$captured)
+                {
+                    parent::__construct();
+                }
+
+                public function sendChat(
+                    array $messages,
+                    ?array $document_filenames = null,
+                    ?string $user_id = null,
+                    bool $force_web_search = false,
+                    ?string $source_policy = null,
+                    bool $allow_auto_realtime_web = true,
+                    ?array $document_ids = null,
+                ): \Generator {
+                    $this->captured = $messages;
+                    yield 'OK';
+                }
+            };
+        });
+
+        $this->runExecuteStream($user, $conversation);
+
+        // History harus berisi pesan dari DB
+        $this->assertNotNull($capturedMessages);
+        $this->assertNotEmpty($capturedMessages);
+        $lastMsg = end($capturedMessages);
+        $this->assertSame('user', $lastMsg['role']);
+        $this->assertSame('Pertanyaan dari DB', $lastMsg['content']);
     }
 
     // -------------------------------------------------------------------------
@@ -136,6 +198,12 @@ class ChatStreamTest extends TestCase
         $conversation = Conversation::create([
             'user_id' => $user->id,
             'title' => 'Persistence test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan',
         ]);
 
         $this->app->bind(AIService::class, fn () => new class extends AIService
@@ -153,9 +221,7 @@ class ChatStreamTest extends TestCase
             }
         });
 
-        $this->runExecuteStream($user, $conversation, [
-            ['role' => 'user', 'content' => 'Pertanyaan'],
-        ]);
+        $this->runExecuteStream($user, $conversation);
 
         $this->assertDatabaseHas('messages', [
             'conversation_id' => $conversation->id,
@@ -165,7 +231,7 @@ class ChatStreamTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
-    // Idempotency
+    // Idempotency — job selesai duluan, stream datang belakangan
     // -------------------------------------------------------------------------
 
     public function test_stream_does_not_duplicate_message_if_assistant_already_exists(): void
@@ -204,9 +270,7 @@ class ChatStreamTest extends TestCase
             }
         });
 
-        $this->runExecuteStream($user, $conversation, [
-            ['role' => 'user', 'content' => 'Pertanyaan'],
-        ]);
+        $this->runExecuteStream($user, $conversation);
 
         // Only one assistant message should exist
         $assistantCount = Message::where('conversation_id', $conversation->id)
@@ -214,6 +278,171 @@ class ChatStreamTest extends TestCase
             ->count();
 
         $this->assertSame(1, $assistantCount, 'Tidak boleh ada duplikat assistant message');
+    }
+
+    // -------------------------------------------------------------------------
+    // Race condition: stream selesai duluan, job berjalan belakangan
+    // -------------------------------------------------------------------------
+
+    public function test_race_stream_first_then_job_produces_single_assistant_message(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Race test: stream first',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan race',
+        ]);
+
+        // Step 1: Stream selesai duluan dan menyimpan assistant message
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(
+                array $messages,
+                ?array $document_filenames = null,
+                ?string $user_id = null,
+                bool $force_web_search = false,
+                ?string $source_policy = null,
+                bool $allow_auto_realtime_web = true,
+                ?array $document_ids = null,
+            ): \Generator {
+                yield 'Jawaban dari stream.';
+            }
+        });
+
+        $this->runExecuteStream($user, $conversation);
+
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban dari stream.',
+        ]);
+
+        // Step 2: Job berjalan belakangan — harus skip karena stream sudah simpan
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(
+                array $messages,
+                ?array $document_filenames = null,
+                ?string $user_id = null,
+                bool $force_web_search = false,
+                ?string $source_policy = null,
+                bool $allow_auto_realtime_web = true,
+                ?array $document_ids = null,
+            ): \Generator {
+                yield 'Jawaban dari job (seharusnya tidak tersimpan).';
+            }
+        });
+
+        $job = new GenerateChatResponse(
+            conversationId: (int) $conversation->id,
+            userId: (int) $user->id,
+            history: [['role' => 'user', 'content' => 'Pertanyaan race']],
+        );
+        $job->handle(app(AIService::class), new ChatOrchestrationService);
+
+        // Hanya satu assistant message yang boleh ada
+        $assistantCount = Message::where('conversation_id', $conversation->id)
+            ->where('role', 'assistant')
+            ->count();
+
+        $this->assertSame(1, $assistantCount, 'Race: stream selesai duluan, job tidak boleh duplikat');
+
+        // Konten yang tersimpan harus dari stream, bukan job
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban dari stream.',
+        ]);
+        $this->assertDatabaseMissing('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban dari job (seharusnya tidak tersimpan).',
+        ]);
+    }
+
+    public function test_race_job_first_then_stream_produces_single_assistant_message(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Race test: job first',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan race job first',
+        ]);
+
+        // Step 1: Job selesai duluan
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(
+                array $messages,
+                ?array $document_filenames = null,
+                ?string $user_id = null,
+                bool $force_web_search = false,
+                ?string $source_policy = null,
+                bool $allow_auto_realtime_web = true,
+                ?array $document_ids = null,
+            ): \Generator {
+                yield 'Jawaban dari job.';
+            }
+        });
+
+        $job = new GenerateChatResponse(
+            conversationId: (int) $conversation->id,
+            userId: (int) $user->id,
+            history: [['role' => 'user', 'content' => 'Pertanyaan race job first']],
+        );
+        $job->handle(app(AIService::class), new ChatOrchestrationService);
+
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban dari job.',
+        ]);
+
+        // Step 2: Stream selesai belakangan — harus skip karena job sudah simpan
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(
+                array $messages,
+                ?array $document_filenames = null,
+                ?string $user_id = null,
+                bool $force_web_search = false,
+                ?string $source_policy = null,
+                bool $allow_auto_realtime_web = true,
+                ?array $document_ids = null,
+            ): \Generator {
+                yield 'Jawaban dari stream (seharusnya tidak tersimpan).';
+            }
+        });
+
+        $this->runExecuteStream($user, $conversation);
+
+        // Hanya satu assistant message yang boleh ada
+        $assistantCount = Message::where('conversation_id', $conversation->id)
+            ->where('role', 'assistant')
+            ->count();
+
+        $this->assertSame(1, $assistantCount, 'Race: job selesai duluan, stream tidak boleh duplikat');
+
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban dari job.',
+        ]);
+        $this->assertDatabaseMissing('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban dari stream (seharusnya tidak tersimpan).',
+        ]);
     }
 
     // -------------------------------------------------------------------------
@@ -226,6 +455,12 @@ class ChatStreamTest extends TestCase
         $conversation = Conversation::create([
             'user_id' => $user->id,
             'title' => 'Error sentinel test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan',
         ]);
 
         $this->app->bind(AIService::class, fn () => new class extends AIService
@@ -243,9 +478,7 @@ class ChatStreamTest extends TestCase
             }
         });
 
-        $body = $this->runExecuteStream($user, $conversation, [
-            ['role' => 'user', 'content' => 'Pertanyaan'],
-        ]);
+        $body = $this->runExecuteStream($user, $conversation);
 
         $this->assertStringContainsString('event: error', $body);
 
@@ -268,6 +501,12 @@ class ChatStreamTest extends TestCase
         $conversation = Conversation::create([
             'user_id' => $user->id,
             'title' => 'Document filter test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Halo',
         ]);
 
         $readyDoc = Document::create([
@@ -324,6 +563,7 @@ class ChatStreamTest extends TestCase
         $docContext = $orchestrator->getActiveDocumentContext([$readyDoc->id, $foreignDoc->id]);
 
         $controller = app(ChatStreamController::class);
+        ob_start();
         $controller->executeStream(
             app(AIService::class),
             $orchestrator,
@@ -337,6 +577,7 @@ class ChatStreamTest extends TestCase
             $conversation,
             $user,
         );
+        ob_get_clean();
 
         $this->assertNotNull($captured->documentIds);
         $this->assertContains($readyDoc->id, $captured->documentIds);
@@ -356,6 +597,12 @@ class ChatStreamTest extends TestCase
             'title' => 'Message ID event test',
         ]);
 
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan',
+        ]);
+
         $this->app->bind(AIService::class, fn () => new class extends AIService
         {
             public function sendChat(
@@ -371,9 +618,7 @@ class ChatStreamTest extends TestCase
             }
         });
 
-        $body = $this->runExecuteStream($user, $conversation, [
-            ['role' => 'user', 'content' => 'Pertanyaan'],
-        ]);
+        $body = $this->runExecuteStream($user, $conversation);
 
         $this->assertStringContainsString('event: message-id', $body);
     }
@@ -384,15 +629,13 @@ class ChatStreamTest extends TestCase
 
     /**
      * Call executeStream() directly and capture its echo output.
-     * This avoids the PHPUnit "risky" warning caused by StreamedResponse closures.
+     * History is reconstructed from DB messages (no query string).
      *
-     * @param  array<int, array{role: string, content: string}>  $history
      * @param  array<int, int>  $documentIds
      */
     private function runExecuteStream(
         User $user,
         Conversation $conversation,
-        array $history,
         array $documentIds = [],
         bool $webSearchMode = false,
     ): string {
@@ -400,6 +643,15 @@ class ChatStreamTest extends TestCase
 
         $orchestrator = app(ChatOrchestrationService::class);
         $docContext = $orchestrator->getActiveDocumentContext($documentIds);
+
+        // Reconstruct history from DB (same as controller does)
+        $dbMessages = \App\Models\Message::query()
+            ->where('conversation_id', $conversation->id)
+            ->orderBy('id', 'asc')
+            ->get(['role', 'content'])
+            ->map(fn ($m) => ['role' => (string) $m->role, 'content' => (string) $m->content])
+            ->all();
+        $history = $orchestrator->buildHistory($dbMessages);
 
         $controller = app(ChatStreamController::class);
 

--- a/laravel/tests/Feature/Chat/ChatStreamTest.php
+++ b/laravel/tests/Feature/Chat/ChatStreamTest.php
@@ -624,6 +624,143 @@ class ChatStreamTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // Single-runner claim: stream skip AI jika job sudah selesai duluan
+    // -------------------------------------------------------------------------
+
+    public function test_stream_skips_ai_call_if_job_already_answered(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Single-runner claim test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan',
+        ]);
+
+        // Job sudah menyimpan assistant message sebelum stream dimulai
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban dari job.',
+        ]);
+
+        $aiCalled = false;
+        $this->app->bind(AIService::class, function () use (&$aiCalled) {
+            return new class($aiCalled) extends AIService
+            {
+                public function __construct(private bool &$called)
+                {
+                    parent::__construct();
+                }
+
+                public function sendChat(
+                    array $messages,
+                    ?array $document_filenames = null,
+                    ?string $user_id = null,
+                    bool $force_web_search = false,
+                    ?string $source_policy = null,
+                    bool $allow_auto_realtime_web = true,
+                    ?array $document_ids = null,
+                ): \Generator {
+                    $this->called = true;
+                    yield 'Chunk yang tidak boleh dikirim.';
+                }
+            };
+        });
+
+        $body = $this->runExecuteStream($user, $conversation);
+
+        // AI tidak boleh dipanggil sama sekali
+        $this->assertFalse($aiCalled, 'Stream tidak boleh memanggil AI jika job sudah menjawab');
+
+        // Stream harus langsung kirim done tanpa chunk
+        $this->assertStringContainsString('event: done', $body);
+        $this->assertStringNotContainsString('event: chunk', $body);
+
+        // Hanya satu assistant message
+        $this->assertSame(1, Message::where('conversation_id', $conversation->id)
+            ->where('role', 'assistant')->count());
+    }
+
+    // -------------------------------------------------------------------------
+    // Error recovery: stream error tidak menimpa jawaban sukses dari job
+    // -------------------------------------------------------------------------
+
+    public function test_stream_error_does_not_overwrite_successful_job_answer(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Error recovery test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan',
+        ]);
+
+        // Job sudah menyimpan jawaban sukses
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban sukses dari job.',
+            'is_error' => false,
+        ]);
+
+        // Stream error — saveErrorMessage harus skip karena job sudah simpan
+        $orchestrator = app(ChatOrchestrationService::class);
+        $this->actingAs($user);
+        $result = $orchestrator->saveErrorMessage($conversation->id, 'Error dari stream.', $user->id);
+
+        $this->assertNull($result, 'saveErrorMessage harus skip jika job sudah menyimpan jawaban');
+
+        // Hanya satu assistant message (jawaban sukses dari job)
+        $this->assertSame(1, Message::where('conversation_id', $conversation->id)
+            ->where('role', 'assistant')->count());
+
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban sukses dari job.',
+            'is_error' => false,
+        ]);
+    }
+
+    public function test_save_error_message_is_idempotent_when_called_twice(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Error idempotency test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan',
+        ]);
+
+        $orchestrator = app(ChatOrchestrationService::class);
+        $this->actingAs($user);
+
+        // Panggil saveErrorMessage dua kali (stream dan job keduanya error)
+        $first = $orchestrator->saveErrorMessage($conversation->id, 'Error pertama.', $user->id);
+        $second = $orchestrator->saveErrorMessage($conversation->id, 'Error kedua.', $user->id);
+
+        $this->assertNotNull($first, 'Panggilan pertama harus berhasil menyimpan');
+        $this->assertNull($second, 'Panggilan kedua harus skip (idempotensi)');
+
+        // Hanya satu error message
+        $this->assertSame(1, Message::where('conversation_id', $conversation->id)
+            ->where('role', 'assistant')->count());
+    }
+
+    // -------------------------------------------------------------------------
     // Helper
     // -------------------------------------------------------------------------
 

--- a/laravel/tests/Feature/Chat/ChatStreamTest.php
+++ b/laravel/tests/Feature/Chat/ChatStreamTest.php
@@ -857,6 +857,66 @@ class ChatStreamTest extends TestCase
         $orchestrator->releaseStreamClaim($claimKey);
     }
 
+    public function test_job_skips_ai_when_stream_already_persisted_answer(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Job skip after stream persisted',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan stream sudah jawab',
+        ]);
+
+        // Simulate stream already persisted assistant message
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban dari stream.',
+        ]);
+
+        $aiCalled = false;
+        $this->app->bind(AIService::class, function () use (&$aiCalled) {
+            return new class($aiCalled) extends AIService
+            {
+                public function __construct(private bool &$called)
+                {
+                    parent::__construct();
+                }
+
+                public function sendChat(
+                    array $messages,
+                    ?array $document_filenames = null,
+                    ?string $user_id = null,
+                    bool $force_web_search = false,
+                    ?string $source_policy = null,
+                    bool $allow_auto_realtime_web = true,
+                    ?array $document_ids = null,
+                ): \Generator {
+                    $this->called = true;
+                    yield 'Tidak boleh dipanggil karena stream sudah jawab';
+                }
+            };
+        });
+
+        $this->actingAs($user);
+        $job = new GenerateChatResponse(
+            conversationId: (int) $conversation->id,
+            userId: (int) $user->id,
+            history: [['role' => 'user', 'content' => 'Pertanyaan stream sudah jawab']],
+        );
+        $job->handle(app(AIService::class), app(ChatOrchestrationService::class));
+
+        $this->assertFalse($aiCalled, 'Job tidak boleh memanggil AI jika stream sudah menyimpan jawaban');
+        $this->assertSame(1, Message::query()
+            ->where('conversation_id', $conversation->id)
+            ->where('role', 'assistant')
+            ->count(), 'Harus tetap satu assistant message');
+    }
+
     public function test_execute_stream_acquires_claim_before_ai_call(): void
     {
         $user = User::factory()->create();

--- a/laravel/tests/Feature/Chat/ChatStreamTest.php
+++ b/laravel/tests/Feature/Chat/ChatStreamTest.php
@@ -799,6 +799,64 @@ class ChatStreamTest extends TestCase
         $this->assertSame('Jawaban sukses dari job.', $assistantMessages->first()->content);
     }
 
+    public function test_job_skips_ai_when_stream_claim_is_active(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Mid-stream claim test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan mid-stream',
+        ]);
+
+        $orchestrator = app(ChatOrchestrationService::class);
+        $claimKey = $orchestrator->acquireStreamClaim($conversation->id);
+        $this->assertNotNull($claimKey);
+
+        $aiCalled = false;
+        $this->app->bind(AIService::class, function () use (&$aiCalled) {
+            return new class($aiCalled) extends AIService
+            {
+                public function __construct(private bool &$called)
+                {
+                    parent::__construct();
+                }
+
+                public function sendChat(
+                    array $messages,
+                    ?array $document_filenames = null,
+                    ?string $user_id = null,
+                    bool $force_web_search = false,
+                    ?string $source_policy = null,
+                    bool $allow_auto_realtime_web = true,
+                    ?array $document_ids = null,
+                ): \Generator {
+                    $this->called = true;
+                    yield 'Tidak boleh dipanggil saat stream claim aktif';
+                }
+            };
+        });
+
+        $job = new GenerateChatResponse(
+            conversationId: (int) $conversation->id,
+            userId: (int) $user->id,
+            history: [['role' => 'user', 'content' => 'Pertanyaan mid-stream']],
+        );
+        $job->handle(app(AIService::class), $orchestrator);
+
+        $this->assertFalse($aiCalled, 'Job harus skip AI call saat stream claim aktif');
+        $this->assertSame(0, Message::query()
+            ->where('conversation_id', $conversation->id)
+            ->where('role', 'assistant')
+            ->count());
+
+        $orchestrator->releaseStreamClaim($claimKey);
+    }
+
     // -------------------------------------------------------------------------
     // Helper
     // -------------------------------------------------------------------------

--- a/laravel/tests/Feature/Chat/ChatStreamTest.php
+++ b/laravel/tests/Feature/Chat/ChatStreamTest.php
@@ -857,6 +857,57 @@ class ChatStreamTest extends TestCase
         $orchestrator->releaseStreamClaim($claimKey);
     }
 
+    public function test_execute_stream_acquires_claim_before_ai_call(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Claim lifecycle test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan claim lifecycle',
+        ]);
+
+        $claimWasActiveInsideSendChat = false;
+
+        $this->app->bind(AIService::class, function () use ($conversation, &$claimWasActiveInsideSendChat) {
+            return new class($conversation, $claimWasActiveInsideSendChat) extends AIService
+            {
+                public function __construct(
+                    private Conversation $conversation,
+                    private bool &$claimWasActiveInsideSendChat,
+                ) {
+                    parent::__construct();
+                }
+
+                public function sendChat(
+                    array $messages,
+                    ?array $document_filenames = null,
+                    ?string $user_id = null,
+                    bool $force_web_search = false,
+                    ?string $source_policy = null,
+                    bool $allow_auto_realtime_web = true,
+                    ?array $document_ids = null,
+                ): \Generator {
+                    $orchestrator = app(ChatOrchestrationService::class);
+                    $this->claimWasActiveInsideSendChat = $orchestrator->hasActiveStreamClaim((int) $this->conversation->id);
+                    yield 'Chunk dengan claim aktif';
+                }
+            };
+        });
+
+        $body = $this->runExecuteStream($user, $conversation);
+
+        $this->assertTrue($claimWasActiveInsideSendChat, 'Claim harus aktif saat sendChat() dipanggil');
+        $this->assertStringContainsString('event: done', $body);
+
+        $orchestrator = app(ChatOrchestrationService::class);
+        $this->assertFalse($orchestrator->hasActiveStreamClaim($conversation->id), 'Claim harus dilepas setelah stream selesai');
+    }
+
     // -------------------------------------------------------------------------
     // Helper
     // -------------------------------------------------------------------------

--- a/laravel/tests/Feature/Chat/ChatStreamTest.php
+++ b/laravel/tests/Feature/Chat/ChatStreamTest.php
@@ -1,0 +1,423 @@
+<?php
+
+namespace Tests\Feature\Chat;
+
+use App\Http\Controllers\Chat\ChatStreamController;
+use App\Models\Conversation;
+use App\Models\Document;
+use App\Models\Message;
+use App\Models\User;
+use App\Services\AIService;
+use App\Services\ChatOrchestrationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ChatStreamTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // -------------------------------------------------------------------------
+    // Auth / ownership guards
+    // -------------------------------------------------------------------------
+
+    public function test_stream_returns_401_for_unauthenticated_user(): void
+    {
+        $owner = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $owner->id,
+            'title' => 'Test conversation',
+        ]);
+
+        $this->get(route('chat.stream', ['conversationId' => $conversation->id]))
+            ->assertRedirect(route('login'));
+    }
+
+    public function test_stream_returns_404_for_foreign_conversation(): void
+    {
+        $owner = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $conversation = Conversation::create([
+            'user_id' => $owner->id,
+            'title' => 'Owned by owner',
+        ]);
+
+        $this->actingAs($otherUser)
+            ->get(route('chat.stream', ['conversationId' => $conversation->id]))
+            ->assertNotFound();
+    }
+
+    public function test_stream_returns_404_for_nonexistent_conversation(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('chat.stream', ['conversationId' => 999999]))
+            ->assertNotFound();
+    }
+
+    // -------------------------------------------------------------------------
+    // SSE output / header tests
+    // -------------------------------------------------------------------------
+
+    public function test_stream_returns_sse_content_type_header(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Header test',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(
+                array $messages,
+                ?array $document_filenames = null,
+                ?string $user_id = null,
+                bool $force_web_search = false,
+                ?string $source_policy = null,
+                bool $allow_auto_realtime_web = true,
+                ?array $document_ids = null,
+            ): \Generator {
+                yield 'OK';
+            }
+        });
+
+        $history = json_encode([['role' => 'user', 'content' => 'Halo']]);
+
+        $response = $this->actingAs($user)
+            ->get(route('chat.stream', ['conversationId' => $conversation->id]).'?history='.urlencode($history));
+
+        $response->assertOk();
+        $this->assertStringContainsString('text/event-stream', $response->headers->get('Content-Type'));
+    }
+
+    public function test_stream_sends_sse_chunks_for_valid_conversation(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Streaming test',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(
+                array $messages,
+                ?array $document_filenames = null,
+                ?string $user_id = null,
+                bool $force_web_search = false,
+                ?string $source_policy = null,
+                bool $allow_auto_realtime_web = true,
+                ?array $document_ids = null,
+            ): \Generator {
+                yield 'Halo ';
+                yield 'dunia!';
+            }
+        });
+
+        $body = $this->runExecuteStream($user, $conversation, [
+            ['role' => 'user', 'content' => 'Halo'],
+        ]);
+
+        $this->assertStringContainsString('event: chunk', $body);
+        $this->assertStringContainsString('Halo ', $body);
+        $this->assertStringContainsString('dunia!', $body);
+        $this->assertStringContainsString('event: done', $body);
+    }
+
+    // -------------------------------------------------------------------------
+    // DB persistence
+    // -------------------------------------------------------------------------
+
+    public function test_stream_persists_assistant_message_to_db_after_stream(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Persistence test',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(
+                array $messages,
+                ?array $document_filenames = null,
+                ?string $user_id = null,
+                bool $force_web_search = false,
+                ?string $source_policy = null,
+                bool $allow_auto_realtime_web = true,
+                ?array $document_ids = null,
+            ): \Generator {
+                yield 'Jawaban dari streaming.';
+            }
+        });
+
+        $this->runExecuteStream($user, $conversation, [
+            ['role' => 'user', 'content' => 'Pertanyaan'],
+        ]);
+
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban dari streaming.',
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Idempotency
+    // -------------------------------------------------------------------------
+
+    public function test_stream_does_not_duplicate_message_if_assistant_already_exists(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Idempotency test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan',
+        ]);
+
+        // Simulate job already saved the assistant message
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban dari job.',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(
+                array $messages,
+                ?array $document_filenames = null,
+                ?string $user_id = null,
+                bool $force_web_search = false,
+                ?string $source_policy = null,
+                bool $allow_auto_realtime_web = true,
+                ?array $document_ids = null,
+            ): \Generator {
+                yield 'Jawaban duplikat dari stream.';
+            }
+        });
+
+        $this->runExecuteStream($user, $conversation, [
+            ['role' => 'user', 'content' => 'Pertanyaan'],
+        ]);
+
+        // Only one assistant message should exist
+        $assistantCount = Message::where('conversation_id', $conversation->id)
+            ->where('role', 'assistant')
+            ->count();
+
+        $this->assertSame(1, $assistantCount, 'Tidak boleh ada duplikat assistant message');
+    }
+
+    // -------------------------------------------------------------------------
+    // Error sentinel
+    // -------------------------------------------------------------------------
+
+    public function test_stream_saves_error_message_when_ai_returns_sentinel(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Error sentinel test',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(
+                array $messages,
+                ?array $document_filenames = null,
+                ?string $user_id = null,
+                bool $force_web_search = false,
+                ?string $source_policy = null,
+                bool $allow_auto_realtime_web = true,
+                ?array $document_ids = null,
+            ): \Generator {
+                yield AIService::ERROR_SENTINEL.'❌ Kesalahan sistem.';
+            }
+        });
+
+        $body = $this->runExecuteStream($user, $conversation, [
+            ['role' => 'user', 'content' => 'Pertanyaan'],
+        ]);
+
+        $this->assertStringContainsString('event: error', $body);
+
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'is_error' => true,
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Document filtering
+    // -------------------------------------------------------------------------
+
+    public function test_stream_only_uses_owned_ready_documents(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Document filter test',
+        ]);
+
+        $readyDoc = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'ready.pdf',
+            'original_name' => 'ready.pdf',
+            'file_path' => 'documents/'.$user->id.'/ready.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 100,
+            'status' => 'ready',
+        ]);
+
+        $foreignDoc = Document::create([
+            'user_id' => $otherUser->id,
+            'filename' => 'foreign.pdf',
+            'original_name' => 'foreign.pdf',
+            'file_path' => 'documents/'.$otherUser->id.'/foreign.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 100,
+            'status' => 'ready',
+        ]);
+
+        $captured = new \stdClass;
+        $captured->documentIds = null;
+        $captured->filenames = null;
+
+        $this->app->bind(AIService::class, function () use ($captured) {
+            return new class($captured) extends AIService
+            {
+                public function __construct(private \stdClass $captured)
+                {
+                    parent::__construct();
+                }
+
+                public function sendChat(
+                    array $messages,
+                    ?array $document_filenames = null,
+                    ?string $user_id = null,
+                    bool $force_web_search = false,
+                    ?string $source_policy = null,
+                    bool $allow_auto_realtime_web = true,
+                    ?array $document_ids = null,
+                ): \Generator {
+                    $this->captured->documentIds = $document_ids;
+                    $this->captured->filenames = $document_filenames;
+                    yield 'OK';
+                }
+            };
+        });
+
+        $this->actingAs($user);
+
+        $orchestrator = app(ChatOrchestrationService::class);
+        $docContext = $orchestrator->getActiveDocumentContext([$readyDoc->id, $foreignDoc->id]);
+
+        $controller = app(ChatStreamController::class);
+        $controller->executeStream(
+            app(AIService::class),
+            $orchestrator,
+            [['role' => 'user', 'content' => 'Halo']],
+            $docContext['filenames'],
+            $docContext['ids'],
+            $orchestrator->getSourcePolicy($docContext['filenames']),
+            $orchestrator->shouldAllowAutoRealtimeWeb($docContext['filenames']),
+            false,
+            $conversation->id,
+            $conversation,
+            $user,
+        );
+
+        $this->assertNotNull($captured->documentIds);
+        $this->assertContains($readyDoc->id, $captured->documentIds);
+        $this->assertNotContains($foreignDoc->id, $captured->documentIds);
+        $this->assertSame(['ready.pdf'], $captured->filenames);
+    }
+
+    // -------------------------------------------------------------------------
+    // message-id event
+    // -------------------------------------------------------------------------
+
+    public function test_stream_sends_message_id_event_after_persistence(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Message ID event test',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(
+                array $messages,
+                ?array $document_filenames = null,
+                ?string $user_id = null,
+                bool $force_web_search = false,
+                ?string $source_policy = null,
+                bool $allow_auto_realtime_web = true,
+                ?array $document_ids = null,
+            ): \Generator {
+                yield 'Jawaban tersimpan.';
+            }
+        });
+
+        $body = $this->runExecuteStream($user, $conversation, [
+            ['role' => 'user', 'content' => 'Pertanyaan'],
+        ]);
+
+        $this->assertStringContainsString('event: message-id', $body);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    /**
+     * Call executeStream() directly and capture its echo output.
+     * This avoids the PHPUnit "risky" warning caused by StreamedResponse closures.
+     *
+     * @param  array<int, array{role: string, content: string}>  $history
+     * @param  array<int, int>  $documentIds
+     */
+    private function runExecuteStream(
+        User $user,
+        Conversation $conversation,
+        array $history,
+        array $documentIds = [],
+        bool $webSearchMode = false,
+    ): string {
+        $this->actingAs($user);
+
+        $orchestrator = app(ChatOrchestrationService::class);
+        $docContext = $orchestrator->getActiveDocumentContext($documentIds);
+
+        $controller = app(ChatStreamController::class);
+
+        ob_start();
+        $controller->executeStream(
+            app(AIService::class),
+            $orchestrator,
+            $history,
+            $docContext['filenames'],
+            $docContext['ids'],
+            $orchestrator->getSourcePolicy($docContext['filenames']),
+            $orchestrator->shouldAllowAutoRealtimeWeb($docContext['filenames']),
+            $webSearchMode,
+            $conversation->id,
+            $conversation,
+            $user,
+        );
+
+        return (string) ob_get_clean();
+    }
+}

--- a/laravel/tests/Feature/Chat/ChatStreamTest.php
+++ b/laravel/tests/Feature/Chat/ChatStreamTest.php
@@ -960,6 +960,112 @@ class ChatStreamTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // Duplicate stream adoption rejected
+    // -------------------------------------------------------------------------
+
+    public function test_duplicate_stream_adoption_is_rejected(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Duplicate stream test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan duplikat stream',
+        ]);
+
+        $orchestrator = app(ChatOrchestrationService::class);
+
+        // First: intent claim (sendMessage path)
+        $intentKey = $orchestrator->acquireStreamClaim($conversation->id);
+        $this->assertNotNull($intentKey, 'Intent claim harus berhasil');
+
+        // Second: stream adopts intent → active
+        $activeKey = $orchestrator->acquireStreamClaim($conversation->id);
+        $this->assertNotNull($activeKey, 'Stream pertama harus bisa adopt intent');
+        $this->assertSame($intentKey, $activeKey);
+
+        // Third: duplicate stream tries to adopt active → rejected
+        $duplicateKey = $orchestrator->acquireStreamClaim($conversation->id);
+        $this->assertNull($duplicateKey, 'Stream duplikat harus ditolak saat claim sudah active');
+
+        $orchestrator->releaseStreamClaim($activeKey);
+    }
+
+    // -------------------------------------------------------------------------
+    // No-stream fallback: intent claim stale, job runs AI
+    // -------------------------------------------------------------------------
+
+    public function test_job_runs_ai_after_intent_claim_expires(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'No-stream fallback test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan fallback no-stream',
+        ]);
+
+        $orchestrator = app(ChatOrchestrationService::class);
+
+        // Simulate sendMessage() creating intent claim
+        $claimKey = $orchestrator->acquireStreamClaim($conversation->id);
+        $this->assertNotNull($claimKey);
+        $this->assertTrue($orchestrator->hasActiveStreamClaim($conversation->id));
+
+        // Simulate claim expiry (stream never connected)
+        $orchestrator->releaseStreamClaim($claimKey);
+        $this->assertFalse($orchestrator->hasActiveStreamClaim($conversation->id));
+
+        // Job should now run AI since claim is gone
+        $aiCalled = false;
+        $this->app->bind(AIService::class, function () use (&$aiCalled) {
+            return new class($aiCalled) extends AIService
+            {
+                public function __construct(private bool &$called)
+                {
+                    parent::__construct();
+                }
+
+                public function sendChat(
+                    array $messages,
+                    ?array $document_filenames = null,
+                    ?string $user_id = null,
+                    bool $force_web_search = false,
+                    ?string $source_policy = null,
+                    bool $allow_auto_realtime_web = true,
+                    ?array $document_ids = null,
+                ): \Generator {
+                    $this->called = true;
+                    yield 'Jawaban fallback dari job.';
+                }
+            };
+        });
+
+        $this->actingAs($user);
+        $job = new GenerateChatResponse(
+            conversationId: (int) $conversation->id,
+            userId: (int) $user->id,
+            history: [['role' => 'user', 'content' => 'Pertanyaan fallback no-stream']],
+        );
+        $job->handle(app(AIService::class), $orchestrator);
+
+        $this->assertTrue($aiCalled, 'Job harus memanggil AI setelah claim stale/expired');
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban fallback dari job.',
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
     // Helper
     // -------------------------------------------------------------------------
 

--- a/laravel/tests/Feature/Chat/ChatStreamTest.php
+++ b/laravel/tests/Feature/Chat/ChatStreamTest.php
@@ -908,6 +908,57 @@ class ChatStreamTest extends TestCase
         $this->assertFalse($orchestrator->hasActiveStreamClaim($conversation->id), 'Claim harus dilepas setelah stream selesai');
     }
 
+    public function test_execute_stream_adopts_pre_existing_claim_from_send_message(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Claim adoption test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan adopsi claim',
+        ]);
+
+        $orchestrator = app(ChatOrchestrationService::class);
+
+        $preClaimKey = $orchestrator->acquireStreamClaim($conversation->id);
+        $this->assertNotNull($preClaimKey, 'Pre-claim harus berhasil dibuat');
+
+        $aiCalled = false;
+        $this->app->bind(AIService::class, function () use (&$aiCalled) {
+            return new class($aiCalled) extends AIService
+            {
+                public function __construct(private bool &$called)
+                {
+                    parent::__construct();
+                }
+
+                public function sendChat(
+                    array $messages,
+                    ?array $document_filenames = null,
+                    ?string $user_id = null,
+                    bool $force_web_search = false,
+                    ?string $source_policy = null,
+                    bool $allow_auto_realtime_web = true,
+                    ?array $document_ids = null,
+                ): \Generator {
+                    $this->called = true;
+                    yield 'Stream jalan meski pre-claim ada';
+                }
+            };
+        });
+
+        $body = $this->runExecuteStream($user, $conversation);
+
+        $this->assertTrue($aiCalled, 'Stream harus tetap memanggil AI meski pre-claim sudah ada');
+        $this->assertStringContainsString('Stream jalan meski pre-claim ada', $body);
+        $this->assertStringContainsString('event: done', $body);
+        $this->assertFalse($orchestrator->hasActiveStreamClaim($conversation->id), 'Claim harus dilepas setelah stream selesai');
+    }
+
     // -------------------------------------------------------------------------
     // Helper
     // -------------------------------------------------------------------------

--- a/laravel/tests/Feature/Chat/ChatStreamTest.php
+++ b/laravel/tests/Feature/Chat/ChatStreamTest.php
@@ -760,6 +760,45 @@ class ChatStreamTest extends TestCase
             ->where('role', 'assistant')->count());
     }
 
+    public function test_stream_error_first_then_job_success_recovers_to_normal_answer(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Error then success recovery test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan pemulihan',
+        ]);
+
+        $orchestrator = app(ChatOrchestrationService::class);
+
+        // Step 1: stream menyimpan error duluan
+        $this->actingAs($user);
+        $savedError = $orchestrator->saveErrorMessage($conversation->id, 'Error awal dari stream.', $user->id);
+        $this->assertNotNull($savedError);
+        $this->assertTrue((bool) $savedError->is_error);
+
+        // Step 2: job sukses belakangan harus memulihkan row yang sama menjadi normal
+        $savedSuccess = $orchestrator->saveAssistantMessage($conversation->id, 'Jawaban sukses dari job.', $user->id);
+        $this->assertNotNull($savedSuccess);
+        $this->assertFalse((bool) $savedSuccess->is_error);
+        $this->assertSame('Jawaban sukses dari job.', $savedSuccess->content);
+
+        // Tetap satu assistant message setelah recovery
+        $assistantMessages = Message::query()
+            ->where('conversation_id', $conversation->id)
+            ->where('role', 'assistant')
+            ->get();
+
+        $this->assertCount(1, $assistantMessages);
+        $this->assertFalse((bool) $assistantMessages->first()->is_error);
+        $this->assertSame('Jawaban sukses dari job.', $assistantMessages->first()->content);
+    }
+
     // -------------------------------------------------------------------------
     // Helper
     // -------------------------------------------------------------------------

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -16,6 +16,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\RateLimiter;
 use Livewire\Livewire;
@@ -788,6 +789,7 @@ class ChatUiTest extends TestCase
     public function test_send_message_dispatches_ack_and_queues_response_with_conversation_id_payload(): void
     {
         Queue::fake();
+        Cache::flush();
 
         $user = User::factory()->create();
 
@@ -815,6 +817,10 @@ class ChatUiTest extends TestCase
             return $job->conversationId === $conversationId
                 && $job->userId === (int) $user->id;
         });
+
+        $claimKey = app(ChatOrchestrationService::class)->streamClaimKeyForLatestUserMessage($conversationId);
+        $this->assertNotNull($claimKey);
+        $this->assertTrue(Cache::has($claimKey), 'Claim stream harus dibuat saat sendMessage agar fallback job deterministik.');
     }
 
     public function test_save_assistant_message_returns_null_when_create_hits_conversation_fk_race(): void


### PR DESCRIPTION
## Summary

Closes #189

Mengaktifkan streaming live end-to-end dari Python AI ke browser untuk tiga mode: chat biasa, web search, dan chat dokumen. Sebelumnya UI hanya mengetahui jawaban selesai lewat `wire:poll.3s` sehingga user melihat layar kosong sampai seluruh jawaban selesai.

## Perubahan

- **`laravel/app/Http/Controllers/Chat/ChatStreamController.php`** (baru) — SSE endpoint `GET /chat/stream/{conversationId}` yang memanggil `AIService::sendChat()` langsung dan stream chunk ke browser sebagai `text/event-stream`. Setelah stream selesai, menyimpan final message ke DB via `ChatOrchestrationService`.
- **`laravel/routes/web.php`** — Tambah route `chat.stream` dengan middleware `auth`, `verified`, throttle 60/menit.
- **`laravel/resources/js/chat-page.js`** — `chatMessages` Alpine component membuka `EventSource` ke endpoint SSE setelah `user-message-acked`. Chunk di-feed langsung ke `streamingText`. EventSource ditutup saat `done` event diterima atau conversation berganti.
- **`laravel/tests/Feature/Chat/ChatStreamTest.php`** (baru) — 10 test: auth/ownership guards, SSE header, chunk output, persistensi DB, idempotensi duplikat, error sentinel, document filtering, message-id event.
- **`issue/issue-189-streaming-live-chat-2026-05-15.md`** — Issue plan.

## Arsitektur

```
Browser → POST /livewire (sendMessage) → user-message-acked
        → GET /chat/stream/{id}?history=...  (EventSource)
              → AIService::sendChat() → Python AI SSE
              ← chunk events → streamingText (live)
              ← done event → refreshPendingChatState()
```

Job queue (`GenerateChatResponse`) tetap berjalan sebagai fallback. Idempotensi dijaga: controller hanya menyimpan assistant message jika belum ada setelah user message terakhir.

## Test

- 308 test pass, 0 regresi
- 10 test baru di `ChatStreamTest`

## Catatan

- `wire:poll.3s` tetap sebagai recovery path jika stream gagal di tengah jalan
- Tidak ada perubahan pada Python AI, RAG, atau kualitas retrieval