### PR TITLE
[codex] Fix chat fallback and vector cleanup bugs

### DIFF
--- a/issue/issue-205-fix-chat-rag-stream-audit-bugs-2026-05-18.md
+++ b/issue/issue-205-fix-chat-rag-stream-audit-bugs-2026-05-18.md
@@ -1,0 +1,60 @@
+# Fix Chat Error, RAG Cleanup, and Stream Metadata Edge Cases
+
+## Latar Belakang
+Audit bug menemukan tiga area yang masih perlu diperketat:
+- Python chat cascade masih dapat mengirim pesan outage sebagai jawaban assistant normal ketika tidak ada model atau semua model gagal.
+- Cleanup legacy vector dokumen masih memakai filter filename yang terlalu luas pada jalur user delete.
+- Parser metadata stream Laravel masih dapat menghapus teks literal yang kebetulan memuat marker internal seperti `[MODEL:...]`.
+
+GitHub Issue: https://github.com/Hasbi1605/ISTA-AI/issues/205
+
+## Tujuan
+- Error infrastruktur LLM tersimpan dan tampil sebagai error, bukan jawaban normal.
+- Cleanup legacy Chroma hanya menghapus chunk legacy tanpa `document_id`.
+- Marker stream internal tidak memakan konten jawaban yang sah.
+- Regression test menutup ketiga perilaku.
+
+## Ruang Lingkup
+- Update `python-ai/app/services/llm_streaming.py` untuk sentinel error cascade.
+- Update `python-ai/app/services/rag_ingest.py` untuk cleanup legacy berbasis ID hasil metadata scan.
+- Update `laravel/app/Services/ChatOrchestrationService.php` untuk parsing marker stream yang lebih ketat.
+- Tambah/update test Python dan Laravel yang relevan.
+
+## Di Luar Scope
+- Mengubah provider/model fallback.
+- Refactor besar arsitektur streaming.
+- Mengubah UI chat selain efek dari event/error yang sudah ada.
+- Migrasi data Chroma existing.
+
+## Area / File Terkait
+- `python-ai/app/services/llm_streaming.py`
+- `python-ai/tests/test_llm_streaming.py`
+- `python-ai/app/services/rag_ingest.py`
+- `python-ai/tests/test_rag_ingest_delete.py`
+- `laravel/app/Services/ChatOrchestrationService.php`
+- Test Laravel chat orchestration/stream metadata.
+
+## Risiko
+- Sentinel error harus tetap kompatibel dengan Laravel `AIService::ERROR_SENTINEL`.
+- Cleanup legacy harus tetap membersihkan chunk lama tanpa `document_id`, tetapi tidak boleh menghapus chunk dokumen baru yang punya `document_id`.
+- Parser marker tidak boleh memecah metadata yang memang dikirim Python di awal chunk.
+
+## Langkah Implementasi
+1. Tambahkan kontrak sentinel di Python cascade ketika model list kosong atau semua model gagal.
+2. Tambahkan test Python untuk output sentinel pada dua skenario tersebut.
+3. Ganti cleanup legacy filename broad delete menjadi metadata scan dan delete by IDs untuk item tanpa `document_id`.
+4. Update test delete RAG agar membuktikan chunk dengan `document_id` berbeda tidak ikut terhapus.
+5. Perketat parsing `[MODEL:]` agar hanya diproses saat marker berada di awal buffer/chunk metadata.
+6. Tambahkan test Laravel untuk literal `[MODEL:...]` di tengah jawaban.
+7. Jalankan targeted test Python dan Laravel.
+
+## Rencana Test
+- `cd python-ai && source venv/bin/activate && pytest tests/test_llm_streaming.py tests/test_rag_ingest_delete.py`
+- `cd laravel && php artisan test --filter=ChatStreamTest`
+- Jika diperlukan, jalankan subset Laravel tambahan untuk `ChatOrchestrationService`.
+
+## Kriteria Selesai
+- Ketiga bug/regression tertutup oleh test.
+- Targeted tests lulus.
+- Branch dipush ke GitHub.
+- Draft PR dibuat dan mengacu ke issue #205.

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -3,16 +3,18 @@
 namespace App\Services;
 
 use App\Models\Conversation;
