### PR TITLE
[codex] Fix runtime chat/document race bugs

### DIFF
--- a/issue/issue-201-runtime-chat-document-bugfix.md
+++ b/issue/issue-201-runtime-chat-document-bugfix.md
@@ -1,0 +1,60 @@
+# Issue 201 Runtime Chat/Document Bugfix
+
+## Latar Belakang
+GitHub issue #201 mencatat bug runtime dan data integrity pada chat streaming, cleanup cloud storage, preview job dokumen, dan ordering pesan. Perbaikan harus kecil, terarah, dan tetap mempertahankan fallback job chat yang sudah ada.
+
+## Tujuan
+- Mencegah duplicate AI runner pada race stream claim.
+- Menghapus `cloud_storage_files` terkait saat document atau conversation dihapus.
+- Membuat preview job aman ketika document sudah hard-deleted sebelum job diproses.
+- Membuat urutan pesan stabil saat `created_at` sama.
+
+## Ruang Lingkup
+- Laravel chat orchestration dan stream controller.
+- Delete document dan delete conversation cleanup.
+- Render document preview job guard.
+- Targeted feature/unit tests untuk perilaku di atas.
+
+## Di Luar Scope
+- Technical debt issue #202: dual OTP path, MemoCanvas legacy, ProcessDocument fallback, SOURCES parser hardening, memo version token binding.
+- Perubahan Python AI.
+- Refactor besar struktur chat/document.
+
+## Area / File Terkait
+- `laravel/app/Services/ChatOrchestrationService.php`
+- `laravel/app/Http/Controllers/Chat/ChatStreamController.php`
+- `laravel/app/Livewire/Chat/ChatIndex.php`
+- `laravel/app/Services/DocumentLifecycleService.php`
+- `laravel/app/Jobs/RenderDocumentPreview.php`
+- `laravel/tests/Feature/Chat/ChatStreamTest.php`
+- `laravel/tests/Feature/Documents/DocumentDeletionTest.php`
+- `laravel/tests/Feature/Jobs/ProcessDocumentTest.php`
+
+## Risiko
+- Stream claim harus tetap membiarkan job fallback recover jika stream tidak pernah connect atau gagal.
+- Delete conversation harus menghapus cloud rows sebelum message rows hilang.
+- Tests queue/model serialization perlu memverifikasi behavior tanpa membuat test brittle terhadap internal Laravel queue.
+
+## Langkah Implementasi
+1. Pisahkan pembuatan intent dan acquisition runner stream.
+2. Gunakan cache lock saat transisi claim ke `active`.
+3. Update caller: `sendMessage()` membuat intent, `ChatStreamController` acquire runner.
+4. Tambahkan cleanup `cloud_storage_files` untuk document dan conversation delete.
+5. Tambahkan `deleteWhenMissingModels` dan guard `failed()` pada `RenderDocumentPreview`.
+6. Tambahkan tie-break `orderBy('id')` untuk load pesan.
+7. Tambahkan atau update tests relevan.
+
+## Rencana Test
+- Jalankan targeted tests chat stream claim.
+- Jalankan targeted tests document deletion/cloud storage cleanup.
+- Jalankan targeted tests process/preview job.
+- Jalankan targeted test untuk ordering pesan.
+- Jika targeted tests stabil, jalankan suite Laravel relevan atau full `php artisan test`.
+
+## Kriteria Selesai
+- Duplicate stream tidak memanggil AI dua kali.
+- Job fallback tetap defer saat claim aktif.
+- Delete document/conversation tidak meninggalkan cloud rows.
+- Preview job aman untuk missing document.
+- Message ordering deterministic.
+- Tests relevan lulus.

