### PR TITLE
feat: tuning polling interval setelah streaming aktif (#194)

### DIFF
--- a/issue/issue-194-polling-queue-tuning-2026-05-15.md
+++ b/issue/issue-194-polling-queue-tuning-2026-05-15.md
@@ -1,0 +1,54 @@
+# Issue #194 — Tuning Polling, Queue, dan Server Runtime Setelah Streaming Aktif
+
+## Latar Belakang
+
+Setelah streaming live aktif (#189), `wire:poll.3s="refreshPendingChatState"` tidak lagi menjadi jalur utama rendering jawaban chat. Polling sekarang hanya berfungsi sebagai safety net/fallback jika stream gagal di tengah jalan. Interval 3 detik terlalu agresif untuk fallback — setiap user yang sedang menunggu jawaban akan mengirim request Livewire setiap 3 detik.
+
+## Analisis Polling Saat Ini
+
+### 1. `chat-index.blade.php` — `wire:poll.3s="refreshPendingChatState"`
+- **Kondisi aktif:** Hanya saat `$pendingConversationIds` tidak kosong
+- **Fungsi:** Cek apakah job background sudah selesai dan load pesan baru
+- **Setelah streaming:** Streaming sudah mengirim `done` event dan trigger `refreshPendingChatState()` langsung. Polling 3s hanya fallback.
+- **Tuning:** 3s → 15s (safety net, bukan jalur utama)
+
+### 2. `chat-right-sidebar.blade.php` — `wire:poll.3s/20s="loadAvailableDocuments"`
+- **Kondisi aktif:** 3s saat ada dokumen processing, 20s saat idle
+- **Fungsi:** Refresh status dokumen yang sedang diproses
+- **Evaluasi:** 3s saat processing sudah cukup responsif. Ubah ke 5s untuk mengurangi beban sedikit tanpa mengorbankan UX.
+- **Tuning:** 3s → 5s saat processing, 20s tetap saat idle
+
+### 3. `document-viewer.blade.php` — `wire:poll.3s` (preview loading)
+- **Kondisi aktif:** Saat preview dokumen sedang disiapkan
+- **Fungsi:** Cek apakah preview sudah siap
+- **Evaluasi:** Preview generation bisa memakan 5-15 detik. Poll 3s terlalu agresif.
+- **Tuning:** 3s → 5s saat preview loading
+
+## Scope Implementasi
+
+### File Diubah
+- `laravel/resources/views/livewire/chat/chat-index.blade.php` — poll 3s → 15s
+- `laravel/resources/views/livewire/chat/partials/chat-right-sidebar.blade.php` — poll 3s → 5s saat processing
+- `laravel/resources/views/livewire/documents/document-viewer.blade.php` — poll 3s → 5s saat preview loading
+
+### File Baru
+- `issue/issue-194-polling-queue-tuning-2026-05-15.md` — issue plan ini
+
+## Acceptance Criteria
+
+- [ ] `wire:poll.3s="refreshPendingChatState"` berubah ke 15s
+- [ ] Polling dokumen sidebar saat processing berubah dari 3s ke 5s
+- [ ] Polling preview dokumen saat loading berubah dari 3s ke 5s
+- [ ] Test Laravel tetap hijau
+- [ ] `wire:poll.3s="refreshPendingChatState"` masih terlihat di test (diupdate ke 15s)
+
+## Rollback
+
+Ubah kembali interval di template blade:
+- `wire:poll.15s` → `wire:poll.3s` di `chat-index.blade.php`
+- `wire:poll.5s` → `wire:poll.3s` di `chat-right-sidebar.blade.php`
+- `wire:poll.5s` → `wire:poll.3s` di `document-viewer.blade.php`
+
+## Catatan Runtime
+
+Issue ini juga menyebut evaluasi `php -S` vs PHP-FPM + Caddy/Nginx atau Octane. Ini adalah keputusan infrastruktur yang membutuhkan metrik production nyata dan rencana deploy terpisah. Scope PR ini hanya mencakup perubahan polling interval yang aman dan reversible.

--- a/issue/issue-194-polling-queue-tuning-2026-05-15.md
+++ b/issue/issue-194-polling-queue-tuning-2026-05-15.md
@@ -1,21 +1,22 @@
-# Issue #194 — Tuning Polling, Queue, dan Server Runtime Setelah Streaming Aktif
+# Issue #194 — Tuning Polling Interval Dokumen dan Preview Setelah Streaming Aktif
 
 ## Latar Belakang
 
-Setelah streaming live aktif (#189), `wire:poll.3s="refreshPendingChatState"` tidak lagi menjadi jalur utama rendering jawaban chat. Polling sekarang hanya berfungsi sebagai safety net/fallback jika stream gagal di tengah jalan. Interval 3 detik terlalu agresif untuk fallback — setiap user yang sedang menunggu jawaban akan mengirim request Livewire setiap 3 detik.
+Setelah streaming live aktif (#189), beberapa polling interval di UI masih menggunakan 3s yang terlalu agresif untuk kasus di mana responsivitas tinggi tidak diperlukan. PR ini mengurangi interval polling untuk dokumen sidebar dan preview viewer dari 3s ke 5s.
 
-## Analisis Polling Saat Ini
+`wire:poll.3s="refreshPendingChatState"` di `chat-index.blade.php` **tidak diubah** karena `GenerateChatResponse` tidak dispatch event apapun setelah assistant message dipersist — polling tetap satu-satunya jalur refresh untuk chat. Mengubahnya ke 15s akan memperburuk latency yang dirasakan user hingga 15 detik. Push/event-based refresh menjadi scope PR terpisah.
+
+## Analisis Polling
 
 ### 1. `chat-index.blade.php` — `wire:poll.3s="refreshPendingChatState"`
 - **Kondisi aktif:** Hanya saat `$pendingConversationIds` tidak kosong
-- **Fungsi:** Cek apakah job background sudah selesai dan load pesan baru
-- **Setelah streaming:** Streaming sudah mengirim `done` event dan trigger `refreshPendingChatState()` langsung. Polling 3s hanya fallback.
-- **Tuning:** 3s → 15s (safety net, bukan jalur utama)
+- **Fungsi:** Satu-satunya jalur untuk mendeteksi assistant message yang sudah selesai dipersist
+- **Keputusan final:** Tetap 3s — tidak diubah di PR ini
+- **Catatan:** Push/event-based refresh (dispatch dari job setelah selesai) adalah scope PR terpisah
 
 ### 2. `chat-right-sidebar.blade.php` — `wire:poll.3s/20s="loadAvailableDocuments"`
 - **Kondisi aktif:** 3s saat ada dokumen processing, 20s saat idle
 - **Fungsi:** Refresh status dokumen yang sedang diproses
-- **Evaluasi:** 3s saat processing sudah cukup responsif. Ubah ke 5s untuk mengurangi beban sedikit tanpa mengorbankan UX.
 - **Tuning:** 3s → 5s saat processing, 20s tetap saat idle
 
 ### 3. `document-viewer.blade.php` — `wire:poll.3s` (preview loading)
@@ -27,25 +28,26 @@ Setelah streaming live aktif (#189), `wire:poll.3s="refreshPendingChatState"` ti
 ## Scope Implementasi
 
 ### File Diubah
-- `laravel/resources/views/livewire/chat/chat-index.blade.php` — poll 3s → 15s
 - `laravel/resources/views/livewire/chat/partials/chat-right-sidebar.blade.php` — poll 3s → 5s saat processing
 - `laravel/resources/views/livewire/documents/document-viewer.blade.php` — poll 3s → 5s saat preview loading
+
+### File Tidak Diubah
+- `laravel/resources/views/livewire/chat/chat-index.blade.php` — chat polling tetap 3s
 
 ### File Baru
 - `issue/issue-194-polling-queue-tuning-2026-05-15.md` — issue plan ini
 
 ## Acceptance Criteria
 
-- [ ] `wire:poll.3s="refreshPendingChatState"` berubah ke 15s
+- [ ] `wire:poll.3s="refreshPendingChatState"` di `chat-index.blade.php` tetap 3s (tidak berubah)
 - [ ] Polling dokumen sidebar saat processing berubah dari 3s ke 5s
 - [ ] Polling preview dokumen saat loading berubah dari 3s ke 5s
 - [ ] Test Laravel tetap hijau
-- [ ] `wire:poll.3s="refreshPendingChatState"` masih terlihat di test (diupdate ke 15s)
+- [ ] `ChatUiTest` assertion tetap mencari `wire:poll.3s="refreshPendingChatState"`
 
 ## Rollback
 
 Ubah kembali interval di template blade:
-- `wire:poll.15s` → `wire:poll.3s` di `chat-index.blade.php`
 - `wire:poll.5s` → `wire:poll.3s` di `chat-right-sidebar.blade.php`
 - `wire:poll.5s` → `wire:poll.3s` di `document-viewer.blade.php`
 

--- a/laravel/resources/views/livewire/chat/chat-index.blade.php
+++ b/laravel/resources/views/livewire/chat/chat-index.blade.php
@@ -30,11 +30,10 @@
     {{-- ===== CHAT TAB CONTENT ===== --}}
     <div x-show="activeTab === 'chat'" class="flex w-full h-full overflow-hidden">
         @if(! empty($pendingConversationIds))
-            {{-- Polling interval 15s: setelah streaming aktif (#189), polling bukan lagi jalur utama.
-                 Streaming mengirim 'done' event dan trigger refreshPendingChatState() langsung.
-                 15s hanya sebagai safety net jika stream gagal di tengah jalan.
-                 Rollback: ubah wire:poll.15s kembali ke wire:poll.3s --}}
-            <div wire:poll.15s="refreshPendingChatState" class="hidden" aria-hidden="true"></div>
+            {{-- Polling 3s: jalur utama untuk mendeteksi assistant message yang sudah selesai dipersist.
+                 GenerateChatResponse tidak dispatch event setelah selesai, sehingga polling tetap
+                 dibutuhkan sebagai satu-satunya mekanisme refresh. --}}
+            <div wire:poll.3s="refreshPendingChatState" class="hidden" aria-hidden="true"></div>
         @endif
 
         <!-- LEFT SIDEBAR: Chat History -->

--- a/laravel/resources/views/livewire/chat/chat-index.blade.php
+++ b/laravel/resources/views/livewire/chat/chat-index.blade.php
@@ -30,7 +30,11 @@
     {{-- ===== CHAT TAB CONTENT ===== --}}
     <div x-show="activeTab === 'chat'" class="flex w-full h-full overflow-hidden">
         @if(! empty($pendingConversationIds))
-            <div wire:poll.3s="refreshPendingChatState" class="hidden" aria-hidden="true"></div>
+            {{-- Polling interval 15s: setelah streaming aktif (#189), polling bukan lagi jalur utama.
+                 Streaming mengirim 'done' event dan trigger refreshPendingChatState() langsung.
+                 15s hanya sebagai safety net jika stream gagal di tengah jalan.
+                 Rollback: ubah wire:poll.15s kembali ke wire:poll.3s --}}
+            <div wire:poll.15s="refreshPendingChatState" class="hidden" aria-hidden="true"></div>
         @endif
 
         <!-- LEFT SIDEBAR: Chat History -->

--- a/laravel/resources/views/livewire/chat/partials/chat-right-sidebar.blade.php
+++ b/laravel/resources/views/livewire/chat/partials/chat-right-sidebar.blade.php
@@ -37,7 +37,10 @@
         @endif
     </div>
 
-    <div class="flex-1 overflow-y-auto px-4 pt-4" @if($hasDocumentsInProgress) wire:poll.3s="loadAvailableDocuments" @else wire:poll.20s="loadAvailableDocuments" @endif>
+    {{-- Polling interval: 5s saat ada dokumen processing (turun dari 3s), 20s saat idle.
+         Preview generation memakan 5-15 detik, poll 3s terlalu agresif.
+         Rollback: ubah wire:poll.5s kembali ke wire:poll.3s --}}
+    <div class="flex-1 overflow-y-auto px-4 pt-4" @if($hasDocumentsInProgress) wire:poll.5s="loadAvailableDocuments" @else wire:poll.20s="loadAvailableDocuments" @endif>
           <div class="mb-4">
               @php
                   $readyDocumentIds = $availableDocuments->where('status', 'ready')->pluck('id')->map(fn ($id) => (int) $id)->toArray();

--- a/laravel/resources/views/livewire/documents/document-viewer.blade.php
+++ b/laravel/resources/views/livewire/documents/document-viewer.blade.php
@@ -217,7 +217,9 @@
                                 </p>
                             </div>
                         @else
-                            <div wire:poll.3s
+                            {{-- Poll 5s: preview generation memakan 5-15 detik, 3s terlalu agresif.
+                                 Rollback: ubah wire:poll.5s kembali ke wire:poll.3s --}}
+                            <div wire:poll.5s
                                  class="flex flex-col items-center justify-center h-full p-8 text-center gap-3">
                                 <span class="h-6 w-6 rounded-full border-2 border-stone-400 border-t-transparent animate-spin"></span>
                                 <p class="text-sm text-gray-600 dark:text-gray-300">

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -496,7 +496,7 @@ class ChatUiTest extends TestCase
             ->assertSee('h-3 w-3 shrink-0 rounded-full border', false)
             ->assertSee('min-w-0 flex-1 truncate', false)
             ->assertSee('bg-sky-500', false)
-            ->assertSee('wire:poll.15s="refreshPendingChatState"', false)
+            ->assertSee('wire:poll.3s="refreshPendingChatState"', false)
             ->assertSee('navigateToConversation($event,', false)
             ->assertSee('navigateToNewChat($event)', false)
             ->assertSee('chat-history-item', false)

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -496,7 +496,7 @@ class ChatUiTest extends TestCase
             ->assertSee('h-3 w-3 shrink-0 rounded-full border', false)
             ->assertSee('min-w-0 flex-1 truncate', false)
             ->assertSee('bg-sky-500', false)
-            ->assertSee('wire:poll.3s="refreshPendingChatState"', false)
+            ->assertSee('wire:poll.15s="refreshPendingChatState"', false)
             ->assertSee('navigateToConversation($event,', false)
             ->assertSee('navigateToNewChat($event)', false)
             ->assertSee('chat-history-item', false)


### PR DESCRIPTION
## Summary

Closes #194

Mengurangi beban Livewire polling untuk dokumen sidebar dan preview viewer. Chat polling (`refreshPendingChatState`) **tidak diubah** karena `GenerateChatResponse` tidak dispatch event setelah selesai — polling tetap satu-satunya jalur refresh untuk chat.

## Perubahan

### 1. `chat-right-sidebar.blade.php` — `wire:poll.3s` → `wire:poll.5s` (saat processing)
- Preview generation memakan 5-15 detik, poll 3s terlalu agresif
- Poll 20s saat idle tetap tidak berubah
- **Rollback:** ubah `wire:poll.5s` → `wire:poll.3s`

### 2. `document-viewer.blade.php` — `wire:poll.3s` → `wire:poll.5s` (saat preview loading)
- Konsisten dengan sidebar — preview generation tidak butuh poll setiap 3s
- **Rollback:** ubah `wire:poll.5s` → `wire:poll.3s`

### Tidak Diubah
- `chat-index.blade.php` — `wire:poll.3s="refreshPendingChatState"` tetap 3s. `GenerateChatResponse` tidak dispatch event setelah `saveAssistantMessage`, sehingga polling adalah satu-satunya jalur refresh. Mengubah ke 15s akan memperburuk latency hingga 15 detik. Push/event-based refresh menjadi scope PR terpisah.

## Catatan Runtime

Issue ini juga menyebut evaluasi `php -S` vs PHP-FPM + Caddy/Nginx atau Octane. Ini adalah keputusan infrastruktur yang membutuhkan metrik production nyata dan rencana deploy terpisah. PR ini hanya mencakup perubahan polling interval yang aman dan reversible.

## Test

- `ChatUiTest.php` assertion tetap `wire:poll.3s="refreshPendingChatState"` — tidak berubah dari main
- 38 ChatUiTest pass, 0 regresi