-use App\Models\Message;
 use App\Models\Document;
+use App\Models\Message;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\QueryException;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 class ChatOrchestrationService
 {
     private const STREAM_CLAIM_TTL_SECONDS = 240;
+
     private const SANITIZE_REPLACEMENTS = [
         '/\bchunks?\b/i' => 'bagian dokumen',
         '/\bchunk(?:ing|ed)?\b/i' => 'bagian dokumen',
@@ -25,11 +27,12 @@ class ChatOrchestrationService
 
     public function createConversationIfNeeded(?int $currentConversationId, string $prompt): int
     {
-        if (!$currentConversationId) {
+        if (! $currentConversationId) {
             $conversation = Conversation::create([
                 'user_id' => Auth::id(),
-                'title' => substr($prompt, 0, 50) . '...'
+                'title' => substr($prompt, 0, 50).'...',
             ]);
+
             return $conversation->id;
         }
 
@@ -49,7 +52,7 @@ class ChatOrchestrationService
         $userMessage = Message::create([
             'conversation_id' => $conversationId,
             'role' => 'user',
-            'content' => $prompt
+            'content' => $prompt,
         ]);
 
         return $userMessage->toArray();
@@ -173,7 +176,7 @@ class ChatOrchestrationService
 
     public function getSourcePolicy(?array $documentFilenames): string
     {
-        return !empty($documentFilenames) ? 'document_context' : 'hybrid_realtime_auto';
+        return ! empty($documentFilenames) ? 'document_context' : 'hybrid_realtime_auto';
     }
 
     public function shouldAllowAutoRealtimeWeb(?array $documentFilenames): bool
@@ -196,12 +199,13 @@ class ChatOrchestrationService
         $documentSources = [];
 
         foreach ($normalizedSources as $source) {
-            if (!empty($source['url'])) {
+            if (! empty($source['url'])) {
                 $webSources[] = $source;
+
                 continue;
             }
 
-            if (!empty($source['filename'])) {
+            if (! empty($source['filename'])) {
                 $documentSources[] = $source['filename'];
             }
         }
@@ -212,10 +216,10 @@ class ChatOrchestrationService
             return "\n\n---\nDokumen rujukan: **{$documentSources[0]}**";
         }
 
-        $lines = ["", "", "---", "**Rujukan:**"];
+        $lines = ['', '', '---', '**Rujukan:**'];
 
         foreach ($webSources as $source) {
-            $title = !empty($source['title']) ? $source['title'] : parse_url($source['url'], PHP_URL_HOST);
+            $title = ! empty($source['title']) ? $source['title'] : parse_url($source['url'], PHP_URL_HOST);
             $lines[] = "- [{$title}]({$source['url']})";
         }
 
@@ -269,6 +273,7 @@ class ChatOrchestrationService
     {
         $cleanContent = preg_replace('/\[SOURCES:\[.+?\]\]/s', '', $fullResponse);
         $cleanContent = $this->sanitizeAssistantOutput((string) $cleanContent);
+
         return trim($cleanContent);
     }
 
@@ -384,6 +389,7 @@ class ChatOrchestrationService
         }
 
         $value = Cache::get($claimKey);
+
         return $value === 'intent' || $value === 'active';
     }
 
@@ -398,8 +404,8 @@ class ChatOrchestrationService
             // terakhir agar baik SSE stream maupun background job tidak bisa
             // menyimpan dua assistant message untuk satu user message yang sama.
             // Ini adalah single source of truth untuk race condition di kedua jalur.
-            return \Illuminate\Support\Facades\DB::transaction(function () use ($conversationId, $content) {
-                $latestUserMessage = \App\Models\Message::query()
+            return DB::transaction(function () use ($conversationId, $content) {
+                $latestUserMessage = Message::query()
                     ->where('conversation_id', $conversationId)
                     ->where('role', 'user')
                     ->latest('id')
@@ -410,7 +416,7 @@ class ChatOrchestrationService
                 // - jika sukses (is_error=false): skip (idempotent)
                 // - jika error (is_error=true): upgrade menjadi jawaban sukses
                 if ($latestUserMessage !== null) {
-                    $latestAssistant = \App\Models\Message::query()
+                    $latestAssistant = Message::query()
                         ->where('conversation_id', $conversationId)
                         ->where('role', 'assistant')
                         ->where('id', '>', $latestUserMessage->id)
@@ -456,8 +462,8 @@ class ChatOrchestrationService
             // tidak duplikat jika stream dan job keduanya gagal bersamaan.
             // Jika sudah ada assistant message (normal atau error) setelah user message
             // terakhir, skip — ini mencegah error stream menimpa jawaban sukses dari job.
-            return \Illuminate\Support\Facades\DB::transaction(function () use ($conversationId, $content) {
-                $latestUserMessage = \App\Models\Message::query()
+            return DB::transaction(function () use ($conversationId, $content) {
+                $latestUserMessage = Message::query()
                     ->where('conversation_id', $conversationId)
                     ->where('role', 'user')
                     ->latest('id')
@@ -465,7 +471,7 @@ class ChatOrchestrationService
                     ->first();
 
                 if ($latestUserMessage !== null) {
-                    $latestAssistant = \App\Models\Message::query()
+                    $latestAssistant = Message::query()
                         ->where('conversation_id', $conversationId)
                         ->where('role', 'assistant')
                         ->where('id', '>', $latestUserMessage->id)
@@ -523,13 +529,13 @@ class ChatOrchestrationService
 
     public function extractStreamMetadata(string $chunk, string $buffer = ''): array
     {
-        $combined = $buffer . $chunk;
+        $combined = $buffer.$chunk;
         $modelName = null;
         $sources = null;
 
-        if (preg_match('/\[MODEL:(.+?)\]\n?/', $combined, $matches)) {
+        if (preg_match('/^\[MODEL:(.+?)\]\n?/', $combined, $matches)) {
             $modelName = trim((string) $matches[1]);
-            $combined = preg_replace('/\[MODEL:.+?\]\n?/', '', $combined, 1) ?? $combined;
+            $combined = preg_replace('/^\[MODEL:.+?\]\n?/', '', $combined, 1) ?? $combined;
         }
 
         [$combined, $sourcesBuffer, $parsedSources] = $this->extractSourcesMetadata($combined);
@@ -551,7 +557,7 @@ class ChatOrchestrationService
             $tail = substr($combined, $markerPos);
             $isComplete = preg_match('/^\[MODEL:(.+?)\]\n?/s', $tail) === 1;
 
-            if (!$isComplete) {
+            if ($markerPos === 0 && ! $isComplete) {
                 $nextBuffer = $tail;
                 $combined = substr($combined, 0, $markerPos);
                 break;
@@ -581,6 +587,7 @@ class ChatOrchestrationService
 
             if ($combined[$jsonStart] !== '[') {
                 $searchOffset = $jsonStart;
+
                 continue;
             }
 
@@ -595,6 +602,7 @@ class ChatOrchestrationService
 
             if ($combined[$jsonEnd + 1] !== ']') {
                 $searchOffset = $jsonEnd + 1;
+
                 continue;
             }
 
@@ -628,11 +636,13 @@ class ChatOrchestrationService
             if ($inString) {
                 if ($escape) {
                     $escape = false;
+
                     continue;
                 }
 
                 if ($char === '\\') {
                     $escape = true;
+
                     continue;
                 }
 
@@ -645,11 +655,13 @@ class ChatOrchestrationService
 
             if ($char === '"') {
                 $inString = true;
+
                 continue;
             }
 
             if ($char === '[') {
                 $depth++;
+
                 continue;
             }
 

--- a/laravel/tests/Unit/Services/ChatOrchestrationServiceTest.php
+++ b/laravel/tests/Unit/Services/ChatOrchestrationServiceTest.php
@@ -9,7 +9,7 @@ class ChatOrchestrationServiceTest extends TestCase
 {
     public function test_build_history_preserves_messages_without_injecting_system_prompt(): void
     {
-        $service = new ChatOrchestrationService();
+        $service = new ChatOrchestrationService;
 
         $messages = [
             ['role' => 'user', 'content' => 'Tolong ringkas agenda hari ini'],
@@ -26,7 +26,7 @@ class ChatOrchestrationServiceTest extends TestCase
 
     public function test_build_history_strips_database_fields_before_sending_to_ai(): void
     {
-        $service = new ChatOrchestrationService();
+        $service = new ChatOrchestrationService;
 
         $messages = [
             [
@@ -52,8 +52,12 @@ class ChatOrchestrationServiceTest extends TestCase
     public function test_build_history_drops_leading_assistant_after_truncation(): void
     {
         // When window boundary falls mid-pair, result must not start with assistant
-        $service = new class extends ChatOrchestrationService {
-            protected function maxHistoryMessages(): int { return 4; }
+        $service = new class extends ChatOrchestrationService
+        {
+            protected function maxHistoryMessages(): int
+            {
+                return 4;
+            }
         };
 
         // 6 messages: u1 a1 u2 a2 u3 a3
@@ -92,8 +96,12 @@ class ChatOrchestrationServiceTest extends TestCase
 
     public function test_build_history_does_not_drop_leading_user_message(): void
     {
-        $service = new class extends ChatOrchestrationService {
-            protected function maxHistoryMessages(): int { return 4; }
+        $service = new class extends ChatOrchestrationService
+        {
+            protected function maxHistoryMessages(): int
+            {
+                return 4;
+            }
         };
 
         $messages = [
@@ -116,8 +124,12 @@ class ChatOrchestrationServiceTest extends TestCase
     public function test_build_history_truncates_to_max_messages_keeping_most_recent(): void
     {
         // Use anonymous subclass to override maxHistoryMessages() without config()
-        $service = new class extends ChatOrchestrationService {
-            protected function maxHistoryMessages(): int { return 4; }
+        $service = new class extends ChatOrchestrationService
+        {
+            protected function maxHistoryMessages(): int
+            {
+                return 4;
+            }
         };
 
         $messages = [];
@@ -137,8 +149,12 @@ class ChatOrchestrationServiceTest extends TestCase
 
     public function test_build_history_does_not_truncate_when_within_limit(): void
     {
-        $service = new class extends ChatOrchestrationService {
-            protected function maxHistoryMessages(): int { return 20; }
+        $service = new class extends ChatOrchestrationService
+        {
+            protected function maxHistoryMessages(): int
+            {
+                return 20;
+            }
         };
 
         $messages = [
@@ -154,7 +170,7 @@ class ChatOrchestrationServiceTest extends TestCase
 
     public function test_single_document_source_uses_compact_reference_footer(): void
     {
-        $service = new ChatOrchestrationService();
+        $service = new ChatOrchestrationService;
 
         $footer = $service->sanitizeAndFormatSources([
             ['filename' => 'memo-rapat.pdf'],
@@ -165,7 +181,7 @@ class ChatOrchestrationServiceTest extends TestCase
 
     public function test_mixed_sources_use_adaptive_reference_block(): void
     {
-        $service = new ChatOrchestrationService();
+        $service = new ChatOrchestrationService;
 
         $footer = $service->sanitizeAndFormatSources([
             ['type' => 'web', 'title' => 'Portal Resmi', 'url' => 'https://example.com/resmi'],
@@ -181,7 +197,7 @@ class ChatOrchestrationServiceTest extends TestCase
 
     public function test_duplicate_sources_are_deduplicated_before_rendering(): void
     {
-        $service = new ChatOrchestrationService();
+        $service = new ChatOrchestrationService;
 
         $footer = $service->sanitizeAndFormatSources([
             ['type' => 'web', 'title' => 'Portal Resmi', 'url' => 'https://example.com/resmi'],
@@ -196,7 +212,7 @@ class ChatOrchestrationServiceTest extends TestCase
 
     public function test_extract_stream_metadata_buffers_split_sources_marker(): void
     {
-        $service = new ChatOrchestrationService();
+        $service = new ChatOrchestrationService;
 
         $firstPass = $service->extractStreamMetadata('Jawaban awal [SOURCES:[{"url":"https://example.com"', '');
 
@@ -215,7 +231,7 @@ class ChatOrchestrationServiceTest extends TestCase
 
     public function test_extract_stream_metadata_handles_source_strings_containing_brackets(): void
     {
-        $service = new ChatOrchestrationService();
+        $service = new ChatOrchestrationService;
         $sourcesJson = json_encode([
             [
                 'url' => 'https://example.com',
@@ -242,7 +258,7 @@ class ChatOrchestrationServiceTest extends TestCase
 
     public function test_extract_stream_metadata_removes_balanced_malformed_sources_without_throwing(): void
     {
-        $service = new ChatOrchestrationService();
+        $service = new ChatOrchestrationService;
 
         $result = $service->extractStreamMetadata(
             'Jawaban [SOURCES:[{"url":}]] selesai',
@@ -252,5 +268,22 @@ class ChatOrchestrationServiceTest extends TestCase
         $this->assertSame('Jawaban  selesai', $result[0]);
         $this->assertSame('', $result[1]);
         $this->assertNull($result[3]);
+    }
+
+    public function test_extract_stream_metadata_parses_model_marker_only_at_start(): void
+    {
+        $service = new ChatOrchestrationService;
+
+        $metadata = $service->extractStreamMetadata("[MODEL:Gemini]\nJawaban awal", '');
+
+        $this->assertSame('Jawaban awal', $metadata[0]);
+        $this->assertSame('', $metadata[1]);
+        $this->assertSame('Gemini', $metadata[2]);
+
+        $literal = $service->extractStreamMetadata('Jawaban menyebut [MODEL:Gemini] sebagai contoh.', '');
+
+        $this->assertSame('Jawaban menyebut [MODEL:Gemini] sebagai contoh.', $literal[0]);
+        $this->assertSame('', $literal[1]);
+        $this->assertNull($literal[2]);
     }
 }

--- a/python-ai/app/services/llm_streaming.py
+++ b/python-ai/app/services/llm_streaming.py
@@ -10,7 +10,9 @@ import litellm
 from app.env_utils import get_env
 
 logger = logging.getLogger(__name__)
+ERROR_SENTINEL = "[ISTA_AI_ERROR]"
 NATIVE_TEXT_PROVIDERS = {"gemini_native", "bedrock_converse"}
+AI_UNAVAILABLE_MESSAGE = "❌ Maaf, semua layanan AI sedang tidak tersedia. Silakan coba lagi nanti."
 
 # Suppress verbose litellm output.
 litellm.set_verbose = False
@@ -344,7 +346,7 @@ def stream_with_cascade(
 
     if total == 0:
         active_logger.error("❌ Tidak ada model chat yang tersedia.")
-        yield "❌ Maaf, semua layanan AI sedang tidak tersedia. Silakan coba lagi nanti."
+        yield ERROR_SENTINEL + AI_UNAVAILABLE_MESSAGE
         return
 
     for idx, model in enumerate(model_list, start=1):
@@ -397,4 +399,4 @@ def stream_with_cascade(
             continue
 
     active_logger.error("❌ Semua %d model gagal. Tidak ada respons yang bisa dikirim.", total)
-    yield "❌ Maaf, semua layanan AI sedang tidak tersedia. Silakan coba lagi nanti."
+    yield ERROR_SENTINEL + AI_UNAVAILABLE_MESSAGE

--- a/python-ai/app/services/rag_ingest.py
+++ b/python-ai/app/services/rag_ingest.py
@@ -554,7 +554,7 @@ def delete_document_vectors(
                 # Must NOT be used from ProcessDocument job cleanup — that job runs
                 # after the old document was deleted and a new document with the same
                 # filename may already have been uploaded.
-                vectorstore.delete(where={"$and": [{"filename": filename}, {"user_id": str(user_id)}]})
+                _delete_legacy_chunks_by_filename(vectorstore._collection, filename, str(user_id))
         else:
             vectorstore.delete(where={"$and": [{"filename": filename}, {"user_id": str(user_id)}]})
 
@@ -569,9 +569,7 @@ def delete_document_vectors(
                     "$and": [{"document_id": str(document_id)}, {"user_id": str(user_id)}, {"chunk_type": "parent"}],
                 })
                 if cleanup_legacy:
-                    raw_col.delete(where={
-                        "$and": [{"filename": filename}, {"user_id": str(user_id)}, {"chunk_type": "parent"}],
-                    })
+                    _delete_legacy_chunks_by_filename(raw_col, filename, str(user_id), chunk_type="parent")
             else:
                 raw_col.delete(where={
                     "$and": [{"filename": filename}, {"user_id": str(user_id)}, {"chunk_type": "parent"}],
@@ -585,3 +583,45 @@ def delete_document_vectors(
     except Exception as e:
         logger.error(f"❌ Error deleting vectors for {filename}: {str(e)}")
         return False, str(e)
+
+
+def _delete_legacy_chunks_by_filename(
+    collection,
+    filename: str,
+    user_id: str,
+    chunk_type: str | None = None,
+) -> int:
+    """Delete filename-scoped chunks only when they pre-date document_id metadata."""
+    where_conditions = [{"filename": filename}, {"user_id": str(user_id)}]
+    if chunk_type is not None:
+        where_conditions.append({"chunk_type": chunk_type})
+
+    where = {"$and": where_conditions}
+
+    try:
+        results = collection.get(where=where, include=["metadatas"])
+    except Exception as exc:
+        logger.warning("Legacy vector lookup skipped for %s user_id=%s: %s", filename, user_id, exc)
+        return 0
+
+    ids = results.get("ids", []) if isinstance(results, dict) else []
+    metadatas = results.get("metadatas", []) if isinstance(results, dict) else []
+    legacy_ids: list[str] = []
+
+    for chunk_id, metadata in zip(ids, metadatas):
+        if not isinstance(metadata, dict):
+            continue
+
+        if str(metadata.get("document_id") or "").strip() == "":
+            legacy_ids.append(str(chunk_id))
+
+    if legacy_ids:
+        collection.delete(ids=legacy_ids)
+        logger.info(
+            "✅ Legacy cleanup: deleted %d filename-only chunks for %s user_id=%s",
+            len(legacy_ids),
+            filename,
+            user_id,
+        )
+
+    return len(legacy_ids)

--- a/python-ai/tests/test_llm_streaming.py
+++ b/python-ai/tests/test_llm_streaming.py
@@ -57,6 +57,50 @@ def test_stream_with_cascade_prefers_configured_model_label(monkeypatch, model, 
     assert output[0] == expected_marker
 
 
+def test_stream_with_cascade_emits_error_sentinel_when_no_models_available():
+    from app.services import llm_streaming
+
+    output = list(
+        llm_streaming.stream_with_cascade(
+            messages=[{"role": "user", "content": "Halo"}],
+            model_list=[],
+        )
+    )
+
+    assert output == [llm_streaming.ERROR_SENTINEL + llm_streaming.AI_UNAVAILABLE_MESSAGE]
+
+
+def test_stream_with_cascade_emits_error_sentinel_when_all_models_fail(monkeypatch):
+    from app.services import llm_streaming
+
+    def fake_run_model(_model, _messages):
+        raise RuntimeError("provider unavailable")
+
+    monkeypatch.setattr(llm_streaming, "_run_model", fake_run_model)
+
+    output = list(
+        llm_streaming.stream_with_cascade(
+            messages=[{"role": "user", "content": "Halo"}],
+            model_list=[
+                {
+                    "label": "Primary",
+                    "provider": "litellm",
+                    "model_name": "primary-model",
+                    "api_key_env": "PRIMARY_TOKEN",
+                },
+                {
+                    "label": "Fallback",
+                    "provider": "litellm",
+                    "model_name": "fallback-model",
+                    "api_key_env": "FALLBACK_TOKEN",
+                },
+            ],
+        )
+    )
+
+    assert output == [llm_streaming.ERROR_SENTINEL + llm_streaming.AI_UNAVAILABLE_MESSAGE]
+
+
 def test_run_model_bedrock_converse_uses_bearer_token_and_parses_text(monkeypatch):
     from app.services import llm_streaming
 

--- a/python-ai/tests/test_rag_ingest_delete.py
+++ b/python-ai/tests/test_rag_ingest_delete.py
@@ -182,25 +182,63 @@ def test_strict_delete_does_not_delete_by_filename(monkeypatch):
 
 def test_legacy_cleanup_delete_removes_both_new_and_legacy_chunks(monkeypatch):
     """
-    Regression: when cleanup_legacy=True (user-initiated delete), both
-    document_id-based AND filename-based filters must be applied to clean
-    up legacy chunks that pre-date document_id tracking.
+    Regression: cleanup_legacy=True must remove strict document_id chunks and
+    filename-only legacy chunks, but must not broad-delete newer chunks that
+    share the same filename and already have a different document_id.
     """
     from app.services.rag_ingest import delete_document_vectors
 
     delete_calls: list = []
 
     class FakeCollection:
-        def delete(self, where):
-            delete_calls.append({"type": "parent", "where": where})
+        def __init__(self, collection_name):
+            self.collection_name = collection_name
+
+        def get(self, where=None, include=None):
+            delete_calls.append({
+                "type": self.collection_name,
+                "op": "get",
+                "where": where,
+                "include": include,
+            })
+
+            if "parent" in self.collection_name.lower():
+                return {
+                    "ids": ["legacy-parent", "new-parent"],
+                    "metadatas": [
+                        {"filename": "agenda.pdf", "user_id": "user-1", "chunk_type": "parent"},
+                        {"filename": "agenda.pdf", "user_id": "user-1", "document_id": "9", "chunk_type": "parent"},
+                    ],
+                }
+
+            return {
+                "ids": ["legacy-main", "new-main"],
+                "metadatas": [
+                    {"filename": "agenda.pdf", "user_id": "user-1"},
+                    {"filename": "agenda.pdf", "user_id": "user-1", "document_id": "9"},
+                ],
+            }
+
+        def delete(self, where=None, ids=None):
+            delete_calls.append({
+                "type": self.collection_name,
+                "op": "delete",
+                "where": where,
+                "ids": ids,
+            })
 
     class FakeChroma:
         def __init__(self, collection_name, **kwargs):
             self.collection_name = collection_name
-            self._collection = FakeCollection()
+            self._collection = FakeCollection(collection_name)
 
         def delete(self, where):
-            delete_calls.append({"type": "main", "where": where})
+            delete_calls.append({
+                "type": self.collection_name,
+                "op": "delete",
+                "where": where,
+                "ids": None,
+            })
 
     monkeypatch.setattr("app.services.rag_ingest.Chroma", FakeChroma)
     monkeypatch.setattr(
@@ -215,12 +253,15 @@ def test_legacy_cleanup_delete_removes_both_new_and_legacy_chunks(monkeypatch):
         cleanup_legacy=True,    # full cleanup — simulates user-initiated delete
     )
 
-    main_deletes = [c for c in delete_calls if c["type"] == "main"]
-    assert len(main_deletes) == 2, f"Expected 2 main delete calls (new + legacy), got {len(main_deletes)}"
+    delete_filters = [str(c["where"]) for c in delete_calls if c["op"] == "delete" and c["where"] is not None]
+    assert any("document_id" in item for item in delete_filters), "One pass must delete by document_id"
+    assert not any("filename" in item and "document_id" not in item for item in delete_filters), \
+        "Legacy cleanup must not broad-delete every chunk with the same filename"
 
-    filters_str = " ".join(str(c["where"]) for c in main_deletes)
-    assert "document_id" in filters_str, "One pass must delete by document_id"
-    assert "filename" in filters_str, "One pass must delete by filename for legacy cleanup"
+    id_deletes = [c["ids"] for c in delete_calls if c["op"] == "delete" and c["ids"] is not None]
+    assert ["legacy-main"] in id_deletes
+    assert ["legacy-parent"] in id_deletes
+    assert all("new-main" not in ids and "new-parent" not in ids for ids in id_deletes)
 
 
 # ── Embedding consistency guard ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- emit the shared ISTA error sentinel when Python chat cascade has no usable model or all configured models fail
- make legacy Chroma cleanup delete only filename-scoped chunks that do not have document_id metadata
- keep literal [MODEL:...] text in assistant answers while still parsing model metadata at the start of a stream chunk
- add local issue plan for #205

## Tests
- cd python-ai && source venv/bin/activate && pytest tests/test_llm_streaming.py tests/test_rag_ingest_delete.py
- cd python-ai && source venv/bin/activate && python -m compileall app/services/llm_streaming.py app/services/rag_ingest.py
- cd laravel && php artisan test --filter=ChatOrchestrationServiceTest
- cd laravel && php artisan test --filter=ChatStreamTest
- cd laravel && vendor/bin/pint --test app/Services/ChatOrchestrationService.php tests/Unit/Services/ChatOrchestrationServiceTest.php

Closes #205