### PR TITLE
Wave 1 low-risk security hardening

### DIFF
--- a/issue/security-wave1-low-risk-hardening-2026-05-18.md
+++ b/issue/security-wave1-low-risk-hardening-2026-05-18.md
@@ -1,0 +1,71 @@
+# Wave 1 Low-Risk Security Hardening
+
+GitHub issue: https://github.com/Hasbi1605/ISTA-AI/issues/230
+
+## Latar Belakang
+Validasi ulang temuan security menunjukkan beberapa hardening bernilai tinggi namun berisiko rendah dapat dipisahkan dari perubahan besar seperti CSP, trusted proxy, dan secret manager. Wave 1 difokuskan pada perubahan kecil yang tidak mengubah alur utama pengguna.
+
+## Tujuan
+- Mengurangi risiko timing side-channel pada token internal Python AI.
+- Mengurangi kemungkinan data sensitif ikut masuk log aplikasi.
+- Membatasi proses dokumen yang menggantung terlalu lama.
+- Menambahkan safety net rate limit pada callback OnlyOffice.
+- Menormalisasi nama user yang dikirim ke konfigurasi OnlyOffice.
+
+## Ruang Lingkup
+- Python AI token verification menggunakan constant-time comparison.
+- Default timeout subprocess dokumen diturunkan ke batas yang lebih aman.
+- Logging Laravel untuk error AI dan global exception direduksi agar tidak membawa body/raw excerpt sensitif.
+- Route callback OnlyOffice diberi throttle ringan.
+- Nama user pada konfigurasi editor OnlyOffice dibersihkan untuk karakter berisiko.
+- Test regresi ditambahkan atau diperbarui untuk area yang berubah.
+
+## Di Luar Scope
+- CSP dan sanitasi markdown image eksternal.
+- Perubahan `trustProxies`.
+- Migrasi `.env.droplet` ke secret manager.
+- Sanitizer HTML export berbasis parser allowlist.
+- Key separation signed URL OnlyOffice.
+- Deploy production.
+
+## Area / File Terkait
+- `python-ai/app/api_shared.py`
+- `python-ai/app/document_runner.py`
+- `python-ai/tests/test_env_utils.py`
+- `python-ai/tests/test_document_runner.py`
+- `laravel/bootstrap/app.php`
+- `laravel/app/Services/AIService.php`
+- `laravel/app/Livewire/Memos/MemoWorkspace.php`
+- `laravel/routes/web.php`
+- Test Laravel terkait security/logging/OnlyOffice.
+
+## Risiko
+- Timeout dokumen yang lebih pendek dapat menggagalkan dokumen sangat besar lebih cepat.
+- Throttle callback OnlyOffice harus cukup longgar agar tidak mengganggu save normal.
+- Redaksi log dapat mengurangi detail debugging production.
+- Normalisasi nama user harus tetap mengizinkan nama Indonesia yang wajar.
+
+## Langkah Implementasi
+1. Tambahkan constant-time comparison untuk `AI_SERVICE_TOKEN`.
+2. Turunkan default `DOCUMENT_PROCESS_SUBPROCESS_TIMEOUT` ke batas konservatif.
+3. Redaksi logging AI service dan global exception message agar tidak menyimpan payload mentah.
+4. Tambahkan throttle ringan pada route OnlyOffice callback.
+5. Normalisasi nama user sebelum dimasukkan ke `editorConfig.user.name`.
+6. Tambahkan test regresi Laravel dan Python.
+7. Jalankan test relevan dan full validation untuk area yang tersentuh.
+
+## Rencana Test
+- Python: test token valid/invalid tetap bekerja dan verify menggunakan `hmac.compare_digest`.
+- Python: test default timeout subprocess memakai nilai baru dan env override tetap dihormati.
+- Laravel: test route callback OnlyOffice memiliki throttle middleware.
+- Laravel: test nama user OnlyOffice dibersihkan dari karakter HTML berisiko.
+- Laravel: test logging AI/global exception tidak membawa raw body/token sensitif.
+- Jalankan full `php artisan test`.
+- Jalankan full `source venv/bin/activate && pytest`.
+
+## Kriteria Selesai
+- Semua perubahan Wave 1 terimplementasi tanpa scope melebar.
+- Test baru menutup perilaku security yang berubah.
+- Full test Laravel dan Python lulus.
+- GitHub issue dibuat.
+- Branch dipush dan PR dibuat untuk review.