--- a/laravel/app/Http/Controllers/Chat/ChatStreamController.php
+++ b/laravel/app/Http/Controllers/Chat/ChatStreamController.php
@@ -121,7 +121,7 @@ class ChatStreamController extends Controller
         Conversation $conversation,
         \App\Models\User $user,
     ): void {
-        $streamClaimKey = $orchestrator->acquireStreamClaim($conversationId);
+        $streamClaimKey = $orchestrator->acquireStreamRunner($conversationId);
         if ($streamClaimKey === null) {
             // Runner lain (job/stream lain) sudah claim latest user message.
             $this->sendSseEvent('done', '1');

--- a/laravel/app/Jobs/RenderDocumentPreview.php
+++ b/laravel/app/Jobs/RenderDocumentPreview.php
@@ -19,6 +19,8 @@ class RenderDocumentPreview implements ShouldBeUniqueUntilProcessing, ShouldQueu
 
     public int $timeout = 300;
 
+    public bool $deleteWhenMissingModels = true;
+
     public function __construct(public Document $document)
     {
         $this->onQueue('document-previews');
@@ -54,12 +56,23 @@ class RenderDocumentPreview implements ShouldBeUniqueUntilProcessing, ShouldQueu
 
     public function failed(\Throwable $exception): void
     {
-        $this->document->forceFill([
+        $fresh = $this->document->fresh();
+
+        if ($fresh === null) {
+            logger()->info('RenderDocumentPreview failed hook skipped — document already deleted', [
+                'document_id' => $this->document->id,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return;
+        }
+
+        $fresh->forceFill([
             'preview_status' => Document::PREVIEW_STATUS_FAILED,
         ])->save();
 
         logger()->error('RenderDocumentPreview job permanently failed', [
-            'document_id' => $this->document->id,
+            'document_id' => $fresh->id,
             'error' => $exception->getMessage(),
         ]);
     }

--- a/laravel/app/Livewire/Chat/ChatIndex.php
+++ b/laravel/app/Livewire/Chat/ChatIndex.php
@@ -147,7 +147,8 @@ class ChatIndex extends Component
         $conversation = Conversation::where('id', $id)
             ->where('user_id', Auth::id())
             ->with(['messages' => function ($query) {
-                $query->orderBy('created_at', 'asc');
+                $query->orderBy('created_at', 'asc')
+                    ->orderBy('id', 'asc');
             }])
             ->firstOrFail();
 
@@ -552,10 +553,18 @@ class ChatIndex extends Component
             ->first();
 
         if ($conversation) {
-            // Delete all messages first
-            $conversation->messages()->delete();
-            // Delete the conversation
-            $conversation->delete();
+            DB::transaction(function () use ($conversation) {
+                $messageIds = $conversation->messages()->pluck('id');
+
+                if ($messageIds->isNotEmpty()) {
+                    CloudStorageFile::query()
+                        ->where('local_type', Message::class)
+                        ->whereIn('local_id', $messageIds)
+                        ->delete();
+                }
+
+                $conversation->delete();
+            });
 
             // If we deleted the current conversation, reset
             if ($this->currentConversationId == $id) {
@@ -643,10 +652,9 @@ class ChatIndex extends Component
         $this->loadConversations();
         $this->dispatch('conversation-activated', id: $conversationIdForRequest);
 
-        // Acquire stream claim as early as possible (right after user message is
-        // persisted) so background job fallback can observe active stream intent
-        // even before EventSource is fully connected.
-        $orchestrator->acquireStreamClaim($conversationIdForRequest);
+        // Create stream intent as early as possible so the background job
+        // fallback can defer while EventSource is still connecting.
+        $orchestrator->createStreamIntent($conversationIdForRequest);
         $this->streamingConversationId = $conversationIdForRequest;
 
         GenerateChatResponse::dispatch(

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -314,43 +314,53 @@ class ChatOrchestrationService
         return sprintf('chat:stream-claim:conversation:%d:user-message:%d', $conversationId, (int) $latestUserMessage->id);
     }
 
-    /**
-     * Acquire or adopt a stream claim for the latest user message.
-     *
-     * Two-state claim lifecycle:
-     *   - 'intent'  : created by sendMessage() before EventSource opens.
-     *                 Signals to the fallback job that a stream is expected.
-     *   - 'active'  : upgraded by executeStream() when it adopts the intent.
-     *                 Duplicate streams that see 'active' are rejected.
-     *
-     * sendMessage() always calls this to create an 'intent' claim.
-     * executeStream() calls this to adopt 'intent' → 'active', or create
-     * 'active' directly if no prior intent exists.
-     * If the claim is already 'active' (duplicate stream), returns null.
-     */
-    public function acquireStreamClaim(int $conversationId): ?string
+    public function createStreamIntent(int $conversationId): ?string
     {
         $claimKey = $this->streamClaimKeyForLatestUserMessage($conversationId);
         if ($claimKey === null) {
             return null;
         }
 
-        $current = Cache::get($claimKey);
+        Cache::add($claimKey, 'intent', now()->addSeconds(self::STREAM_CLAIM_TTL_SECONDS));
 
-        if ($current === null) {
-            // No claim yet — create intent (sendMessage path) or active (direct stream).
-            Cache::add($claimKey, 'intent', now()->addSeconds(self::STREAM_CLAIM_TTL_SECONDS));
-            return $claimKey;
+        return $claimKey;
+    }
+
+    /**
+     * Atomically acquire the single stream runner slot for the latest user
+     * message. The stream can either adopt a sendMessage intent or create an
+     * active claim directly when a stream request reaches the server first.
+     */
+    public function acquireStreamRunner(int $conversationId): ?string
+    {
+        $claimKey = $this->streamClaimKeyForLatestUserMessage($conversationId);
+        if ($claimKey === null) {
+            return null;
         }
 
-        if ($current === 'intent') {
-            // Adopt intent → upgrade to active (stream runner path).
-            Cache::put($claimKey, 'active', now()->addSeconds(self::STREAM_CLAIM_TTL_SECONDS));
-            return $claimKey;
+        $lock = Cache::lock($claimKey.':lock', 5);
+
+        if (! $lock->get()) {
+            return null;
         }
 
-        // Already 'active' — duplicate stream, reject.
-        return null;
+        try {
+            $current = Cache::get($claimKey);
+
+            if ($current === 'active') {
+                return null;
+            }
+
+            if ($current === null || $current === 'intent') {
+                Cache::put($claimKey, 'active', now()->addSeconds(self::STREAM_CLAIM_TTL_SECONDS));
+
+                return $claimKey;
+            }
+
+            return null;
+        } finally {
+            $lock->release();
+        }
     }
 
     public function releaseStreamClaim(?string $claimKey): void

--- a/laravel/app/Services/DocumentLifecycleService.php
+++ b/laravel/app/Services/DocumentLifecycleService.php
@@ -304,6 +304,7 @@ class DocumentLifecycleService
         $this->deleteDocumentVectors($document);
         $this->deleteDocumentFile($document);
         $this->deleteDocumentPreview($document);
+        $document->cloudStorageFiles()->delete();
     }
 
     private function deleteDocumentPreview(Document $document): void

--- a/laravel/tests/Feature/Chat/ChatStreamTest.php
+++ b/laravel/tests/Feature/Chat/ChatStreamTest.php
@@ -875,7 +875,10 @@ class ChatStreamTest extends TestCase
         ]);
 
         $orchestrator = app(ChatOrchestrationService::class);
-        $claimKey = $orchestrator->acquireStreamClaim($conversation->id);
+        $intentKey = $orchestrator->createStreamIntent($conversation->id);
+        $this->assertNotNull($intentKey);
+
+        $claimKey = $orchestrator->acquireStreamRunner($conversation->id);
         $this->assertNotNull($claimKey);
 
         $aiCalled = false;
@@ -1048,7 +1051,7 @@ class ChatStreamTest extends TestCase
 
         $orchestrator = app(ChatOrchestrationService::class);
 
-        $preClaimKey = $orchestrator->acquireStreamClaim($conversation->id);
+        $preClaimKey = $orchestrator->createStreamIntent($conversation->id);
         $this->assertNotNull($preClaimKey, 'Pre-claim harus berhasil dibuat');
 
         $aiCalled = false;
@@ -1105,17 +1108,42 @@ class ChatStreamTest extends TestCase
         $orchestrator = app(ChatOrchestrationService::class);
 
         // First: intent claim (sendMessage path)
-        $intentKey = $orchestrator->acquireStreamClaim($conversation->id);
+        $intentKey = $orchestrator->createStreamIntent($conversation->id);
         $this->assertNotNull($intentKey, 'Intent claim harus berhasil');
 
         // Second: stream adopts intent → active
-        $activeKey = $orchestrator->acquireStreamClaim($conversation->id);
+        $activeKey = $orchestrator->acquireStreamRunner($conversation->id);
         $this->assertNotNull($activeKey, 'Stream pertama harus bisa adopt intent');
         $this->assertSame($intentKey, $activeKey);
 
         // Third: duplicate stream tries to adopt active → rejected
-        $duplicateKey = $orchestrator->acquireStreamClaim($conversation->id);
+        $duplicateKey = $orchestrator->acquireStreamRunner($conversation->id);
         $this->assertNull($duplicateKey, 'Stream duplikat harus ditolak saat claim sudah active');
+
+        $orchestrator->releaseStreamClaim($activeKey);
+    }
+
+    public function test_direct_stream_claim_becomes_active_and_rejects_duplicate_runner(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Direct stream claim test',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan direct stream',
+        ]);
+
+        $orchestrator = app(ChatOrchestrationService::class);
+
+        $activeKey = $orchestrator->acquireStreamRunner($conversation->id);
+        $this->assertNotNull($activeKey, 'Stream pertama harus membuat active claim langsung');
+
+        $duplicateKey = $orchestrator->acquireStreamRunner($conversation->id);
+        $this->assertNull($duplicateKey, 'Stream kedua harus ditolak setelah direct stream active');
 
         $orchestrator->releaseStreamClaim($activeKey);
     }
@@ -1141,7 +1169,7 @@ class ChatStreamTest extends TestCase
         $orchestrator = app(ChatOrchestrationService::class);
 
         // Simulate sendMessage() creating intent claim
-        $claimKey = $orchestrator->acquireStreamClaim($conversation->id);
+        $claimKey = $orchestrator->createStreamIntent($conversation->id);
         $this->assertNotNull($claimKey);
         $this->assertTrue($orchestrator->hasActiveStreamClaim($conversation->id));
 

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Chat;
 use App\Jobs\GenerateChatResponse;
 use App\Jobs\ProcessDocument;
 use App\Livewire\Chat\ChatIndex;
+use App\Models\CloudStorageFile;
 use App\Models\Conversation;
 use App\Models\Document;
 use App\Models\Message;
@@ -721,6 +722,74 @@ class ChatUiTest extends TestCase
             'role' => 'assistant',
             'content' => 'Maaf, jawaban gagal diproses. Silakan coba kirim ulang.',
         ]);
+    }
+
+    public function test_delete_conversation_removes_message_cloud_storage_files(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Conversation dengan export',
+        ]);
+        $message = Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban yang pernah diexport',
+        ]);
+        CloudStorageFile::create([
+            'user_id' => $user->id,
+            'provider' => 'google_drive',
+            'direction' => CloudStorageFile::DIRECTION_EXPORT,
+            'local_type' => Message::class,
+            'local_id' => $message->id,
+            'external_id' => 'drive-message-delete-test',
+            'name' => 'jawaban.pdf',
+            'mime_type' => 'application/pdf',
+            'synced_at' => now(),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(ChatIndex::class, ['id' => $conversation->id])
+            ->call('deleteConversation', $conversation->id);
+
+        $this->assertDatabaseMissing('cloud_storage_files', [
+            'local_type' => Message::class,
+            'local_id' => $message->id,
+        ]);
+        $this->assertDatabaseMissing('messages', ['id' => $message->id]);
+        $this->assertDatabaseMissing('conversations', ['id' => $conversation->id]);
+    }
+
+    public function test_load_conversation_orders_messages_by_id_when_timestamps_match(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Same timestamp ordering',
+        ]);
+        $timestamp = now()->startOfSecond();
+        $userMessage = Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Pertanyaan timestamp sama',
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
+        $assistantMessage = Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => 'Jawaban timestamp sama',
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
+
+        $component = Livewire::actingAs($user)
+            ->test(ChatIndex::class, ['id' => $conversation->id]);
+
+        $this->assertSame(
+            [$userMessage->id, $assistantMessage->id],
+            array_column($component->get('messages'), 'id')
+        );
     }
 
     public function test_generate_chat_response_saves_error_message_when_ai_service_returns_sentinel(): void

