### PR TITLE
[codex] Fix valid audit bugs across chat and memos

### DIFF
--- a/issue/issue-215-valid-audit-bugs-2026-05-18.md
+++ b/issue/issue-215-valid-audit-bugs-2026-05-18.md
@@ -1,0 +1,75 @@
+# Fix Valid Audit Bugs: Export, OnlyOffice, Document Processing, History, and Memo Edge Cases
+
+GitHub Issue: https://github.com/Hasbi1605/ISTA-AI/issues/207
+
+## Latar Belakang
+Audit bug terbaru menemukan beberapa defect valid di area chat export, OnlyOffice callback, job pemrosesan dokumen, upload dokumen, stream context, history loading, memo editor, dan endpoint Python document service. Sebagian temuan lain hanya hardening atau bukan bug, sehingga tidak masuk scope implementasi ini.
+
+## Tujuan
+- Mencegah export spreadsheet dari jawaban chat yang tidak punya tabel.
+- Menjaga OnlyOffice editor key tetap stabil selama sesi aktif.
+- Mencegah job dokumen lama menimpa status dokumen yang sudah final.
+- Membuat upload dokumen lebih toleran terhadap MIME browser yang berbeda.
+- Mengurangi beban load history chat/memo dengan batas query dan index.
+- Mengikat context dokumen chat stream ke user message yang tersimpan.
+- Menyamakan validasi ekstensi endpoint extract Python dengan endpoint process.
+- Mengurangi churn token OnlyOffice pada re-render Livewire.
+- Menambah retry cleanup stale vector/parent chunks.
+- Memperbaiki parsing revisi memo yang terlalu luas.
+
+## Ruang Lingkup
+- Bug valid: #2, #3/#5, #6, #7, #8, #9, #10, #13, #17, #18, #20.
+- Perubahan kecil di Laravel Livewire/controller/service/model/migration.
+- Perubahan kecil di Python document export/router dan RAG cleanup.
+- Test regression yang dekat dengan perilaku yang berubah.
+
+## Di Luar Scope
+- Hardening Google Drive OAuth local/testing.
+- Redesign penuh pagination UI chat/memo.
+- Refactor besar sistem chat, RAG, atau OnlyOffice.
+- Perubahan security policy legacy email verification.
+
+## Area / File Terkait
+- `laravel/app/Livewire/Chat/ChatIndex.php`
+- `laravel/app/Http/Controllers/Chat/ChatStreamController.php`
+- `laravel/app/Services/ChatOrchestrationService.php`
+- `laravel/app/Models/Message.php`
+- `laravel/app/Jobs/ProcessDocument.php`
+- `laravel/app/Http/Controllers/OnlyOfficeCallbackController.php`
+- `laravel/app/Livewire/Memos/MemoWorkspace.php`
+- `laravel/app/Livewire/Memos/MemoIndex.php`
+- `laravel/database/migrations/*`
+- `python-ai/app/routers/documents.py`
+- `python-ai/app/services/document_export.py`
+- `python-ai/app/services/rag_ingest.py`
+
+## Risiko
+- Migrasi `messages.document_ids` harus backward-compatible untuk pesan lama.
+- Perubahan OnlyOffice key tidak boleh mengganggu status force-save.
+- Pembatasan history harus tidak merusak urutan sidebar.
+- Python export harus tetap mengekspor XLSX/CSV saat HTML memang berisi tabel.
+
+## Langkah Implementasi
+1. Tambah metadata `document_ids` pada user message dan gunakan metadata itu di stream.
+2. Blok export/upload XLSX/CSV ketika HTML tidak mengandung tabel.
+3. Hentikan invalidasi editor key pada OnlyOffice status 2.
+4. Guard `ProcessDocument::failed()` agar hanya mengubah pending/processing menjadi error.
+5. Longgarkan validasi upload dengan menghapus strict `mimetypes` pada Livewire upload.
+6. Batasi query history chat/memo dan tambahkan index user/update/id.
+7. Cache config editor memo per memo/version/file path di component state terkunci.
+8. Tambah validasi ekstensi untuk endpoint Python extract.
+9. Tambah retry helper untuk cleanup stale Chroma IDs.
+10. Perketat cleanup value revisi memo untuk trailing instruksi generik.
+
+## Rencana Test
+- Laravel: targeted feature/unit tests untuk Google Drive upload, OnlyOffice callback, ProcessDocument, Chat UI/stream context, MemoWorkspace.
+- Laravel formatting: Pint untuk file PHP yang berubah.
+- Python: pytest untuk document export/router dan RAG cleanup.
+- Compile Python file yang berubah.
+
+## Kriteria Selesai
+- GitHub issue dibuat.
+- Branch baru dibuat dari `main`.
+- Perubahan bug valid diimplementasikan dengan test regression.
+- Test relevan Laravel dan Python lulus.
+- Commit dibuat, branch di-push, dan draft PR dibuka.

--- a/laravel/app/Http/Controllers/Chat/ChatStreamController.php
+++ b/laravel/app/Http/Controllers/Chat/ChatStreamController.php
@@ -34,7 +34,8 @@ class ChatStreamController extends Controller
         //   - URL length limits (414) with long conversations
         //   - Chat content leaking into access logs / proxy logs
         //   - Arbitrary history injection from client
-        $documentIds = $this->parseDocumentIds($request->input('document_ids', '[]'));
+        $requestedDocumentIds = $this->parseDocumentIds($request->input('document_ids', '[]'));
+        $documentIds = $this->documentIdsForLatestUserMessage($conversationId, $requestedDocumentIds);
         $webSearchMode = filter_var($request->input('web_search_mode', false), FILTER_VALIDATE_BOOLEAN);
 
         $aiService = app(AIService::class);
@@ -281,5 +282,30 @@ class ChatStreamController extends Controller
         } catch (\Throwable) {
             return [];
         }
+    }
+
+    /**
+     * Prefer document IDs persisted with the latest user message so a tampered
+     * EventSource query string cannot silently swap the RAG context.
+     *
+     * @param  array<int, int>  $fallbackDocumentIds
+     * @return array<int, int>
+     */
+    private function documentIdsForLatestUserMessage(int $conversationId, array $fallbackDocumentIds): array
+    {
+        $message = Message::query()
+            ->where('conversation_id', $conversationId)
+            ->where('role', 'user')
+            ->orderByDesc('id')
+            ->first(['document_ids']);
+
+        if ($message === null || $message->document_ids === null) {
+            return $fallbackDocumentIds;
+        }
+
+        return array_values(array_filter(
+            array_map(fn ($id) => is_numeric($id) ? (int) $id : null, $message->document_ids),
+            fn ($id) => $id !== null && $id > 0,
+        ));
     }
 }

--- a/laravel/app/Http/Controllers/OnlyOfficeCallbackController.php
+++ b/laravel/app/Http/Controllers/OnlyOfficeCallbackController.php
@@ -50,6 +50,8 @@ class OnlyOfficeCallbackController extends Controller
         // ── Status 4: no users currently editing ────────────────────────────
         // All editors have closed the document; no file to save. Acknowledge.
         if ($status === 4) {
+            app(MemoDocumentKey::class)->invalidateEditorKey($memo, $version);
+
             return response()->json(['error' => 0]);
         }
 