--- a/laravel/app/Livewire/Memos/MemoWorkspace.php
+++ b/laravel/app/Livewire/Memos/MemoWorkspace.php
@@ -561,7 +561,7 @@ class MemoWorkspace extends Component
                 'lang' => 'id',
                 'user' => [
                     'id' => (string) Auth::id(),
-                    'name' => (string) Auth::user()?->name,
+                    'name' => $this->safeEditorUserName((string) Auth::user()?->name),
                 ],
             ],
             'exp' => now()->addMinutes($ttlMinutes)->getTimestamp(),
@@ -573,6 +573,15 @@ class MemoWorkspace extends Component
         $this->editorConfigCache = $config;
 
         return $this->editorConfigCache;
+    }
+
+    protected function safeEditorUserName(string $name): string
+    {
+        $clean = preg_replace('/[<>"`]+/u', ' ', $name) ?? '';
+        $clean = preg_replace("/[^\p{L}\p{M}\p{N}\s.'-]+/u", ' ', $clean) ?? '';
+        $clean = preg_replace('/\s+/u', ' ', trim($clean)) ?? '';
+
+        return mb_substr($clean !== '' ? $clean : 'Pengguna', 0, 120);
     }
 
     protected function forgetEditorConfigCache(): void

--- a/laravel/app/Services/AIService.php
+++ b/laravel/app/Services/AIService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class AIService
 {
@@ -16,11 +17,17 @@ class AIService
     public const ERROR_SENTINEL = '[ISTA_AI_ERROR]';
 
     protected $client;
+
     protected $baseUrl;
+
     protected $documentBaseUrl;
+
     protected $token;
+
     protected $documentToken;
+
     protected $maxRetries;
+
     protected $retryDelayMs;
 
     public function __construct()
@@ -48,10 +55,9 @@ class AIService
     /**
      * Send a list of messages to the Python AI service and stream the response.
      *
-     * @param array $messages
-     * @param array|null $document_filenames Optional document filenames for RAG mode
-     * @param string|null $user_id User ID for authorization in RAG mode
-     * @param array|null $document_ids Optional document IDs for stable Chroma filtering
+     * @param  array|null  $document_filenames  Optional document filenames for RAG mode
+     * @param  string|null  $user_id  User ID for authorization in RAG mode
+     * @param  array|null  $document_ids  Optional document IDs for stable Chroma filtering
      * @return \Generator
      */
     public function sendChat(
@@ -89,7 +95,7 @@ class AIService
         for ($attempt = 1; $attempt <= $this->maxRetries; $attempt++) {
             try {
                 $headers = [
-                    'Authorization' => 'Bearer ' . $this->token,
+                    'Authorization' => 'Bearer '.$this->token,
                     'Accept' => 'text/event-stream',
                     'Content-Type' => 'application/json',
                 ];
@@ -98,7 +104,7 @@ class AIService
                     $headers['X-Request-ID'] = $request_id;
                 }
 
-                $response = $this->client->post($this->baseUrl . '/api/chat', [
+                $response = $this->client->post($this->baseUrl.'/api/chat', [
                     'headers' => $headers,
                     'json' => $payload,
                     'stream' => true,
@@ -106,7 +112,7 @@ class AIService
 
                 $body = $response->getBody();
 
-                while (!$body->eof()) {
+                while (! $body->eof()) {
                     yield $body->read(1024);
                 }
 
@@ -120,18 +126,19 @@ class AIService
                     'max_retries' => $this->maxRetries,
                     'base_url' => $this->baseUrl,
                     'status' => $response?->getStatusCode(),
-                    'message' => $e->getMessage(),
-                    'response_excerpt' => $responseBody ? mb_substr($responseBody, 0, 500) : null,
+                    'message' => $this->sanitizeLogMessage($e->getMessage()),
+                    'response_body_bytes' => is_string($responseBody) ? strlen($responseBody) : null,
                 ]);
 
                 if ($attempt >= $this->maxRetries) {
                     Log::error('AI Service Error: max retries reached', [
                         'base_url' => $this->baseUrl,
                         'status' => $response?->getStatusCode(),
-                        'message' => $e->getMessage(),
-                        'response_excerpt' => $responseBody ? mb_substr($responseBody, 0, 500) : null,
+                        'message' => $this->sanitizeLogMessage($e->getMessage()),
+                        'response_body_bytes' => is_string($responseBody) ? strlen($responseBody) : null,
                     ]);
-                    yield self::ERROR_SENTINEL."❌ Kesalahan sistem saat menghubungi otak AI. Silakan coba lagi nanti.";
+                    yield self::ERROR_SENTINEL.'❌ Kesalahan sistem saat menghubungi otak AI. Silakan coba lagi nanti.';
+
                     return;
                 }
 
@@ -140,9 +147,10 @@ class AIService
                 }
             } catch (\Throwable $e) {
                 Log::error('Unexpected AI Service Error', [
-                    'message' => $e->getMessage(),
+                    'message' => $this->sanitizeLogMessage($e->getMessage()),
                 ]);
-                yield self::ERROR_SENTINEL."❌ Kesalahan sistem saat menghubungi otak AI. Silakan coba lagi nanti.";
+                yield self::ERROR_SENTINEL.'❌ Kesalahan sistem saat menghubungi otak AI. Silakan coba lagi nanti.';
+
                 return;
             }
         }
@@ -151,9 +159,7 @@ class AIService
     /**
      * Summarize a document.
      *
-     * @param string $filename
-     * @param string|null $user_id User ID for authorization
-     * @return array
+     * @param  string|null  $user_id  User ID for authorization
      */
     public function summarizeDocument(string $filename, ?string $user_id = null, string $documentId = ''): array
     {
@@ -167,9 +173,9 @@ class AIService
                 $payload['document_id'] = $documentId;
             }
 
-            $response = $this->client->post($this->documentBaseUrl . '/api/documents/summarize', [
+            $response = $this->client->post($this->documentBaseUrl.'/api/documents/summarize', [
                 'headers' => [
-                    'Authorization' => 'Bearer ' . $this->documentToken,
+                    'Authorization' => 'Bearer '.$this->documentToken,
                     'Accept' => 'application/json',
                     'Content-Type' => 'application/json',
                 ],
@@ -178,10 +184,13 @@ class AIService
 
             return json_decode($response->getBody()->getContents(), true);
         } catch (RequestException $e) {
-            Log::error('AI Service Summarize Error: ' . $e->getMessage());
+            Log::error('AI Service Summarize Error', [
+                'message' => $this->sanitizeLogMessage($e->getMessage()),
+            ]);
+
             return [
                 'status' => 'error',
-                'message' => 'Gagal merangkum dokumen: ' . $e->getMessage()
+                'message' => 'Gagal merangkum dokumen. Silakan coba lagi nanti.',
             ];
         }
     }
@@ -207,12 +216,33 @@ class AIService
     private function normalizeIntConfig(mixed $value, int $default): int
     {
         $normalized = $this->normalizeStringConfig($value, (string) $default);
+
         return is_numeric($normalized) ? (int) $normalized : $default;
     }
 
     private function normalizeFloatConfig(mixed $value, float $default): float
     {
         $normalized = $this->normalizeStringConfig($value, (string) $default);
+
         return is_numeric($normalized) ? (float) $normalized : $default;
+    }
+
+    private function sanitizeLogMessage(?string $message): ?string
+    {
+        if ($message === null || $message === '') {
+            return $message;
+        }
+
+        $patterns = [
+            '/Bearer\s+[A-Za-z0-9._~+\-\/]+=*/i' => 'Bearer [REDACTED]',
+            '/github_pat_[A-Za-z0-9_]+/i' => 'github_pat_[REDACTED]',
+            '/GOCSPX-[A-Za-z0-9_-]+/i' => 'GOCSPX-[REDACTED]',
+            '/\b(re|sk|ghp|gho|ghu|ghs)_[A-Za-z0-9_]{12,}\b/i' => '[REDACTED_TOKEN]',
+            '/\b(token|secret|password|api[_-]?key)(["\']?\s*[:=]\s*["\']?)[^"\'\s,}]+/i' => '$1$2[REDACTED]',
+        ];
+
+        $redacted = preg_replace(array_keys($patterns), array_values($patterns), $message) ?? $message;
+
+        return Str::limit($redacted, 500);
     }
 }

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -25,10 +25,11 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions) {
         $exceptions->reportable(function (Throwable $e) {
-            Log::error('Global Exception Caught: '.$e->getMessage(), [
+            Log::error('Global Exception Caught', [
                 'exception_class' => get_class($e),
                 'file' => $e->getFile(),
                 'line' => $e->getLine(),
+                'message_hash' => hash('sha256', $e->getMessage()),
             ]);
         });
 

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -43,6 +43,7 @@ Route::get('chat/stream/{conversationId}', [ChatStreamController::class, 'stream
     ->name('chat.stream');
 
 Route::post('onlyoffice/callback/{memo}', OnlyOfficeCallbackController::class)
+    ->middleware('throttle:120,1')
     ->name('onlyoffice.callback');
 
 Route::get('chat/memos/{memo}/signed-file', [MemoFileController::class, 'signed'])

--- a/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
+++ b/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
@@ -709,6 +709,34 @@ class MemoWorkspaceTest extends TestCase
         $this->assertSame($firstConfig['token'], $secondConfig['token']);
     }
 
+    public function test_editor_config_sanitizes_user_name_for_onlyoffice(): void
+    {
+        Storage::fake('local');
+        config([
+            'services.onlyoffice.jwt_secret' => 'workspace-secret',
+            'services.onlyoffice.laravel_internal_url' => 'http://laravel:8000',
+        ]);
+
+        $user = User::factory()->create([
+            'name' => '<img src=x onerror=alert(1)> Hasbi "Admin"',
+            'email_verified_at' => now(),
+        ]);
+        [$memo] = $this->memoWithVersion($user, 'Memo Nama User', 'memos/'.$user->id.'/memo-nama-user.docx');
+
+        $config = Livewire::actingAs($user)
+            ->test(MemoWorkspace::class)
+            ->call('loadMemo', $memo->id)
+            ->instance()
+            ->editorConfig();
+
+        $editorName = $config['editorConfig']['user']['name'];
+
+        $this->assertSame('img src x onerror alert 1 Hasbi Admin', $editorName);
+        $this->assertStringNotContainsString('<', $editorName);
+        $this->assertStringNotContainsString('>', $editorName);
+        $this->assertStringNotContainsString('"', $editorName);
+    }
+
     public function test_loading_another_memo_with_sync_force_saves_active_editor_first(): void
     {
         Storage::fake('local');

--- a/laravel/tests/Feature/Memos/OnlyOfficeCallbackTest.php
+++ b/laravel/tests/Feature/Memos/OnlyOfficeCallbackTest.php
@@ -8,13 +8,29 @@ use App\Models\User;
 use App\Services\OnlyOffice\JwtSigner;
 use App\Services\OnlyOffice\MemoDocumentKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class OnlyOfficeCallbackTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function test_callback_route_has_light_throttle_middleware(): void
+    {
+        $route = Arr::first(app('router')->getRoutes(), fn ($route) => $route->getName() === 'onlyoffice.callback');
+
+        $this->assertNotNull($route);
+        $middlewares = $route->gatherMiddleware();
+
+        $hasThrottle = (bool) collect($middlewares)->first(
+            fn ($middleware) => Str::startsWith($middleware, 'throttle:')
+        );
+
+        $this->assertTrue($hasThrottle);
+    }
 
     public function test_callback_rejects_missing_token(): void
     {

--- a/laravel/tests/Feature/SecurityLoggingTest.php
+++ b/laravel/tests/Feature/SecurityLoggingTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class SecurityLoggingTest extends TestCase
+{
+    public function test_global_exception_report_does_not_log_raw_exception_message(): void
+    {
+        Log::spy();
+
+        report(new RuntimeException('Bearer leaked-token private prompt body'));
+
+        Log::shouldHaveReceived('error')->with('Global Exception Caught', Mockery::on(function (array $context) {
+            return ($context['exception_class'] ?? null) === RuntimeException::class
+                && isset($context['file'], $context['line'], $context['message_hash'])
+                && ! isset($context['message']);
+        }));
+    }
+}

--- a/laravel/tests/Unit/AIServiceTest.php
+++ b/laravel/tests/Unit/AIServiceTest.php
@@ -23,7 +23,7 @@ class AIServiceTest extends TestCase
         config()->set('services.ai_service.timeout', " '121.5' ");
         config()->set('services.ai_service.read_timeout', ' "122.5" ');
 
-        $service = new AIService();
+        $service = new AIService;
         $reflection = new \ReflectionClass($service);
 
         $baseUrl = $reflection->getProperty('baseUrl');
@@ -64,7 +64,7 @@ class AIServiceTest extends TestCase
         $handlerStack = HandlerStack::create($mock);
         $mockClient = new Client(['handler' => $handlerStack]);
 
-        $service = new AIService();
+        $service = new AIService;
         $reflection = new \ReflectionClass($service);
         $clientProp = $reflection->getProperty('client');
         $clientProp->setAccessible(true);
@@ -82,5 +82,20 @@ class AIServiceTest extends TestCase
         $this->assertStringEndsWith(']', AIService::ERROR_SENTINEL);
         $this->assertStringNotContainsString('MODEL', AIService::ERROR_SENTINEL);
         $this->assertStringNotContainsString('SOURCES', AIService::ERROR_SENTINEL);
+    }
+
+    public function test_ai_service_redacts_sensitive_log_messages(): void
+    {
+        $service = new AIService;
+        $reflection = new \ReflectionClass($service);
+        $method = $reflection->getMethod('sanitizeLogMessage');
+        $method->setAccessible(true);
+
+        $message = 'Authorization: Bearer super-secret-token token=raw-secret GOCSPX-client-secret';
+
+        $this->assertSame(
+            'Authorization: Bearer [REDACTED] token=[REDACTED] GOCSPX-[REDACTED]',
+            $method->invoke($service, $message)
+        );
     }
 }

--- a/python-ai/app/api_shared.py
+++ b/python-ai/app/api_shared.py
@@ -1,3 +1,4 @@
+import hmac
 import os
 import socket
 
@@ -32,7 +33,7 @@ def verify_token(authorization: str | None = Header(None)):
     if token is None:
         raise HTTPException(status_code=503, detail="AI Service token is not configured.")
 
-    if not authorization or authorization != f"Bearer {token}":
+    if not authorization or not hmac.compare_digest(authorization, f"Bearer {token}"):
         raise HTTPException(status_code=401, detail="Unauthorized access to AI Service.")
 
 

--- a/python-ai/app/document_runner.py
+++ b/python-ai/app/document_runner.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, Tuple
 
 from app.env_utils import get_env_int
 
+DEFAULT_DOCUMENT_PROCESS_SUBPROCESS_TIMEOUT = 900
+
 
 def _parse_result_payload(stdout: str) -> Dict[str, Any]:
     lines = [line.strip() for line in stdout.splitlines() if line.strip()]
@@ -22,7 +24,7 @@ def _parse_result_payload(stdout: str) -> Dict[str, Any]:
 
 
 def run_document_process(file_path: str, filename: str, user_id: str, document_id: str = "") -> Tuple[bool, str]:
-    timeout_seconds = get_env_int("DOCUMENT_PROCESS_SUBPROCESS_TIMEOUT", 3600)
+    timeout_seconds = get_env_int("DOCUMENT_PROCESS_SUBPROCESS_TIMEOUT", DEFAULT_DOCUMENT_PROCESS_SUBPROCESS_TIMEOUT)
     app_dir = os.path.dirname(os.path.dirname(__file__))
 
     completed = subprocess.run(

--- a/python-ai/tests/test_document_runner.py
+++ b/python-ai/tests/test_document_runner.py
@@ -6,7 +6,11 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from app.document_runner import _parse_result_payload, run_document_process
+from app.document_runner import (
+    DEFAULT_DOCUMENT_PROCESS_SUBPROCESS_TIMEOUT,
+    _parse_result_payload,
+    run_document_process,
+)
 
 
 def test_parse_result_payload_uses_last_valid_json_line():
@@ -20,7 +24,10 @@ def test_parse_result_payload_uses_last_valid_json_line():
 
 
 def test_run_document_process_returns_success_payload(monkeypatch):
+    captured = {}
+
     def fake_run(*args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
         return subprocess.CompletedProcess(
             args=args[0],
             returncode=0,
@@ -34,6 +41,29 @@ def test_run_document_process_returns_success_payload(monkeypatch):
 
     assert success is True
     assert message == "processed"
+    assert captured["timeout"] == DEFAULT_DOCUMENT_PROCESS_SUBPROCESS_TIMEOUT
+
+
+def test_run_document_process_honors_timeout_env_override(monkeypatch):
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="{\"success\": true, \"message\": \"processed\"}\n",
+            stderr="",
+        )
+
+    monkeypatch.setenv("DOCUMENT_PROCESS_SUBPROCESS_TIMEOUT", "1200")
+    monkeypatch.setattr("app.document_runner.subprocess.run", fake_run)
+
+    success, message = run_document_process("/tmp/doc.pdf", "doc.pdf", "42")
+
+    assert success is True
+    assert message == "processed"
+    assert captured["timeout"] == 1200
 
 
 def test_run_document_process_falls_back_to_stderr_when_payload_missing(monkeypatch):

--- a/python-ai/tests/test_env_utils.py
+++ b/python-ai/tests/test_env_utils.py
@@ -71,3 +71,18 @@ def test_internal_service_token_accepts_configured_secret(monkeypatch):
 
     assert get_internal_service_token() == "safe-secret"
     assert verify_token("Bearer safe-secret") is None
+
+def test_verify_token_uses_constant_time_comparison(monkeypatch):
+    import app.api_shared as shared
+
+    calls = []
+
+    def fake_compare_digest(provided, expected):
+        calls.append((provided, expected))
+        return True
+
+    monkeypatch.setenv("AI_SERVICE_TOKEN", "safe-secret")
+    monkeypatch.setattr(shared.hmac, "compare_digest", fake_compare_digest)
+
+    assert shared.verify_token("Bearer provided-secret") is None
+    assert calls == [("Bearer provided-secret", "Bearer safe-secret")]


### PR DESCRIPTION
## Summary
- Add constant-time AI service token comparison and reduce document subprocess default timeout to 900 seconds.
- Redact sensitive Laravel AI/global exception logging and avoid raw AI response excerpts.
- Add a light OnlyOffice callback throttle and sanitize OnlyOffice editor user names.
- Add issue plan and regression tests for the Wave 1 hardening items.

Closes #230

## Verification
- `cd laravel && vendor/bin/pint --test --dirty`
- `cd laravel && php artisan test`
- `cd python-ai && source venv/bin/activate && pytest`
- `cd laravel && composer audit --locked`
- `cd laravel && npm audit --audit-level=high`
- `cd python-ai && source venv/bin/activate && pip-audit -r requirements.txt`

## Notes
- `ruff` is not installed in the local Python virtualenv, so Python formatting/linting was covered by the full pytest suite and existing dependency audit only.
- CSP, trusted proxies, secret-manager migration, parser-based export sanitization, and OnlyOffice signed URL key separation remain intentionally out of scope for this Wave 1 PR.