### PR TITLE
Fix trusted proxy config during HTTP boot

### DIFF
--- a/laravel/app/Support/TrustedProxyConfig.php
+++ b/laravel/app/Support/TrustedProxyConfig.php
@@ -2,6 +2,8 @@
 
 namespace App\Support;
 
+use Illuminate\Container\Container;
+
 class TrustedProxyConfig
 {
     private const DEFAULT_TRUSTED_PROXIES = '127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16';
@@ -11,7 +13,12 @@ class TrustedProxyConfig
      */
     public static function fromConfig(): array
     {
-        return self::fromString(config('trustedproxy.proxies', self::DEFAULT_TRUSTED_PROXIES));
+        $container = Container::getInstance();
+        $value = $container?->bound('config')
+            ? $container->make('config')->get('trustedproxy.proxies', self::DEFAULT_TRUSTED_PROXIES)
+            : env('TRUSTED_PROXIES', self::DEFAULT_TRUSTED_PROXIES);
+
+        return self::fromString($value);
     }
 
     /**

--- a/laravel/tests/Unit/Support/TrustedProxyConfigTest.php
+++ b/laravel/tests/Unit/Support/TrustedProxyConfigTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Support;
 
 use App\Support\TrustedProxyConfig;
+use Illuminate\Container\Container;
 use Tests\TestCase;
 
 class TrustedProxyConfigTest extends TestCase
@@ -12,6 +13,24 @@ class TrustedProxyConfigTest extends TestCase
         config(['trustedproxy.proxies' => '127.0.0.1,172.18.0.0/16']);
 
         $this->assertSame(['127.0.0.1', '172.18.0.0/16'], TrustedProxyConfig::fromConfig());
+    }
+
+    public function test_from_config_is_safe_before_config_repository_is_bound(): void
+    {
+        $originalContainer = Container::getInstance();
+
+        Container::setInstance(new Container);
+
+        try {
+            $this->assertSame([
+                '127.0.0.1',
+                '10.0.0.0/8',
+                '172.16.0.0/12',
+                '192.168.0.0/16',
+            ], TrustedProxyConfig::fromConfig());
+        } finally {
+            Container::setInstance($originalContainer);
+        }
     }
 
     public function test_from_string_falls_back_to_default_when_empty(): void


### PR DESCRIPTION
## Summary\n- Avoid resolving Laravel's config repository while the HTTP kernel middleware stack is still being built.\n- Fall back to TRUSTED_PROXIES env/defaults when the config repository is not bound yet.\n- Add regression coverage for early-container boot.\n\n## Why\nPost-deploy smoke testing found production /login returning a PHP fatal before Laravel could send CSP/security headers: TrustedProxyConfig::fromConfig() called config() too early during HTTP kernel construction.\n\n## Verification\n- cd laravel && vendor/bin/pint --dirty\n- cd laravel && php artisan test tests/Unit/Support/TrustedProxyConfigTest.php tests/Feature/SecurityTrustedProxyTest.php tests/Feature/SecurityHeadersTest.php → 7 passed\n- cd laravel && php artisan test → 396 passed\n- cd laravel && composer audit --locked\n- cd laravel && npm audit --audit-level=high\n- Local PHP built-in server smoke: /login returns 200 with CSP/security headers and no fatal\n\n✅ Hotfix is safe to merge.