--- a/laravel/tests/Feature/Documents/DocumentDeletionTest.php
+++ b/laravel/tests/Feature/Documents/DocumentDeletionTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Documents;
 
 use App\Livewire\Chat\ChatIndex;
+use App\Models\CloudStorageFile;
 use App\Models\Document;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -33,6 +34,17 @@ class DocumentDeletionTest extends TestCase
             'file_size_bytes' => 123,
             'status' => 'ready',
         ]);
+        CloudStorageFile::create([
+            'user_id' => $user->id,
+            'provider' => 'google_drive',
+            'direction' => CloudStorageFile::DIRECTION_IMPORT,
+            'local_type' => Document::class,
+            'local_id' => $document->id,
+            'external_id' => 'drive-document-delete-test',
+            'name' => 'delete_chat.pdf',
+            'mime_type' => 'application/pdf',
+            'synced_at' => now(),
+        ]);
 
         Http::fake([
             '*' => Http::response(['message' => 'success'], 200),
@@ -43,6 +55,10 @@ class DocumentDeletionTest extends TestCase
             ->call('deleteDocument', $document->id);
 
         $this->assertDatabaseMissing('documents', ['id' => $document->id]);
+        $this->assertDatabaseMissing('cloud_storage_files', [
+            'local_type' => Document::class,
+            'local_id' => $document->id,
+        ]);
         Storage::disk('local')->assertMissing($filePath);
         $component->assertSee('Dokumen berhasil dihapus.');
         Http::assertSent(function ($request) use ($document, $user) {

--- a/laravel/tests/Feature/Jobs/ProcessDocumentTest.php
+++ b/laravel/tests/Feature/Jobs/ProcessDocumentTest.php
@@ -515,4 +515,47 @@ class ProcessDocumentTest extends TestCase
 
         $this->assertFalse($rendererCalled, 'Renderer must not be called when preview is already ready.');
     }
+
+    public function test_render_preview_job_discards_missing_document_models(): void
+    {
+        $user = User::factory()->create();
+
+        $document = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'missing-preview.pdf',
+            'original_name' => 'missing-preview.pdf',
+            'file_path' => 'documents/'.$user->id.'/missing-preview.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 123,
+            'status' => 'ready',
+            'preview_status' => Document::PREVIEW_STATUS_PENDING,
+        ]);
+
+        $job = new RenderDocumentPreview($document);
+
+        $this->assertTrue($job->deleteWhenMissingModels);
+    }
+
+    public function test_render_preview_failed_hook_skips_deleted_document(): void
+    {
+        $user = User::factory()->create();
+
+        $document = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'deleted-preview.pdf',
+            'original_name' => 'deleted-preview.pdf',
+            'file_path' => 'documents/'.$user->id.'/deleted-preview.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 123,
+            'status' => 'ready',
+            'preview_status' => Document::PREVIEW_STATUS_PENDING,
+        ]);
+
+        $job = new RenderDocumentPreview($document);
+        $document->delete();
+
+        $job->failed(new \RuntimeException('Preview render failed after delete'));
+
+        $this->assertDatabaseMissing('documents', ['id' => $document->id]);
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes the chat stream claim race by splitting stream intent creation from atomic stream runner acquisition.
- Cleans up `cloud_storage_files` for deleted documents and exported chat messages when conversations are deleted.
- Makes `RenderDocumentPreview` discard missing models and skip failed-hook writes after document deletion.
- Adds deterministic message ordering for same-timestamp chat messages.
- Adds a local implementation plan in `issue/issue-201-runtime-chat-document-bugfix.md`.

## Root Cause
The previous stream claim method mixed two responsibilities: creating an intent for the fallback job and adopting that claim as an active stream runner. The cache read/write transition was not atomic, so duplicate stream requests could both proceed to the Python AI service. Separately, polymorphic cloud storage rows had no FK cascade, preview jobs could fail on missing serialized models, and chat message eager loading had no ID tie-breaker.

## Validation
- `php artisan test tests/Feature/Chat/ChatStreamTest.php`
- `php artisan test tests/Feature/Documents/DocumentDeletionTest.php tests/Feature/Chat/ChatUiTest.php tests/Feature/Jobs/ProcessDocumentTest.php`
- `php artisan test`
- `git diff --check`
- `php -l` on changed PHP files

Closes #201