@@ -189,9 +191,6 @@ class OnlyOfficeCallbackController extends Controller
                         app(MemoForceSaveService::class)->markSucceeded((string) ($callback['userdata'] ?? ''), $memo, $version);
                     }
 
-                    if ($status === 2) {
-                        app(MemoDocumentKey::class)->invalidateEditorKey($memo, $version);
-                    }
                 });
             } finally {
                 @unlink($tempPath);

--- a/laravel/app/Jobs/ProcessDocument.php
+++ b/laravel/app/Jobs/ProcessDocument.php
@@ -34,8 +34,6 @@ class ProcessDocument implements ShouldQueue
      * the queue to silently discard the job instead of throwing an exception.
      *
      * Soft-deleted documents are handled inside handle() via fresh()->trashed().
-     *
-     * @var bool
      */
     public bool $deleteWhenMissingModels = true;
 
@@ -151,24 +149,24 @@ class ProcessDocument implements ShouldQueue
             return;
         }
 
-            // 3. Send to Python Microservice (with extended timeout for embedding)
-            $pythonUrl = rtrim((string) config('services.ai_document_service.url', config('services.ai_service.url', 'http://127.0.0.1:8001')), '/')
-                .'/api/documents/process';
-            $token = config('services.ai_document_service.token', config('services.ai_service.token'));
+        // 3. Send to Python Microservice (with extended timeout for embedding)
+        $pythonUrl = rtrim((string) config('services.ai_document_service.url', config('services.ai_service.url', 'http://127.0.0.1:8001')), '/')
+            .'/api/documents/process';
+        $token = config('services.ai_document_service.token', config('services.ai_service.token'));
 
-            $response = Http::timeout(900) // 15 minutes timeout for large documents
-                ->withHeaders([
-                    'Authorization' => "Bearer {$token}",
-                ])
-                ->attach(
-                    'file',
-                    $fileContent,
-                    $this->document->original_name
-                )
-                ->post($pythonUrl, [
-                    'user_id' => (string) $this->document->user_id,
-                    'document_id' => (string) $this->document->id,
-                ]);
+        $response = Http::timeout(900) // 15 minutes timeout for large documents
+            ->withHeaders([
+                'Authorization' => "Bearer {$token}",
+            ])
+            ->attach(
+                'file',
+                $fileContent,
+                $this->document->original_name
+            )
+            ->post($pythonUrl, [
+                'user_id' => (string) $this->document->user_id,
+                'document_id' => (string) $this->document->id,
+            ]);
 
         if ($response->successful()) {
             $freshDocument = $this->document->fresh();
@@ -233,8 +231,8 @@ class ProcessDocument implements ShouldQueue
 
             $this->document = $freshDocument;
 
-                // 5. Dispatch preview rendering job as a fallback if the
-                // eager upload-time dispatch has not already completed it.
+            // 5. Dispatch preview rendering job as a fallback if the
+            // eager upload-time dispatch has not already completed it.
             try {
                 $freshDocument = $this->document->fresh();
                 if ($freshDocument !== null && $freshDocument->preview_status !== Document::PREVIEW_STATUS_READY) {
@@ -269,7 +267,11 @@ class ProcessDocument implements ShouldQueue
             return;
         }
 
-        $this->document->update(['status' => 'error']);
+        Document::query()
+            ->whereKey($this->document->id)
+            ->whereIn('status', ['pending', 'processing'])
+            ->update(['status' => 'error']);
+
         logger()->error("Document processing permanently failed for ID {$this->document->id}: ".$exception->getMessage());
     }
 

--- a/laravel/app/Livewire/Chat/ChatIndex.php
+++ b/laravel/app/Livewire/Chat/ChatIndex.php
@@ -83,6 +83,8 @@ class ChatIndex extends Component
     // Maximum chats to show before "Show More"
     const MAX_VISIBLE_CHATS = 10;
 
+    private const HISTORY_LOAD_LIMIT = 100;
+
     public function mount($id = null)
     {
         $this->loadConversations();
@@ -119,6 +121,7 @@ class ChatIndex extends Component
             ->with('latestMessage')
             ->orderBy('updated_at', 'desc')
             ->orderBy('id', 'desc')
+            ->limit(self::HISTORY_LOAD_LIMIT)
             ->get();
         $this->pendingConversationIds = $this->conversations
             ->filter(fn (Conversation $conversation) => $this->conversationHasPendingResponse($conversation))
@@ -368,14 +371,12 @@ class ChatIndex extends Component
                     'required',
                     'file',
                     'mimes:'.implode(',', Document::attachmentFileExtensions()),
-                    'mimetypes:'.implode(',', Document::attachmentMimeTypes()),
                     'max:51200',
                 ],
             ], [
                 'chatAttachment.required' => 'Pilih file dokumen terlebih dahulu.',
                 'chatAttachment.file' => 'Lampiran chat harus berupa file dokumen.',
                 'chatAttachment.mimes' => 'Lampiran chat harus berupa file PDF, DOCX, XLSX, atau CSV.',
-                'chatAttachment.mimetypes' => 'Lampiran chat harus berupa file PDF, DOCX, XLSX, atau CSV.',
                 'chatAttachment.max' => 'Ukuran lampiran chat tidak boleh lebih dari 50 MB.',
             ], [
                 'chatAttachment' => 'lampiran chat',
@@ -488,6 +489,13 @@ class ChatIndex extends Component
                 'html_input' => 'strip',
                 'allow_unsafe_links' => false,
             ]);
