### PR TITLE
feat: tuning RAG dokumen — HyDE smart, top_k 5, doc_candidates 20 (#192)

### DIFF
--- a/issue/issue-192-rag-tuning-hyde-topk-rerank-2026-05-15.md
+++ b/issue/issue-192-rag-tuning-hyde-topk-rerank-2026-05-15.md
@@ -1,0 +1,83 @@
+# Issue #192 — Tuning RAG Dokumen: HyDE, top_k, Rerank, dan Recall Berbasis Eval
+
+## Latar Belakang
+
+Audit (#188) dan baseline metrik (#190) menemukan beberapa kandidat tuning RAG dokumen:
+- HyDE saat ini `mode: always` — menambah ~300-600ms per request retrieval
+- `top_k: 8` dan `doc_candidates: 25` — context besar memperlambat TTFT LLM
+- HyDE `timeout: 3s` sudah ketat, tapi `max_attempts: 2` bisa memperlambat jika model pertama lambat
+
+## Keputusan Berbasis Eval
+
+### HyDE: `always` → `smart`
+
+**Alasan:**
+- Mode `always` menambah ~300-600ms untuk SETIAP query dokumen, termasuk query sederhana seperti "ringkaskan dokumen ini" yang tidak butuh HyDE
+- Mode `smart` sudah punya pattern detection yang baik di `_should_use_hyde()` — aktif untuk query konseptual (mengapa, bagaimana, analisis, evaluasi, dll)
+- Eval set (#190) menunjukkan query dokumen kantor mayoritas adalah ringkasan, fakta spesifik, dan pertanyaan langsung — bukan query konseptual yang butuh HyDE
+- Rollback mudah: ubah `mode: smart` kembali ke `mode: always` di YAML
+
+**Guardrail:**
+- Mode `smart` tetap aktif untuk query konseptual panjang (>= 8 kata dengan tanda tanya)
+- Tidak menghapus HyDE — hanya mengubah kapan diaktifkan
+
+### top_k: 8 → 5, doc_candidates: 25 → 20
+
+**Alasan:**
+- `top_k: 8` dengan PDR aktif berarti 8 parent chunks (~1500 token each) = ~12.000 token context
+- Mengurangi ke 5 chunks = ~7.500 token — masih cukup untuk menjawab pertanyaan dokumen kantor
+- `doc_candidates: 25 → 20` mengurangi jumlah chunk yang di-fetch dari ChromaDB sebelum rerank
+- Eval set (#190) menunjukkan 5 chunk sudah cukup untuk recall pada query dokumen kantor
+- Rollback: ubah nilai di YAML
+
+**Guardrail:**
+- `top_n` tetap sama dengan `top_k` (5) agar reranker tidak membuang chunk yang dibutuhkan
+- Multi-document retrieval tetap adil: forced inclusion tetap aktif
+
+### HyDE max_attempts: 2 → 1
+
+**Alasan:**
+- Dengan `timeout: 3s` dan `max_attempts: 2`, worst case HyDE bisa memakan 6s
+- Mengurangi ke 1 attempt: jika model pertama gagal, langsung fallback ke query asli
+- Tidak mengurangi kualitas karena model pertama (Groq/Llama) sudah cepat dan reliable
+
+## Scope Implementasi
+
+### File Diubah
+- `python-ai/config/ai_config.yaml` — ubah HyDE mode, top_k, doc_candidates, max_attempts
+- `python-ai/app/services/rag_hybrid.py` — kurangi max_attempts default dari 2 ke 1
+- `python-ai/tests/test_rag_policy_singleton.py` atau test baru — verifikasi HyDE smart mode
+
+### File Baru
+- `python-ai/tests/test_rag_tuning.py` — test untuk perubahan tuning
+- `issue/issue-192-rag-tuning-hyde-topk-rerank-2026-05-15.md` — issue plan ini
+
+## Acceptance Criteria
+
+- [ ] HyDE mode berubah ke `smart` di config
+- [ ] top_k berubah ke 5, doc_candidates ke 20
+- [ ] HyDE max_attempts berubah ke 1
+- [ ] Test memverifikasi HyDE smart mode aktif untuk query konseptual
+- [ ] Test memverifikasi HyDE smart mode skip untuk query sederhana
+- [ ] Full Python test hijau
+
+## Rollback
+
+Semua perubahan bisa di-rollback dengan mengubah nilai di `ai_config.yaml`:
+```yaml
+hyde:
+  mode: always      # rollback dari smart
+  max_tokens: 100
+  timeout: 3
+
+semantic_rerank:
+  top_k: 8          # rollback dari 5
+  top_n: 8          # rollback dari 5
+  doc_candidates: 25 # rollback dari 20
+```
+
+## Cara Verifikasi
+
+```bash
+cd python-ai && source venv/bin/activate && pytest
+```

--- a/python-ai/app/services/rag_hybrid.py
+++ b/python-ai/app/services/rag_hybrid.py
@@ -72,7 +72,10 @@ def _generate_hyde_query(original_query: str, timeout: int = 5, max_tokens: int 
 
         sorted_models = sorted(models, key=_hyde_priority)
 
-        max_attempts = 2
+        # Tuning #192: max_attempts 2→1 agar HyDE gagal cepat dan fallback ke query asli.
+        # Dengan timeout=3s dan 2 attempts, worst case = 6s. Dengan 1 attempt = 3s max.
+        # Rollback: ubah kembali ke max_attempts = 2
+        max_attempts = 1
         attempts = 0
 
         for model in sorted_models:

--- a/python-ai/app/services/rag_hybrid.py
+++ b/python-ai/app/services/rag_hybrid.py
@@ -74,8 +74,9 @@ def _generate_hyde_query(original_query: str, timeout: int = 5, max_tokens: int 
 
         # Tuning #192: max_attempts 2→1 agar HyDE gagal cepat dan fallback ke query asli.
         # Dengan timeout=3s dan 2 attempts, worst case = 6s. Dengan 1 attempt = 3s max.
-        # Rollback: ubah kembali ke max_attempts = 2
-        max_attempts = 1
+        # Rollback: ubah retrieval.hyde.max_attempts di ai_config.yaml ke 2
+        from app.config_loader import get_hyde_config
+        max_attempts = get_hyde_config().get('max_attempts', 1)
         attempts = 0
 
         for model in sorted_models:

--- a/python-ai/config/ai_config.yaml
+++ b/python-ai/config/ai_config.yaml
@@ -230,10 +230,14 @@ retrieval:
     model: "langsearch-reranker-v1"
     timeout: 8
     # ── RAG document reranking ─────────────────────────────────────────────────
-    top_k: 8          # Chunk yang dikembalikan ke LLM setelah reranking
-    top_n: 8          # Alias top_k untuk kompatibilitas
+    # Tuning #192: top_k 8→5, top_n 8→5, doc_candidates 25→20
+    # Alasan: 5 chunk (~7.500 token dengan PDR) cukup untuk dokumen kantor,
+    # mengurangi context size dan mempercepat TTFT LLM.
+    # Rollback: ubah kembali ke top_k: 8, top_n: 8, doc_candidates: 25
+    top_k: 5          # Chunk yang dikembalikan ke LLM setelah reranking
+    top_n: 5          # Alias top_k untuk kompatibilitas
     # ⚠️ WAJIB: doc_candidates >= top_n (makin besar = makin akurat tapi lebih lambat)
-    doc_candidates: 25
+    doc_candidates: 20
     # ── Web search result reranking ────────────────────────────────────────────
     # Skala lebih kecil dari RAG karena hasil web sudah cukup relevan dari LangSearch
     web_candidates: 10  # Max hasil web yang dikirim ke reranker
@@ -261,18 +265,18 @@ retrieval:
   # Sebelum vector search, LLM membuat jawaban hipotetis singkat dari query.
   # Jawaban hipotetis + query asli diembed bersama untuk retrieval yang lebih kaya.
   #
-  # Untuk dokumen kantor/akademik: gunakan mode 'always' karena:
-  #   - Keakuratan > kecepatan untuk analisis dokumen
-  #   - User punya pola query beragam, tidak bisa diprediksi dengan keyword
-  #   - Timeout 3s: jika LLM lambat → fallback ke query asli (tanpa error)
-  #   - Actual overhead: ~300-600ms (bukan 2 detik, karena max_tokens=100)
+  # Tuning #192: mode always → smart
+  # Alasan: mode 'always' menambah ~300-600ms untuk SETIAP query dokumen,
+  # termasuk query sederhana (ringkasan, fakta langsung) yang tidak butuh HyDE.
+  # Mode 'smart' aktif hanya untuk query konseptual (mengapa, bagaimana, analisis, dll).
+  # Rollback: ubah mode: smart kembali ke mode: always
   #
-  # mode: always → DIREKOMENDASIKAN untuk dokumen kantor (+300-600ms, lebih akurat)
-  # mode: smart  → aktif hanya untuk pola konseptual tertentu (fragile)
+  # mode: always → aktif untuk semua query (+300-600ms, lebih akurat untuk query kompleks)
+  # mode: smart  → aktif hanya untuk pola konseptual tertentu (lebih cepat untuk query sederhana)
   # mode: off    → matikan sepenuhnya (tercepat, akurasi standar)
   hyde:
     enabled: true
-    mode: always     # 'always' | 'smart' | 'off'
+    mode: smart      # Tuning #192: always → smart. Rollback: ubah ke always
     max_tokens: 100  # jawaban hipotetis singkat (100 token = ~2-3 kalimat)
     timeout: 3       # detik — timeout ketat: jika lambat, skip gracefully
 

--- a/python-ai/config/ai_config.yaml
+++ b/python-ai/config/ai_config.yaml
@@ -279,6 +279,7 @@ retrieval:
     mode: smart      # Tuning #192: always → smart. Rollback: ubah ke always
     max_tokens: 100  # jawaban hipotetis singkat (100 token = ~2-3 kalimat)
     timeout: 3       # detik — timeout ketat: jika lambat, skip gracefully
+    max_attempts: 1  # Tuning #192: 2→1 agar HyDE gagal cepat, fallback ke query asli. Rollback: ubah ke 2
 
 
 # ============================================

--- a/python-ai/tests/test_rag_tuning.py
+++ b/python-ai/tests/test_rag_tuning.py
@@ -1,0 +1,228 @@
+"""
+Test untuk tuning RAG dokumen — Issue #192.
+
+Verifikasi:
+1. HyDE smart mode aktif untuk query konseptual, skip untuk query sederhana
+2. HyDE max_attempts = 1 (failfast)
+3. Config top_k, doc_candidates sesuai nilai tuning
+4. Rollback config bisa dikembalikan ke nilai sebelumnya
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# HyDE smart mode — _should_use_hyde()
+# ---------------------------------------------------------------------------
+
+class TestHydeSmartMode:
+    """Verifikasi logika _should_use_hyde() untuk mode smart."""
+
+    @pytest.mark.parametrize("query,expected_use", [
+        # Query konseptual — HyDE harus aktif
+        ("mengapa kebijakan ini diterapkan di lingkungan kantor?", True),
+        ("bagaimana cara kerja sistem pengarsipan dokumen ini?", True),
+        ("apa hubungan antara prosedur A dan prosedur B dalam dokumen?", True),
+        ("jelaskan konsep manajemen risiko yang disebutkan dalam laporan", True),
+        ("analisis dampak perubahan kebijakan terhadap pegawai", True),
+        ("evaluasi efektivitas program yang dijelaskan dalam dokumen ini?", True),
+        ("apa yang dimaksud dengan istilah teknis dalam bagian ketiga?", True),
+        ("bagaimana pengaruh regulasi baru terhadap prosedur yang ada?", True),
+        # Query sederhana — HyDE harus skip
+        ("ringkaskan dokumen ini", False),
+        ("buat ringkasan dari laporan", False),
+        ("apa isi dokumen?", False),
+        ("tampilkan poin utama", False),
+        ("halo", False),
+        ("hi apa kabar", False),
+        ("baca isi dokumen ini", False),
+        ("jelaskan isi dokumen", False),
+    ])
+    def test_should_use_hyde_smart_mode(self, query, expected_use):
+        from app.services.rag_hybrid import _should_use_hyde
+        result, reason = _should_use_hyde(query)
+        assert result == expected_use, (
+            f"Query '{query}': expected HyDE={expected_use}, got HyDE={result} (reason: {reason})"
+        )
+
+    def test_short_query_always_skips_hyde(self):
+        """Query pendek (< 5 kata) selalu skip HyDE."""
+        from app.services.rag_hybrid import _should_use_hyde
+        result, reason = _should_use_hyde("apa itu")
+        assert result is False
+        assert "pendek" in reason
+
+    def test_long_question_with_mark_uses_hyde(self):
+        """Query panjang (>= 8 kata) dengan tanda tanya menggunakan HyDE."""
+        from app.services.rag_hybrid import _should_use_hyde
+        query = "apakah dokumen ini membahas prosedur pengadaan barang dan jasa?"
+        result, reason = _should_use_hyde(query)
+        assert result is True
+
+    def test_hyde_skip_patterns_take_priority(self):
+        """Pattern skip harus diprioritaskan di atas pattern use."""
+        from app.services.rag_hybrid import _should_use_hyde
+        # "rangkum" adalah skip pattern, meski query panjang
+        result, reason = _should_use_hyde("rangkum dan analisis dokumen ini secara mendalam")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# HyDE max_attempts = 1 (failfast tuning #192)
+# ---------------------------------------------------------------------------
+
+class TestHydeMaxAttempts:
+    """Verifikasi HyDE hanya mencoba 1 model sebelum fallback."""
+
+    def test_hyde_stops_after_one_failed_attempt(self, monkeypatch):
+        """Jika model pertama gagal, HyDE langsung fallback ke query asli."""
+        import app.services.rag_hybrid as rh
+
+        attempt_count = {"count": 0}
+
+        def fake_completion(**kwargs):
+            attempt_count["count"] += 1
+            raise RuntimeError("model timeout")
+
+        monkeypatch.setattr("app.services.rag_hybrid.get_env", lambda k, d=None: "fake-key")
+
+        import litellm
+        monkeypatch.setattr(litellm, "completion", fake_completion)
+
+        fake_models = [
+            {"label": "Model A", "model_name": "groq/llama", "api_key_env": "KEY_A", "provider": "litellm"},
+            {"label": "Model B", "model_name": "groq/llama2", "api_key_env": "KEY_B", "provider": "litellm"},
+        ]
+
+        import app.config_loader as cl
+        monkeypatch.setattr(cl, "get_chat_models", lambda: fake_models)
+
+        result = rh._generate_hyde_query("mengapa kebijakan ini diterapkan?")
+
+        # Harus fallback ke query asli
+        assert result == "mengapa kebijakan ini diterapkan?"
+        # Hanya 1 attempt (max_attempts=1)
+        assert attempt_count["count"] == 1, (
+            f"HyDE harus berhenti setelah 1 attempt, tapi mencoba {attempt_count['count']} kali"
+        )
+
+    def test_hyde_returns_original_query_on_timeout(self, monkeypatch):
+        """Jika HyDE timeout, kembalikan query asli tanpa error."""
+        import app.services.rag_hybrid as rh
+
+        monkeypatch.setattr("app.services.rag_hybrid.get_env", lambda k, d=None: "fake-key")
+
+        import litellm
+        monkeypatch.setattr(litellm, "completion", lambda **kwargs: (_ for _ in ()).throw(
+            Exception("Request timed out")
+        ))
+
+        import app.config_loader as cl
+        monkeypatch.setattr(cl, "get_chat_models", lambda: [
+            {"label": "Model A", "model_name": "groq/llama", "api_key_env": "KEY_A", "provider": "litellm"},
+        ])
+
+        original = "bagaimana cara kerja sistem ini?"
+        result = rh._generate_hyde_query(original)
+        assert result == original
+
+
+# ---------------------------------------------------------------------------
+# Config values tuning #192
+# ---------------------------------------------------------------------------
+
+class TestConfigTuning:
+    """Verifikasi nilai config setelah tuning #192."""
+
+    def test_hyde_mode_is_smart(self):
+        """HyDE mode harus 'smart' setelah tuning."""
+        from app.config_loader import reload_config, get_hyde_config
+        reload_config()
+        hyde_cfg = get_hyde_config()
+        assert hyde_cfg.get("mode") == "smart", (
+            f"HyDE mode harus 'smart', tapi saat ini '{hyde_cfg.get('mode')}'"
+        )
+
+    def test_hyde_enabled_is_true(self):
+        """HyDE harus tetap enabled."""
+        from app.config_loader import reload_config, get_hyde_config
+        reload_config()
+        hyde_cfg = get_hyde_config()
+        assert hyde_cfg.get("enabled") is True
+
+    def test_top_k_is_five(self):
+        """top_k harus 5 setelah tuning."""
+        from app.config_loader import reload_config, get_rag_top_k
+        reload_config()
+        assert get_rag_top_k() == 5, f"top_k harus 5, tapi saat ini {get_rag_top_k()}"
+
+    def test_top_n_is_five(self):
+        """top_n harus 5 setelah tuning."""
+        from app.config_loader import reload_config, get_rag_top_n
+        reload_config()
+        assert get_rag_top_n() == 5, f"top_n harus 5, tapi saat ini {get_rag_top_n()}"
+
+    def test_doc_candidates_is_twenty(self):
+        """doc_candidates harus 20 setelah tuning."""
+        from app.config_loader import reload_config, get_rag_doc_candidates
+        reload_config()
+        assert get_rag_doc_candidates() == 20, (
+            f"doc_candidates harus 20, tapi saat ini {get_rag_doc_candidates()}"
+        )
+
+    def test_doc_candidates_gte_top_n(self):
+        """doc_candidates harus >= top_n (invariant wajib)."""
+        from app.config_loader import reload_config, get_rag_doc_candidates, get_rag_top_n
+        reload_config()
+        assert get_rag_doc_candidates() >= get_rag_top_n(), (
+            f"doc_candidates ({get_rag_doc_candidates()}) harus >= top_n ({get_rag_top_n()})"
+        )
+
+    def test_hyde_timeout_is_three(self):
+        """HyDE timeout harus 3 detik."""
+        from app.config_loader import reload_config, get_hyde_config
+        reload_config()
+        hyde_cfg = get_hyde_config()
+        assert int(hyde_cfg.get("timeout", 0)) == 3
+
+    def test_web_top_n_unchanged(self):
+        """web_top_n tidak berubah (tetap 5)."""
+        from app.config_loader import reload_config, get_rerank_config
+        reload_config()
+        rerank_cfg = get_rerank_config()
+        assert int(rerank_cfg.get("web_top_n", 0)) == 5
+
+
+# ---------------------------------------------------------------------------
+# Rollback scenario
+# ---------------------------------------------------------------------------
+
+class TestRollbackScenario:
+    """Verifikasi bahwa config bisa di-override untuk rollback."""
+
+    def test_hyde_mode_can_be_overridden_to_always(self, monkeypatch):
+        """Simulasi rollback: mode bisa diubah ke 'always' via config override."""
+        from app.config_loader import reload_config, get_hyde_config
+        import app.config_loader as cl
+
+        # Simulasi config dengan mode always (rollback)
+        original_load = cl.load_config
+
+        def patched_load():
+            cfg = original_load()
+            cfg_copy = dict(cfg)
+            cfg_copy.setdefault("retrieval", {})
+            cfg_copy["retrieval"] = dict(cfg_copy.get("retrieval", {}))
+            cfg_copy["retrieval"]["hyde"] = {"enabled": True, "mode": "always", "timeout": 3, "max_tokens": 100}
+            return cfg_copy
+
+        monkeypatch.setattr(cl, "load_config", patched_load)
+        monkeypatch.setattr(cl, "_config_cache", None)
+
+        # Dengan patch, mode harus always
+        hyde_cfg = get_hyde_config()
+        assert hyde_cfg.get("mode") == "always"


### PR DESCRIPTION
## Summary

Closes #192

Tiga perubahan tuning RAG dokumen berbasis eval set (#190) untuk mengurangi latency chat dokumen sambil menjaga recall dan kualitas jawaban.

## Perubahan

### 1. HyDE mode: `always` → `smart` (`ai_config.yaml`)
- Mode `always` menambah ~300-600ms untuk **setiap** query dokumen, termasuk query sederhana (ringkasan, fakta langsung) yang tidak butuh HyDE
- Mode `smart` aktif hanya untuk query konseptual: mengapa, bagaimana, analisis, evaluasi, apa hubungan, jelaskan konsep, dll
- Query sederhana (ringkaskan, baca isi, tampilkan, halo) langsung ke retrieval tanpa overhead HyDE
- **Rollback:** ubah `mode: smart` → `mode: always` di `ai_config.yaml`

### 2. top_k: 8→5, top_n: 8→5, doc_candidates: 25→20 (`ai_config.yaml`)
- 5 chunk dengan PDR aktif = ~7.500 token context — cukup untuk dokumen kantor
- Mengurangi context size → mempercepat TTFT LLM
- Invariant `doc_candidates >= top_n` tetap terjaga (20 >= 5)
- **Rollback:** ubah kembali ke `top_k: 8, top_n: 8, doc_candidates: 25`

### 3. HyDE max_attempts: 2→1 (`rag_hybrid.py`)
- Dengan `timeout=3s` dan 2 attempts, worst case HyDE = 6s
- Dengan 1 attempt = 3s max sebelum fallback ke query asli
- **Rollback:** ubah `max_attempts = 1` → `max_attempts = 2`

## Test

- `test_rag_tuning.py` (baru) — 30 test:
  - 16 parametrized test HyDE smart mode (query konseptual vs sederhana)
  - 2 test HyDE failfast dan timeout fallback
  - 8 test verifikasi nilai config tuning
  - 1 test rollback scenario (override config ke always)

## Verifikasi

- 238 Python test pass, 0 regresi
- Semua perubahan punya config toggle untuk rollback tanpa deploy ulang

## Rollback

```yaml
# ai_config.yaml
hyde:
  mode: always      # rollback dari smart

semantic_rerank:
  top_k: 8          # rollback dari 5
  top_n: 8          # rollback dari 5
  doc_candidates: 25 # rollback dari 20
```