+
+            if ($this->formatRequiresTable($targetFormat) && ! $this->contentHtmlContainsTable($contentHtml)) {
+                return [
+                    'ok' => false,
+                    'message' => 'Format spreadsheet hanya tersedia untuk jawaban AI yang berisi tabel.',
+                ];
+            }
 
             $exportService = app(DocumentExportService::class);
             $artifact = $exportService->exportContent(
@@ -607,7 +615,9 @@ class ChatIndex extends Component
         // DB transaction with a row lock on the conversation. This prevents two
         // concurrent requests for the same conversation from both passing the
         // pending check and both inserting a user message + dispatching a job.
-        $userMessageArray = DB::transaction(function () use ($conversationIdForRequest, $orchestrator) {
+        $conversationDocuments = $orchestrator->normalizeDocumentIds($this->conversationDocuments);
+
+        $userMessageArray = DB::transaction(function () use ($conversationIdForRequest, $orchestrator, $conversationDocuments) {
             $activeConversation = Conversation::query()
                 ->lockForUpdate()
                 ->find($conversationIdForRequest);
@@ -622,7 +632,7 @@ class ChatIndex extends Component
                 return null;
             }
 
-            return $orchestrator->saveUserMessage($conversationIdForRequest, $this->prompt);
+            return $orchestrator->saveUserMessage($conversationIdForRequest, $this->prompt, $conversationDocuments);
         });
 
         if ($userMessageArray === null) {
@@ -641,7 +651,6 @@ class ChatIndex extends Component
         $this->sources = [];
 
         $history = $orchestrator->buildHistory($this->messages);
-        $conversationDocuments = array_values(array_map('intval', $this->conversationDocuments));
         $webSearchMode = (bool) $this->webSearchMode;
 
         Conversation::query()
@@ -841,6 +850,16 @@ class ChatIndex extends Component
         return in_array($normalized, ['pdf', 'docx', 'xlsx', 'csv'], true)
             ? $normalized
             : null;
+    }
+
+    private function formatRequiresTable(string $targetFormat): bool
+    {
+        return in_array(strtolower(trim($targetFormat)), ['xlsx', 'csv'], true);
+    }
+
+    private function contentHtmlContainsTable(string $contentHtml): bool
+    {
+        return str_contains(Str::lower($contentHtml), '<table');
     }
 
     private function enforceRateLimit(string $action, int $maxAttempts, int $decaySeconds = 60, ?string $message = null): void

--- a/laravel/app/Livewire/Memos/MemoIndex.php
+++ b/laravel/app/Livewire/Memos/MemoIndex.php
@@ -10,12 +10,16 @@ use Livewire\Component;
 #[Layout('layouts.app')]
 class MemoIndex extends Component
 {
+    private const HISTORY_LOAD_LIMIT = 100;
+
     public function render()
     {
         return view('livewire.memos.memo-index', [
             'memos' => Memo::query()
                 ->where('user_id', Auth::id())
                 ->orderBy('updated_at', 'desc')
+                ->orderBy('id', 'desc')
+                ->limit(self::HISTORY_LOAD_LIMIT)
                 ->get(),
         ]);
     }

--- a/laravel/app/Livewire/Memos/MemoWorkspace.php
+++ b/laravel/app/Livewire/Memos/MemoWorkspace.php
@@ -15,15 +15,24 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 
 class MemoWorkspace extends Component
 {
     private const DRAFT_THREAD_KEY = 'draft';
 
+    private const HISTORY_LOAD_LIMIT = 100;
+
     public ?int $activeMemoId = null;
 
     public ?int $activeMemoVersionId = null;
+
+    #[Locked]
+    public ?array $editorConfigCache = null;
+
+    #[Locked]
+    public ?string $editorConfigCacheSignature = null;
 
     public string $memoType = 'memo_internal';
 
@@ -434,6 +443,8 @@ class MemoWorkspace extends Component
     public function editorConfig(): ?array
     {
         if (! $this->activeMemoId) {
+            $this->forgetEditorConfigCache();
+
             return null;
         }
 
@@ -443,6 +454,8 @@ class MemoWorkspace extends Component
             ->first();
 
         if (! $memo) {
+            $this->forgetEditorConfigCache();
+
             return null;
         }
 
@@ -451,13 +464,26 @@ class MemoWorkspace extends Component
         $filePath = $version?->file_path ?: $memo->file_path;
 
         if (! $filePath) {
+            $this->forgetEditorConfigCache();
+
             return null;
+        }
+
+        $versionId = $version?->id;
+        $cacheSignature = implode(':', [
+            Auth::id(),
+            $memo->id,
+            $versionId ?? 'current',
+            $filePath,
+        ]);
+
+        if ($this->editorConfigCacheSignature === $cacheSignature && $this->editorConfigCache !== null) {
+            return $this->editorConfigCache;
         }
 
         $signer = app(JwtSigner::class);
         $laravelInternalUrl = rtrim((string) config('services.onlyoffice.laravel_internal_url', config('app.url')), '/');
         $ttlMinutes = max(1, (int) config('services.onlyoffice.signed_url_ttl_minutes', 30));
-        $versionId = $version?->id;
         $ooToken = app(MemoDocumentKey::class)->generateFileToken($memo, $versionId, $ttlMinutes);
         $documentPath = URL::temporarySignedRoute('memos.file.signed', now()->addMinutes($ttlMinutes), array_filter([
             'memo' => $memo,
@@ -495,7 +521,16 @@ class MemoWorkspace extends Component
 
         $config['token'] = $signer->sign($config);
 
-        return $config;
+        $this->editorConfigCacheSignature = $cacheSignature;
+        $this->editorConfigCache = $config;
+
+        return $this->editorConfigCache;
+    }
+
+    protected function forgetEditorConfigCache(): void
+    {
+        $this->editorConfigCache = null;
+        $this->editorConfigCacheSignature = null;
     }
 
     protected function editorMemoVersion(Memo $memo): ?MemoVersion
@@ -519,6 +554,8 @@ class MemoWorkspace extends Component
         $memos = Memo::with('currentVersion')
             ->where('user_id', Auth::id())
             ->orderBy('updated_at', 'desc')
+            ->orderBy('id', 'desc')
+            ->limit(self::HISTORY_LOAD_LIMIT)
             ->get();
 
         $activeMemoVersions = $this->activeMemoId
@@ -929,6 +966,7 @@ class MemoWorkspace extends Component
     {
         $value = preg_replace('/\s+/u', ' ', trim($value)) ?? $value;
         $value = preg_replace('/[\.,;]\s+(?:bagian\s+(?:isi|lain|lainnya)|metadata|data\s+(?:lain|lainnya|yang\s+lain)|yang\s+lain|lainnya)\b.*$/iu', '', $value) ?? $value;
+        $value = preg_replace('/\s+(?:untuk|agar|supaya)\s+(?:semua|bagian|memo|dokumen|selanjutnya)\b.*$/iu', '', $value) ?? $value;
         $value = preg_replace('/^(?:untuk|kepada|ke)\s+/iu', '', $value) ?? $value;
 
         return trim($value, " \t\n\r\0\x0B\"'.,;:");

--- a/laravel/app/Models/Message.php
+++ b/laravel/app/Models/Message.php
@@ -9,11 +9,12 @@ class Message extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['conversation_id', 'role', 'content', 'is_error'];
+    protected $fillable = ['conversation_id', 'role', 'content', 'is_error', 'document_ids'];
 
     protected function casts(): array
     {
         return [
+            'document_ids' => 'array',
             'is_error' => 'boolean',
         ];
     }

--- a/laravel/app/Services/ChatOrchestrationService.php
+++ b/laravel/app/Services/ChatOrchestrationService.php
@@ -3,16 +3,18 @@
 namespace App\Services;
 
 use App\Models\Conversation;
-use App\Models\Message;
 use App\Models\Document;
+use App\Models\Message;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\QueryException;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 class ChatOrchestrationService
 {
     private const STREAM_CLAIM_TTL_SECONDS = 240;
+
     private const SANITIZE_REPLACEMENTS = [
         '/\bchunks?\b/i' => 'bagian dokumen',
         '/\bchunk(?:ing|ed)?\b/i' => 'bagian dokumen',
@@ -25,11 +27,12 @@ class ChatOrchestrationService
 
     public function createConversationIfNeeded(?int $currentConversationId, string $prompt): int
     {
-        if (!$currentConversationId) {
+        if (! $currentConversationId) {
             $conversation = Conversation::create([
                 'user_id' => Auth::id(),
-                'title' => substr($prompt, 0, 50) . '...'
+                'title' => substr($prompt, 0, 50).'...',
             ]);
+
             return $conversation->id;
         }
 
@@ -44,15 +47,31 @@ class ChatOrchestrationService
         return $currentConversationId;
     }
 
-    public function saveUserMessage(int $conversationId, string $prompt): array
+    /**
+     * @param  array<int, int|string>  $documentIds
+     */
+    public function saveUserMessage(int $conversationId, string $prompt, array $documentIds = []): array
     {
         $userMessage = Message::create([
             'conversation_id' => $conversationId,
             'role' => 'user',
-            'content' => $prompt
+            'content' => $prompt,
+            'document_ids' => $this->normalizeDocumentIds($documentIds),
         ]);
 
         return $userMessage->toArray();
+    }
+
+    /**
+     * @param  array<int, int|string>  $documentIds
+     * @return list<int>
+     */
+    public function normalizeDocumentIds(array $documentIds): array
+    {
+        return array_values(array_unique(array_filter(
+            array_map(fn ($id) => is_numeric($id) ? (int) $id : null, $documentIds),
+            fn ($id) => $id !== null && $id > 0,
+        )));
     }
 
     /**
@@ -173,7 +192,7 @@ class ChatOrchestrationService
 
     public function getSourcePolicy(?array $documentFilenames): string
     {
-        return !empty($documentFilenames) ? 'document_context' : 'hybrid_realtime_auto';
+        return ! empty($documentFilenames) ? 'document_context' : 'hybrid_realtime_auto';
     }
 
     public function shouldAllowAutoRealtimeWeb(?array $documentFilenames): bool
@@ -196,12 +215,13 @@ class ChatOrchestrationService
         $documentSources = [];
 
         foreach ($normalizedSources as $source) {
-            if (!empty($source['url'])) {
+            if (! empty($source['url'])) {
                 $webSources[] = $source;
+
                 continue;
             }
 
-            if (!empty($source['filename'])) {
+            if (! empty($source['filename'])) {
                 $documentSources[] = $source['filename'];
             }
         }
@@ -212,10 +232,10 @@ class ChatOrchestrationService
             return "\n\n---\nDokumen rujukan: **{$documentSources[0]}**";
         }
 
-        $lines = ["", "", "---", "**Rujukan:**"];
+        $lines = ['', '', '---', '**Rujukan:**'];
 
         foreach ($webSources as $source) {
-            $title = !empty($source['title']) ? $source['title'] : parse_url($source['url'], PHP_URL_HOST);
+            $title = ! empty($source['title']) ? $source['title'] : parse_url($source['url'], PHP_URL_HOST);
             $lines[] = "- [{$title}]({$source['url']})";
         }
 
@@ -269,6 +289,7 @@ class ChatOrchestrationService
     {
         $cleanContent = preg_replace('/\[SOURCES:\[.+?\]\]/s', '', $fullResponse);
         $cleanContent = $this->sanitizeAssistantOutput((string) $cleanContent);
+
         return trim($cleanContent);
     }
 
@@ -384,6 +405,7 @@ class ChatOrchestrationService
         }
 
         $value = Cache::get($claimKey);
+
         return $value === 'intent' || $value === 'active';
     }
 
@@ -398,8 +420,8 @@ class ChatOrchestrationService
             // terakhir agar baik SSE stream maupun background job tidak bisa
             // menyimpan dua assistant message untuk satu user message yang sama.
             // Ini adalah single source of truth untuk race condition di kedua jalur.
-            return \Illuminate\Support\Facades\DB::transaction(function () use ($conversationId, $content) {
-                $latestUserMessage = \App\Models\Message::query()
+            return DB::transaction(function () use ($conversationId, $content) {
+                $latestUserMessage = Message::query()
                     ->where('conversation_id', $conversationId)
                     ->where('role', 'user')
                     ->latest('id')
@@ -410,7 +432,7 @@ class ChatOrchestrationService
                 // - jika sukses (is_error=false): skip (idempotent)
                 // - jika error (is_error=true): upgrade menjadi jawaban sukses
                 if ($latestUserMessage !== null) {
-                    $latestAssistant = \App\Models\Message::query()
+                    $latestAssistant = Message::query()
                         ->where('conversation_id', $conversationId)
                         ->where('role', 'assistant')
                         ->where('id', '>', $latestUserMessage->id)
@@ -456,8 +478,8 @@ class ChatOrchestrationService
             // tidak duplikat jika stream dan job keduanya gagal bersamaan.
             // Jika sudah ada assistant message (normal atau error) setelah user message
             // terakhir, skip — ini mencegah error stream menimpa jawaban sukses dari job.
-            return \Illuminate\Support\Facades\DB::transaction(function () use ($conversationId, $content) {
-                $latestUserMessage = \App\Models\Message::query()
+            return DB::transaction(function () use ($conversationId, $content) {
+                $latestUserMessage = Message::query()
                     ->where('conversation_id', $conversationId)
                     ->where('role', 'user')
                     ->latest('id')
@@ -465,7 +487,7 @@ class ChatOrchestrationService
                     ->first();
 
                 if ($latestUserMessage !== null) {
-                    $latestAssistant = \App\Models\Message::query()
+                    $latestAssistant = Message::query()
                         ->where('conversation_id', $conversationId)
                         ->where('role', 'assistant')
                         ->where('id', '>', $latestUserMessage->id)
@@ -523,7 +545,7 @@ class ChatOrchestrationService
 
     public function extractStreamMetadata(string $chunk, string $buffer = ''): array
     {
-        $combined = $buffer . $chunk;
+        $combined = $buffer.$chunk;
         $modelName = null;
         $sources = null;
 
@@ -551,7 +573,7 @@ class ChatOrchestrationService
             $tail = substr($combined, $markerPos);
             $isComplete = preg_match('/^\[MODEL:(.+?)\]\n?/s', $tail) === 1;
 
-            if (!$isComplete) {
+            if (! $isComplete) {
                 $nextBuffer = $tail;
                 $combined = substr($combined, 0, $markerPos);
                 break;
@@ -581,6 +603,7 @@ class ChatOrchestrationService
 
             if ($combined[$jsonStart] !== '[') {
                 $searchOffset = $jsonStart;
+
                 continue;
             }
 
@@ -595,6 +618,7 @@ class ChatOrchestrationService
 
             if ($combined[$jsonEnd + 1] !== ']') {
                 $searchOffset = $jsonEnd + 1;
+
                 continue;
             }
 
@@ -628,11 +652,13 @@ class ChatOrchestrationService
             if ($inString) {
                 if ($escape) {
                     $escape = false;
+
                     continue;
                 }
 
                 if ($char === '\\') {
                     $escape = true;
+
                     continue;
                 }
 
@@ -645,11 +671,13 @@ class ChatOrchestrationService
 
             if ($char === '"') {
                 $inString = true;
+
                 continue;
             }
 
             if ($char === '[') {
                 $depth++;
+
                 continue;
             }
 

--- a/laravel/database/migrations/2026_05_18_000001_add_document_ids_to_messages_table.php
+++ b/laravel/database/migrations/2026_05_18_000001_add_document_ids_to_messages_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->json('document_ids')->nullable()->after('content');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->dropColumn('document_ids');
+        });
+    }
+};

--- a/laravel/database/migrations/2026_05_18_000002_add_history_indexes_to_conversations_and_memos.php
+++ b/laravel/database/migrations/2026_05_18_000002_add_history_indexes_to_conversations_and_memos.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->index(['user_id', 'updated_at', 'id'], 'conversations_user_updated_id_index');
+        });
+
+        Schema::table('memos', function (Blueprint $table) {
+            $table->index(['user_id', 'updated_at', 'id'], 'memos_user_updated_id_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('memos', function (Blueprint $table) {
+            $table->dropIndex('memos_user_updated_id_index');
+        });
+
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->dropIndex('conversations_user_updated_id_index');
+        });
+    }
+};

--- a/laravel/tests/Feature/Chat/ChatStreamTest.php
+++ b/laravel/tests/Feature/Chat/ChatStreamTest.php
@@ -191,6 +191,47 @@ class ChatStreamTest extends TestCase
         $this->assertSame('Pertanyaan dari DB', $lastMsg['content']);
     }
 
+    public function test_stream_document_context_comes_from_latest_user_message_not_query_string(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Document context test',
+        ]);
+        $selectedDoc = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'selected.pdf',
+            'original_name' => 'selected.pdf',
+            'file_path' => 'documents/'.$user->id.'/selected.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 100,
+            'status' => 'ready',
+        ]);
+        $tamperedDoc = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'tampered.pdf',
+            'original_name' => 'tampered.pdf',
+            'file_path' => 'documents/'.$user->id.'/tampered.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 100,
+            'status' => 'ready',
+        ]);
+
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Gunakan dokumen yang dipilih.',
+            'document_ids' => [$selectedDoc->id],
+        ]);
+
+        $method = new \ReflectionMethod(ChatStreamController::class, 'documentIdsForLatestUserMessage');
+        $method->setAccessible(true);
+
+        $documentIds = $method->invoke(app(ChatStreamController::class), $conversation->id, [$tamperedDoc->id]);
+
+        $this->assertSame([(int) $selectedDoc->id], $documentIds);
+    }
+
     // -------------------------------------------------------------------------
     // DB persistence
     // -------------------------------------------------------------------------

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -1730,4 +1730,43 @@ class ChatUiTest extends TestCase
                 && $job->userId === (int) $user->id;
         });
     }
+
+    public function test_send_message_persists_selected_document_context_on_user_message(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Document context conversation',
+        ]);
+        $document = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'context.pdf',
+            'original_name' => 'context.pdf',
+            'file_path' => 'documents/'.$user->id.'/context.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 123,
+            'status' => 'ready',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(ChatIndex::class)
+            ->set('currentConversationId', $conversation->id)
+            ->set('conversationDocuments', [$document->id])
+            ->set('prompt', 'Ringkas dokumen ini')
+            ->call('sendMessage');
+
+        $message = Message::query()
+            ->where('conversation_id', $conversation->id)
+            ->where('role', 'user')
+            ->firstOrFail();
+
+        $this->assertSame([(int) $document->id], $message->document_ids);
+
+        Queue::assertPushed(
+            GenerateChatResponse::class,
+            fn (GenerateChatResponse $job) => $job->conversationDocuments === [(int) $document->id]
+        );
+    }
 }

--- a/laravel/tests/Feature/Chat/DocumentUploadTest.php
+++ b/laravel/tests/Feature/Chat/DocumentUploadTest.php
@@ -44,6 +44,30 @@ class DocumentUploadTest extends TestCase
         Queue::assertPushed(ProcessDocument::class, 1);
     }
 
+    public function test_pdf_upload_accepts_octet_stream_client_mime(): void
+    {
+        Queue::fake();
+        Storage::fake('local');
+
+        $user = User::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test(ChatIndex::class)
+            ->set('chatAttachment', UploadedFile::fake()->createWithContent(
+                'referensi.pdf',
+                "%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF"
+            ))
+            ->assertSet('attachmentUploadStatus', 'success');
+
+        $this->assertDatabaseHas('documents', [
+            'user_id' => $user->id,
+            'original_name' => 'referensi.pdf',
+            'status' => 'pending',
+        ]);
+
+        Queue::assertPushed(ProcessDocument::class, 1);
+    }
+
     public function test_user_cannot_upload_more_than_10_documents(): void
     {
         Queue::fake();

--- a/laravel/tests/Feature/CloudStorage/GoogleDriveUploadTest.php
+++ b/laravel/tests/Feature/CloudStorage/GoogleDriveUploadTest.php
@@ -85,6 +85,34 @@ class GoogleDriveUploadTest extends TestCase
         ]);
     }
 
+    public function test_chat_answer_spreadsheet_upload_requires_table_content(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Drive answer upload',
+        ]);
+        $message = Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'assistant',
+            'content' => "Ini jawaban naratif tanpa tabel.\n\n- Satu\n- Dua",
+        ]);
+
+        $exportService = Mockery::mock(DocumentExportService::class);
+        $exportService->shouldNotReceive('exportContent');
+        $this->app->instance(DocumentExportService::class, $exportService);
+
+        Livewire::actingAs($user)
+            ->test(ChatIndex::class)
+            ->call('saveAnswerToGoogleDrive', $message->id, 'xlsx')
+            ->assertReturned([
+                'ok' => false,
+                'message' => 'Format spreadsheet hanya tersedia untuk jawaban AI yang berisi tabel.',
+            ]);
+
+        $this->assertDatabaseCount('cloud_storage_files', 0);
+    }
+
     public function test_document_viewer_can_upload_exported_file_to_google_drive(): void
     {
         Storage::fake('local');

--- a/laravel/tests/Feature/Jobs/ProcessDocumentTest.php
+++ b/laravel/tests/Feature/Jobs/ProcessDocumentTest.php
@@ -6,7 +6,9 @@ use App\Jobs\ProcessDocument;
 use App\Jobs\RenderDocumentPreview;
 use App\Models\Document;
 use App\Models\User;
+use App\Services\Documents\DocumentPreviewRenderer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
@@ -35,7 +37,7 @@ class ProcessDocumentTest extends TestCase
         $user = User::factory()->create();
 
         // Create dummy file
-        $filePath = 'documents/' . $user->id . '/dummy.pdf';
+        $filePath = 'documents/'.$user->id.'/dummy.pdf';
         Storage::disk('local')->put($filePath, 'dummy content');
 
         $document = Document::create([
@@ -68,7 +70,7 @@ class ProcessDocumentTest extends TestCase
         config()->set('services.ai_document_service.url', 'http://python-ai-docs:8002');
         $user = User::factory()->create();
 
-        $filePath = 'documents/' . $user->id . '/dummy2.pdf';
+        $filePath = 'documents/'.$user->id.'/dummy2.pdf';
         Storage::disk('local')->put($filePath, 'dummy content');
 
         $document = Document::create([
@@ -99,7 +101,7 @@ class ProcessDocumentTest extends TestCase
             'user_id' => $user->id,
             'filename' => 'failed-callback.pdf',
             'original_name' => 'failed-callback.pdf',
-            'file_path' => 'documents/' . $user->id . '/failed-callback.pdf',
+            'file_path' => 'documents/'.$user->id.'/failed-callback.pdf',
             'mime_type' => 'application/pdf',
             'file_size_bytes' => 123,
             'status' => 'processing',
@@ -107,7 +109,7 @@ class ProcessDocumentTest extends TestCase
 
         $job = new ProcessDocument($document);
         // Register this job's own claim token in cache so the guard passes.
-        \Illuminate\Support\Facades\Cache::put(
+        Cache::put(
             'doc_process_claim:'.$document->id,
             $this->readClaimToken($job),
             300,
@@ -125,7 +127,7 @@ class ProcessDocumentTest extends TestCase
             'user_id' => $user->id,
             'filename' => 'missing.pdf',
             'original_name' => 'missing.pdf',
-            'file_path' => 'documents/' . $user->id . '/missing.pdf',
+            'file_path' => 'documents/'.$user->id.'/missing.pdf',
             'mime_type' => 'application/pdf',
             'file_size_bytes' => 123,
             'status' => 'pending',
@@ -176,7 +178,7 @@ class ProcessDocumentTest extends TestCase
         config()->set('services.ai_document_service.url', 'http://python-ai-docs:8002');
 
         // Force the dispatcher to throw to simulate a queue connection failure.
-        \Illuminate\Support\Facades\Queue::shouldReceive('connection')
+        Queue::shouldReceive('connection')
             ->andThrow(new \RuntimeException('queue down'));
 
         $user = User::factory()->create();
@@ -364,7 +366,7 @@ class ProcessDocumentTest extends TestCase
         Http::fake([
             '*/api/documents/process' => function () use ($document) {
                 // Simulate Job B starting handle(): new token written to cache.
-                \Illuminate\Support\Facades\Cache::put(
+                Cache::put(
                     'doc_process_claim:'.$document->id,
                     'new-job-token-from-job-B',
                     300,
@@ -445,7 +447,7 @@ class ProcessDocumentTest extends TestCase
         $jobA = new ProcessDocument($document);
 
         // Register a *different* token to simulate that Job B replaced Job A's claim.
-        \Illuminate\Support\Facades\Cache::put(
+        Cache::put(
             'doc_process_claim:'.$document->id,
             'newer-job-B-token',
             300,
@@ -479,6 +481,26 @@ class ProcessDocumentTest extends TestCase
         $this->assertSame('error', $document->fresh()->status);
     }
 
+    public function test_failed_does_not_overwrite_ready_status_when_claim_cache_is_missing(): void
+    {
+        $user = User::factory()->create();
+
+        $document = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'ready-after-cache-loss.pdf',
+            'original_name' => 'ready-after-cache-loss.pdf',
+            'file_path' => 'documents/'.$user->id.'/ready-after-cache-loss.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 123,
+            'status' => 'ready',
+        ]);
+
+        $job = new ProcessDocument($document);
+        $job->failed(new \RuntimeException('stale failure after newer success'));
+
+        $this->assertSame('ready', $document->fresh()->status);
+    }
+
     // -------------------------------------------------------------------------
     // Stale-job guard: RenderDocumentPreview
     // -------------------------------------------------------------------------
@@ -500,17 +522,17 @@ class ProcessDocumentTest extends TestCase
         ]);
 
         $rendererCalled = false;
-        $renderer = new class($rendererCalled) extends \App\Services\Documents\DocumentPreviewRenderer
+        $renderer = new class($rendererCalled) extends DocumentPreviewRenderer
         {
             public function __construct(private bool &$called) {}
 
-            public function render(\App\Models\Document $document): void
+            public function render(Document $document): void
             {
                 $this->called = true;
             }
         };
 
-        $job = new \App\Jobs\RenderDocumentPreview($document);
+        $job = new RenderDocumentPreview($document);
         $job->handle($renderer);
 
         $this->assertFalse($rendererCalled, 'Renderer must not be called when preview is already ready.');

--- a/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
+++ b/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
@@ -673,6 +673,37 @@ class MemoWorkspaceTest extends TestCase
         $this->assertSame($firstKey, $secondKey);
     }
 
+    public function test_editor_config_reuses_file_token_across_same_memo_rerenders(): void
+    {
+        config([
+            'services.onlyoffice.jwt_secret' => 'workspace-secret',
+            'services.onlyoffice.laravel_internal_url' => 'http://laravel:8000',
+        ]);
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $memo = Memo::create([
+            'user_id' => $user->id,
+            'title' => 'Memo Token Stable',
+            'memo_type' => 'memo_internal',
+            'file_path' => 'memos/'.$user->id.'/memo.docx',
+            'status' => Memo::STATUS_GENERATED,
+        ]);
+
+        $component = Livewire::actingAs($user)
+            ->test(MemoWorkspace::class)
+            ->call('loadMemo', $memo->id);
+
+        $firstConfig = $component->instance()->editorConfig();
+        $component->set('memoPrompt', 'perubahan state biasa');
+        $secondConfig = $component->instance()->editorConfig();
+
+        parse_str((string) parse_url($firstConfig['document']['url'], PHP_URL_QUERY), $firstQuery);
+        parse_str((string) parse_url($secondConfig['document']['url'], PHP_URL_QUERY), $secondQuery);
+
+        $this->assertSame($firstQuery['oo_token'], $secondQuery['oo_token']);
+        $this->assertSame($firstConfig['token'], $secondConfig['token']);
+    }
+
     public function test_generate_configuration_allows_blank_signatory_and_preserves_it_for_ai_service(): void
     {
         Storage::fake('local');
@@ -908,6 +939,58 @@ class MemoWorkspaceTest extends TestCase
         Http::assertSent(fn ($request) => $request['configuration']['date'] === '13 Mei 2026'
             && ! array_key_exists('body_override', $request['configuration']));
         $this->assertSame('13 Mei 2026', $memo->refresh()->configuration['date']);
+    }
+
+    public function test_revision_chat_strips_trailing_generic_instruction_from_date_value(): void
+    {
+        Storage::fake('local');
+        Http::fake([
+            '*/api/memos/generate-body' => Http::response($this->validMemoDocxBytes(), 200, [
+                'X-Memo-Searchable-Text-B64' => base64_encode('Memo revisi tanggal'),
+                'X-Memo-Page-Size' => 'letter',
+                'Content-Type' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            ]),
+        ]);
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $memo = Memo::create([
+            'user_id' => $user->id,
+            'title' => 'Memo Revisi Tanggal Generik',
+            'memo_type' => 'memo_internal',
+            'file_path' => 'memos/'.$user->id.'/memo.docx',
+            'status' => Memo::STATUS_GENERATED,
+            'searchable_text' => 'Memo Revisi Tanggal Generik',
+            'configuration' => [
+                'number' => 'TGL-1/IST/YK/01/2026',
+                'recipient' => 'Kepala Bagian Protokol',
+                'sender' => 'Kepala Istana Kepresidenan Yogyakarta',
+                'subject' => 'Memo Revisi Tanggal Generik',
+                'date' => '12 Mei 2026',
+                'content' => 'Isi memo saat ini.',
+                'signatory' => 'Deni Mulyana',
+                'page_size' => 'letter',
+                'page_size_mode' => 'auto',
+            ],
+        ]);
+        $version = $memo->versions()->create([
+            'version_number' => 1,
+            'label' => 'Versi 1',
+            'file_path' => $memo->file_path,
+            'status' => Memo::STATUS_GENERATED,
+            'configuration' => $memo->configuration,
+            'searchable_text' => $memo->searchable_text,
+        ]);
+        $memo->forceFill(['current_version_id' => $version->id])->save();
+
+        Livewire::actingAs($user)
+            ->test(MemoWorkspace::class)
+            ->call('loadMemo', $memo->id)
+            ->set('memoPrompt', 'tanggal jadi 1 Januari 2026 untuk semua memo selanjutnya')
+            ->call('sendMemoChat')
+            ->assertHasNoErrors();
+
+        Http::assertSent(fn ($request) => $request['configuration']['date'] === '1 Januari 2026');
+        $this->assertSame('1 Januari 2026', $memo->refresh()->configuration['date']);
     }
 
     public function test_revision_chat_applies_name_typo_without_regenerating_unrelated_body(): void

--- a/laravel/tests/Feature/Memos/OnlyOfficeCallbackTest.php
+++ b/laravel/tests/Feature/Memos/OnlyOfficeCallbackTest.php
@@ -1023,7 +1023,7 @@ class OnlyOfficeCallbackTest extends TestCase
         Http::assertNothingSent();
     }
 
-    public function test_callback_status_2_invalidates_editor_key_for_next_session(): void
+    public function test_callback_status_2_keeps_active_editor_key_for_open_session(): void
     {
         config([
             'services.onlyoffice.jwt_secret' => 'callback-secret',
@@ -1051,6 +1051,36 @@ class OnlyOfficeCallbackTest extends TestCase
             'url' => $url,
             'token' => $token,
         ])->assertOk()->assertJson(['error' => 0]);
+
+        $nextKey = app(MemoDocumentKey::class)->forEditor($memo->refresh());
+
+        $this->assertSame($initialKey, $nextKey);
+    }
+
+    public function test_callback_status_4_invalidates_editor_key_after_session_closes(): void
+    {
+        config([
+            'services.onlyoffice.jwt_secret' => 'callback-secret',
+            'services.onlyoffice.internal_url' => 'https://onlyoffice.test',
+        ]);
+        Storage::fake('local');
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $memo = $this->createMemo($user);
+        $initialKey = $this->callbackKey($memo);
+        $token = (new JwtSigner('callback-secret'))->sign([
+            'status' => 4,
+            'key' => $initialKey,
+            'exp' => time() + 60,
+        ]);
+
+        $this->postJson(route('onlyoffice.callback', $memo), [
+            'status' => 4,
+            'key' => $initialKey,
+            'token' => $token,
+        ])->assertOk()->assertJson(['error' => 0]);
+
+        $memo->forceFill(['updated_at' => now()->addMinute()])->save();
 
         $nextKey = app(MemoDocumentKey::class)->forEditor($memo->refresh(), $memo->currentVersion?->refresh());
 

--- a/python-ai/app/routers/documents.py
+++ b/python-ai/app/routers/documents.py
@@ -43,6 +43,17 @@ def _require_safe_filename(filename: str | None) -> str:
     return base
 
 
+def _require_supported_extension(filename: str) -> str:
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Tipe file .{ext} tidak didukung. Gunakan: {', '.join(sorted(ALLOWED_EXTENSIONS))}",
+        )
+
+    return ext
+
+
 def _stream_upload_with_limit(upload_file: UploadFile, dest_path: str) -> None:
     """Write *upload_file* to *dest_path* in chunks.
 
@@ -95,12 +106,7 @@ def upload_document(
 
     file_id = str(uuid.uuid4())
     safe_filename = _require_safe_filename(file.filename)
-    ext = safe_filename.rsplit(".", 1)[-1].lower() if "." in safe_filename else ""
-    if ext not in ALLOWED_EXTENSIONS:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Tipe file .{ext} tidak didukung. Gunakan: {', '.join(sorted(ALLOWED_EXTENSIONS))}",
-        )
+    _require_supported_extension(safe_filename)
     temp_file_path = os.path.join(temp_dir, f"{file_id}_{safe_filename}")
 
     try:
@@ -190,6 +196,7 @@ def extract_tables_endpoint(file: UploadFile = File(...)):
 
     file_id = str(uuid.uuid4())
     safe_filename = _require_safe_filename(file.filename)
+    _require_supported_extension(safe_filename)
     temp_file_path = os.path.join(temp_dir, f"{file_id}_{safe_filename}")
 
     try:
@@ -218,6 +225,7 @@ def extract_content_endpoint(file: UploadFile = File(...)):
 
     file_id = str(uuid.uuid4())
     safe_filename = _require_safe_filename(file.filename)
+    _require_supported_extension(safe_filename)
     temp_file_path = os.path.join(temp_dir, f"{file_id}_{safe_filename}")
 
     try:

--- a/python-ai/app/services/document_export.py
+++ b/python-ai/app/services/document_export.py
@@ -489,6 +489,9 @@ def export_content(content_html: str, target_format: str, file_name: str | None 
 
     tables = _extract_tables_from_html(content_html)
 
+    if target in {"xlsx", "csv"} and not tables:
+        raise ValueError("Format spreadsheet hanya tersedia untuk konten yang memiliki tabel.")
+
     if target == "xlsx":
         return ExportArtifact(
             filename=f"{base_name}.xlsx",

--- a/python-ai/app/services/rag_ingest.py
+++ b/python-ai/app/services/rag_ingest.py
@@ -24,6 +24,57 @@ from app.services.lightweight_text_splitter import LightweightRecursiveTextSplit
 logger = logging.getLogger(__name__)
 
 
+def _delete_chroma_ids_with_retry(
+    delete_callable,
+    ids: list[str],
+    description: str,
+    document_id: str | None,
+    attempts: int = 3,
+    delay_seconds: float = 0.2,
+) -> bool:
+    if not ids:
+        return True
+
+    last_error: Exception | None = None
+
+    for attempt in range(1, attempts + 1):
+        try:
+            delete_callable(ids=ids)
+            if attempt > 1:
+                logger.info(
+                    "Post-ingest cleanup: %s delete succeeded on retry %d for document_id=%s",
+                    description,
+                    attempt,
+                    document_id,
+                )
+
+            return True
+        except Exception as exc:
+            last_error = exc
+            if attempt >= attempts:
+                break
+
+            logger.warning(
+                "Post-ingest cleanup: %s delete attempt %d/%d failed for document_id=%s: %s",
+                description,
+                attempt,
+                attempts,
+                document_id,
+                exc,
+            )
+            time.sleep(delay_seconds)
+
+    logger.warning(
+        "Post-ingest cleanup: %s delete failed after %d attempts for document_id=%s: %s",
+        description,
+        attempts,
+        document_id,
+        last_error,
+    )
+
+    return False
+
+
 def process_document(
     file_path: str,
     filename: str,
@@ -476,16 +527,15 @@ def process_document(
         #   - If this cleanup fails, the old chunks remain as stale duplicates
         #     but retrieval continues to work (new chunks are preferred by score).
         if old_vector_ids:
-            try:
-                vectorstore.delete(ids=old_vector_ids)
+            if _delete_chroma_ids_with_retry(
+                vectorstore.delete,
+                old_vector_ids,
+                "stale vectors",
+                document_id,
+            ):
                 logger.info(
                     "✅ Post-ingest cleanup: deleted %d stale vectors for document_id=%s",
                     len(old_vector_ids), document_id,
-                )
-            except Exception as _cleanup_err:
-                logger.warning(
-                    "Post-ingest cleanup failed (stale chunks may remain): %s",
-                    _cleanup_err,
                 )
 
         if old_parent_ids:
@@ -501,11 +551,16 @@ def process_document(
                 new_p_ids_set: set[str] = set(p_ids) if p_ids else set()
                 stale_parent_ids = [pid for pid in old_parent_ids if pid not in new_p_ids_set]
                 if stale_parent_ids:
-                    _parent_vs._collection.delete(ids=stale_parent_ids)
-                    logger.info(
-                        "✅ Post-ingest cleanup: deleted %d stale parent chunks for document_id=%s",
-                        len(stale_parent_ids), document_id,
-                    )
+                    if _delete_chroma_ids_with_retry(
+                        _parent_vs._collection.delete,
+                        stale_parent_ids,
+                        "stale parent chunks",
+                        document_id,
+                    ):
+                        logger.info(
+                            "✅ Post-ingest cleanup: deleted %d stale parent chunks for document_id=%s",
+                            len(stale_parent_ids), document_id,
+                        )
                 else:
                     logger.info("Post-ingest parent cleanup: no stale IDs to delete (all IDs reused)")
             except Exception as _pcleanup_err:

--- a/python-ai/tests/test_document_export.py
+++ b/python-ai/tests/test_document_export.py
@@ -61,6 +61,31 @@ def test_export_content_creates_pdf_docx_xlsx_and_csv():
     assert b"10" in csv_export.content
 
 
+def test_export_content_rejects_spreadsheet_without_tables():
+    html = "<article><p>Jawaban naratif tanpa tabel.</p></article>"
+
+    with pytest.raises(ValueError, match="Format spreadsheet"):
+        export_content(html, "xlsx", "jawaban-ai")
+
+    with pytest.raises(ValueError, match="Format spreadsheet"):
+        export_content(html, "csv", "jawaban-ai")
+
+
+def test_documents_export_route_rejects_spreadsheet_without_tables():
+    response = client.post(
+        "/api/documents/export",
+        headers=AUTH_HEADERS,
+        json={
+            "content_html": "<p>Jawaban naratif tanpa tabel.</p>",
+            "target_format": "xlsx",
+            "file_name": "jawaban-ai",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "Format spreadsheet" in response.text
+
+
 def test_documents_export_route_returns_binary_download():
     response = client.post(
         "/api/documents/export",
@@ -159,6 +184,18 @@ def test_documents_extract_tables_route_reads_upload():
     first_table = payload["tables"][0]
     assert first_table["header"] == ["Nama", "Nilai"]
     assert first_table["rows"][0] == ["A", "10"]
+
+
+def test_documents_extract_routes_reject_unsupported_extension():
+    for path in ("/api/documents/extract-tables", "/api/documents/extract-content"):
+        response = client.post(
+            path,
+            headers=AUTH_HEADERS,
+            files={"file": ("malware.exe", b"not a supported document", "application/octet-stream")},
+        )
+
+        assert response.status_code == 400
+        assert "tidak didukung" in response.text
 
 
 @pytest.mark.parametrize("filename", ["../berbahaya.pdf", "/etc/passwd"])

--- a/python-ai/tests/test_rag_ingest_delete.py
+++ b/python-ai/tests/test_rag_ingest_delete.py
@@ -52,6 +52,30 @@ def test_delete_document_vectors_scopes_filename_by_user(monkeypatch):
     }]
 
 
+def test_delete_chroma_ids_with_retry_recovers_from_transient_failure(monkeypatch):
+    from app.services import rag_ingest
+
+    monkeypatch.setattr(rag_ingest.time, "sleep", lambda _seconds: None)
+
+    calls = {"count": 0, "ids": None}
+
+    def flaky_delete(*, ids):
+        calls["count"] += 1
+        calls["ids"] = ids
+        if calls["count"] == 1:
+            raise RuntimeError("transient chroma delete failure")
+
+    success = rag_ingest._delete_chroma_ids_with_retry(
+        flaky_delete,
+        ["old-parent-1", "old-parent-2"],
+        "stale parent chunks",
+        "doc-123",
+    )
+
+    assert success is True
+    assert calls == {"count": 2, "ids": ["old-parent-1", "old-parent-2"]}
+
+
 def test_process_document_returns_false_on_partial_batch_failure(monkeypatch, tmp_path):
     """
     Regression for H2: when at least one embedding batch fails during ingest,


### PR DESCRIPTION
## Summary
- Fixes the valid audit findings from #207 across chat export, OnlyOffice callbacks, document processing, upload validation, stream context, history loading, memo editor config, and Python document/RAG helpers.
- Persists selected chat `document_ids` on user messages and has SSE streams use the persisted context instead of trusting query-string document IDs.
- Blocks meaningless XLSX/CSV exports when content has no tables, keeps OnlyOffice editor keys stable through active status-2 saves, and guards stale document job failures from overwriting ready documents.
- Adds bounded history loading/indexes, memo editor config token caching, extension validation for Python extract endpoints, and retry for stale Chroma cleanup.

Closes #207

## Validation
- `cd laravel && php artisan migrate:fresh --env=testing`
- `cd laravel && vendor/bin/pint --test app/Http/Controllers/Chat/ChatStreamController.php app/Http/Controllers/OnlyOfficeCallbackController.php app/Jobs/ProcessDocument.php app/Livewire/Chat/ChatIndex.php app/Livewire/Memos/MemoIndex.php app/Livewire/Memos/MemoWorkspace.php app/Models/Message.php app/Services/ChatOrchestrationService.php database/migrations/2026_05_18_000001_add_document_ids_to_messages_table.php database/migrations/2026_05_18_000002_add_history_indexes_to_conversations_and_memos.php tests/Feature/CloudStorage/GoogleDriveUploadTest.php tests/Feature/Memos/OnlyOfficeCallbackTest.php tests/Feature/Jobs/ProcessDocumentTest.php tests/Feature/Chat/DocumentUploadTest.php tests/Feature/Chat/ChatStreamTest.php tests/Feature/Chat/ChatUiTest.php tests/Feature/Memos/MemoWorkspaceTest.php`
- `cd laravel && php artisan test tests/Feature/CloudStorage/GoogleDriveUploadTest.php tests/Feature/Memos/OnlyOfficeCallbackTest.php tests/Feature/Jobs/ProcessDocumentTest.php tests/Feature/Chat/DocumentUploadTest.php tests/Feature/Chat/ChatStreamTest.php tests/Feature/Chat/ChatUiTest.php tests/Feature/Memos/MemoWorkspaceTest.php tests/Feature/Memos/MemoIndexTest.php`
- `cd python-ai && source venv/bin/activate && python -m compileall app/routers/documents.py app/services/document_export.py app/services/rag_ingest.py tests/test_document_export.py tests/test_rag_ingest_delete.py`
- `cd python-ai && source venv/bin/activate && pytest tests/test_document_export.py tests/test_rag_ingest_delete.py`
- `git diff --check`
