### PR TITLE
Fix production UI regression from CSP and drag overlay

### DIFF
--- a/laravel/app/Http/Middleware/AddSecurityHeaders.php
+++ b/laravel/app/Http/Middleware/AddSecurityHeaders.php
@@ -44,7 +44,7 @@ class AddSecurityHeaders
             'media-src' => ["'self'"],
             'font-src' => ["'self'", 'data:', 'https://fonts.gstatic.com'],
             'style-src' => ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
-            'script-src' => ["'self'", "'unsafe-inline'"],
+            'script-src' => ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
             'connect-src' => ["'self'"],
             'frame-src' => ["'self'"],
             'worker-src' => ["'self'", 'blob:'],

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -466,6 +466,7 @@ const registerChatPageData = (Alpine) => {
         isSwitchingConversation: false,
         isDraggingFile: false,
         dragDepth: 0,
+        dragResetTimer: null,
         dropError: '',
 
         init() {
@@ -504,39 +505,44 @@ const registerChatPageData = (Alpine) => {
         },
 
         onDragEnter(event) {
-            if (!this.hasFiles(event)) {
+            if (!this.prepareFileDrag(event)) {
                 return;
             }
 
             this.dragDepth += 1;
             this.isDraggingFile = true;
+            this.scheduleDragReset();
         },
 
         onDragOver(event) {
-            if (!this.hasFiles(event)) {
+            if (!this.prepareFileDrag(event)) {
                 return;
             }
 
             this.isDraggingFile = true;
+            this.scheduleDragReset();
         },
 
         onDragLeave(event) {
-            if (!this.hasFiles(event)) {
+            if (!this.isDraggingFile && !this.hasFiles(event)) {
                 return;
             }
 
+            event.preventDefault();
             this.dragDepth = Math.max(this.dragDepth - 1, 0);
 
-            if (this.dragDepth === 0) {
-                this.isDraggingFile = false;
+            if (this.dragDepth === 0 || this.isLeavingWindow(event)) {
+                this.resetDraggingFile();
             }
         },
 
         onDropFile(event) {
-            this.dragDepth = 0;
-            this.isDraggingFile = false;
+            if (this.hasFiles(event)) {
+                event.preventDefault();
+            }
 
             const files = event.dataTransfer?.files;
+            this.resetDraggingFile();
 
             if (!files || files.length === 0) {
                 return;
@@ -559,8 +565,43 @@ const registerChatPageData = (Alpine) => {
             this.showRightSidebar = true;
         },
 
+        prepareFileDrag(event) {
+            if (!this.hasFiles(event)) {
+                return false;
+            }
+
+            event.preventDefault();
+
+            if (event.dataTransfer) {
+                event.dataTransfer.dropEffect = 'copy';
+            }
+
+            return true;
+        },
+
         hasFiles(event) {
             return Array.from(event.dataTransfer?.types || []).includes('Files');
+        },
+
+        isLeavingWindow(event) {
+            return event.clientX <= 0
+                || event.clientY <= 0
+                || event.clientX >= window.innerWidth
+                || event.clientY >= window.innerHeight;
+        },
+
+        scheduleDragReset() {
+            window.clearTimeout(this.dragResetTimer);
+            this.dragResetTimer = window.setTimeout(() => {
+                this.resetDraggingFile();
+            }, 1200);
+        },
+
+        resetDraggingFile() {
+            window.clearTimeout(this.dragResetTimer);
+            this.dragResetTimer = null;
+            this.dragDepth = 0;
+            this.isDraggingFile = false;
         },
 
         showDropError(message) {

--- a/laravel/resources/views/dashboard.blade.php
+++ b/laravel/resources/views/dashboard.blade.php
@@ -26,11 +26,11 @@
     </head>
     <body class="ista-shell ista-display-sans text-stone-800 dark:text-gray-100 transition-colors duration-300">
         <x-page-loader />
-        <div class="relative min-h-screen overflow-hidden bg-stone-50/50 transition-colors duration-300 dark:bg-gray-900" style="background-image: radial-gradient(circle at 0 0, rgba(245, 158, 11, 0.08) 0%, rgba(245, 158, 11, 0) 30%), radial-gradient(circle at 100% 100%, rgba(76, 5, 25, 0.08) 0%, rgba(76, 5, 25, 0) 35%), url('{{ asset('images/ista/dashboard-grid.png') }}'); background-size: auto, auto, 8px 8px;">
+        <div class="relative flex min-h-[var(--app-viewport-height)] flex-col overflow-hidden bg-stone-50/50 transition-colors duration-300 dark:bg-gray-900" style="background-image: radial-gradient(circle at 0 0, rgba(245, 158, 11, 0.08) 0%, rgba(245, 158, 11, 0) 30%), radial-gradient(circle at 100% 100%, rgba(76, 5, 25, 0.08) 0%, rgba(76, 5, 25, 0) 35%), url('{{ asset('images/ista/dashboard-grid.png') }}'); background-size: auto, auto, 8px 8px;">
             <div class="pointer-events-none absolute -left-20 -top-20 h-[28rem] w-[28rem] rounded-full bg-amber-100/50 blur-3xl dark:bg-amber-500/5"></div>
             <div class="pointer-events-none absolute -right-24 top-32 h-[24rem] w-[24rem] rounded-full bg-rose-100/60 blur-3xl dark:bg-ista-primary/10"></div>
 
-            <header class="ista-navbar">
+            <header class="ista-navbar flex-none">
                 <div class="mx-auto flex w-full max-w-7xl items-center justify-between px-5 py-4 sm:px-10">
                     <a href="{{ route('dashboard') }}" class="group flex items-center gap-3">
                         <img src="{{ asset('images/ista/logo.png') }}" alt="ISTA AI" class="h-8 w-8 object-contain transition-transform duration-300 group-hover:rotate-6 group-hover:scale-110">
@@ -41,7 +41,7 @@
                             <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />
                             </svg>
-                            <svg x-show="darkMode === true" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <svg x-show="darkMode === true" style="display: none;" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z" />
                             </svg>
                         </button>
@@ -65,7 +65,7 @@
                 </svg>
             </div>
 
-            <main class="relative z-10 mx-auto flex min-h-[calc(100vh-136px)] w-full max-w-7xl items-center px-5 pb-20 pt-16 sm:px-10">
+            <main class="relative z-10 mx-auto flex min-h-0 flex-1 w-full max-w-7xl items-center px-5 py-12 sm:px-10 lg:py-16">
                 <section class="w-full text-center">
                     <div class="mx-auto w-fit ista-pill">Asisten Istana Pintar</div>
                     <h1 class="ista-hero-title mt-8 text-stone-900 dark:text-gray-100">Tanya <strong><span class="text-ista-primary">ISTA</span> <span class="font-light italic text-ista-gold">AI</span></strong></h1>
@@ -95,7 +95,7 @@
                 </section>
             </main>
 
-            <footer class="relative z-20 flex h-[72px] flex-col items-center justify-center border-t border-stone-200/80 bg-white/80 backdrop-blur dark:border-[#1E293B]/70 dark:bg-gray-900/80">
+            <footer class="relative z-20 flex h-[72px] flex-none flex-col items-center justify-center border-t border-stone-200/80 bg-white/80 backdrop-blur dark:border-[#1E293B]/70 dark:bg-gray-900/80">
                 <p class="text-[11px] font-bold uppercase tracking-widest text-[#78716c] dark:text-[#94A3B8]">Copyright &copy; 2026 Istana Kepresidenan Yogyakarta</p>
                 <p class="mt-1 text-[9px] font-medium uppercase tracking-[0.3em] text-[#a8a29e] dark:text-[#64748B]">All Rights Reserved.</p>
             </footer>

--- a/laravel/resources/views/livewire/chat/chat-index.blade.php
+++ b/laravel/resources/views/livewire/chat/chat-index.blade.php
@@ -1,8 +1,11 @@
 <div x-data="chatLayout({ activeTab: $wire.entangle('tab').live })"
-     x-on:dragenter.window.prevent="onDragEnter($event)"
-     x-on:dragover.window.prevent="onDragOver($event)"
-     x-on:dragleave.window.prevent="onDragLeave($event)"
-     x-on:drop.window.prevent="onDropFile($event)"
+     x-on:dragenter.window="onDragEnter($event)"
+     x-on:dragover.window="onDragOver($event)"
+     x-on:dragleave.window="onDragLeave($event)"
+     x-on:drop.window="onDropFile($event)"
+     x-on:dragend.window="resetDraggingFile()"
+     x-on:blur.window="resetDraggingFile()"
+     x-on:keydown.escape.window="resetDraggingFile()"
      x-on:open-sidebar-right.window="showRightSidebar = true"
      x-on:chat-tab-switch.window="setTab($event.detail?.tab)"
      x-on:conversation-loading.window="isSwitchingConversation = true"
@@ -67,7 +70,7 @@
                             <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-[#64748B]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />
                             </svg>
-                            <svg x-show="darkMode === true" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <svg x-show="darkMode === true" style="display: none;" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z" />
                             </svg>
                         </button>
@@ -99,7 +102,7 @@
     </div>
 
     <!-- Drag & Drop Overlay Visual -->
-    <div x-show="isDraggingFile" x-transition.opacity class="fixed inset-0 z-[60] bg-ista-primary/10 backdrop-blur-[2px] flex items-center justify-center pointer-events-none">
+    <div x-show="isDraggingFile" x-cloak x-transition.opacity class="fixed inset-0 z-[60] bg-ista-primary/10 backdrop-blur-[2px] flex items-center justify-center pointer-events-none">
         <div class="h-[120px] w-[320px] rounded-2xl border-2 border-dashed border-ista-primary bg-white/90 dark:bg-gray-900/90 shadow-2xl flex flex-col items-center justify-center gap-3 scale-110 transition-transform">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-ista-primary animate-bounce" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />

--- a/laravel/resources/views/livewire/chat/partials/chat-composer.blade.php
+++ b/laravel/resources/views/livewire/chat/partials/chat-composer.blade.php
@@ -126,7 +126,7 @@
                 </div>
             </div>
 
-            <div x-show="isDraggingFile" x-transition.opacity class="px-3 pb-3 pt-3 w-full">
+            <div x-show="isDraggingFile" x-cloak x-transition.opacity class="px-3 pb-3 pt-3 w-full">
                 <div class="h-[84px] w-full rounded-xl border-2 border-dashed border-ista-primary/40 dark:border-[#8E81FF] bg-ista-primary/5 dark:bg-[#312E81]/20 flex items-center justify-center gap-2 text-[13px] font-semibold text-ista-primary dark:text-[#A5B4FC]">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
@@ -136,7 +136,7 @@
             </div>
         </div>
     </form>
-    <p x-show="dropError" x-transition.opacity class="max-w-3xl mx-auto mt-2 text-xs text-red-500 dark:text-red-400" x-text="dropError"></p>
+    <p x-show="dropError" x-cloak x-transition.opacity class="max-w-3xl mx-auto mt-2 text-xs text-red-500 dark:text-red-400" x-text="dropError"></p>
     <div class="text-center mt-3 text-[11px] text-[#94A3B8] dark:text-[#64748B]">
         ISTA AI dapat keliru. Mohon verifikasi kembali informasi yang penting.
     </div>

--- a/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
+++ b/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
@@ -37,7 +37,7 @@
                 <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-[#64748B]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />
                 </svg>
-                <svg x-show="darkMode === true" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg x-show="darkMode === true" style="display: none;" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z" />
                 </svg>
             </button>

--- a/laravel/tests/Feature/Chat/ChatUiTest.php
+++ b/laravel/tests/Feature/Chat/ChatUiTest.php
@@ -118,6 +118,21 @@ class ChatUiTest extends TestCase
             ->assertSee('aria-label="Tambahkan dokumen terpilih ke chat"', false);
     }
 
+    public function test_chat_drag_drop_overlay_is_cloaked_and_has_reset_handlers(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('chat'))
+            ->assertOk()
+            ->assertSee('x-on:dragenter.window="onDragEnter($event)"', false)
+            ->assertSee('x-on:dragend.window="resetDraggingFile()"', false)
+            ->assertSee('x-on:blur.window="resetDraggingFile()"', false)
+            ->assertSee('x-on:keydown.escape.window="resetDraggingFile()"', false)
+            ->assertSee('x-show="isDraggingFile" x-cloak', false)
+            ->assertDontSee('x-on:dragenter.window.prevent', false);
+    }
+
     public function test_create_conversation_if_needed_throws_for_unowned_conversation(): void
     {
         $userA = User::factory()->create();

--- a/laravel/tests/Feature/DashboardTest.php
+++ b/laravel/tests/Feature/DashboardTest.php
@@ -20,6 +20,18 @@ class DashboardTest extends TestCase
         $response->assertSee(route('guest-memo'), false);
     }
 
+    public function test_dashboard_keeps_header_main_and_footer_inside_viewport(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $response->assertSee('min-h-[var(--app-viewport-height)]', false);
+        $response->assertSee('flex-none', false);
+        $response->assertSee('flex-1', false);
+        $response->assertSee('All Rights Reserved.', false);
+        $response->assertSee('x-show="darkMode === true" style="display: none;"', false);
+    }
+
     public function test_guest_chat_redirects_to_login_and_saves_prompt(): void
     {
         $response = $this->get('/guest-chat?q=hello');

--- a/laravel/tests/Feature/SecurityHeadersTest.php
+++ b/laravel/tests/Feature/SecurityHeadersTest.php
@@ -19,6 +19,7 @@ class SecurityHeadersTest extends TestCase
         $this->assertStringContainsString("img-src 'self' data: blob:", $csp);
         $this->assertStringContainsString("object-src 'none'", $csp);
         $this->assertStringContainsString("frame-ancestors 'self'", $csp);
+        $this->assertStringContainsString("script-src 'self' 'unsafe-inline' 'unsafe-eval'", $csp);
         $this->assertStringNotContainsString('img-src https:', $csp);
         $response->assertHeader('X-Content-Type-Options', 'nosniff');
         $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');


### PR DESCRIPTION
## Summary
- Restore Alpine/Livewire compatibility by allowing the runtime evaluator required by Alpine expressions in the CSP `script-src`.
- Add `x-cloak` and reset handlers to the chat drag/drop upload overlay so it cannot remain visible when drag events are cancelled or the window loses focus.
- Make the dashboard shell a viewport flex column so header, main content, and footer stay inside the visible viewport.
- Hide dark-mode SVG fallbacks by default so both icons do not display before Alpine boots.

## Root cause
The new CSP blocked Alpine's runtime expression evaluator. That made `x-show` states fail in production, which surfaced as the upload overlay being visible on chat/memo and dashboard header controls showing both theme icons.

## Verification
- `cd laravel && vendor/bin/pint --dirty`
- `cd laravel && php artisan test tests/Feature/SecurityHeadersTest.php tests/Feature/DashboardTest.php tests/Feature/Chat/ChatUiTest.php` -> 60 passed
- `cd laravel && npm run build`
- `cd laravel && php -d memory_limit=512M vendor/bin/phpunit` -> 398 tests, 1725 assertions OK
- `cd laravel && composer audit --locked` -> no advisories
- `cd laravel && npm audit --audit-level=high` -> 0 vulnerabilities

Note: `php artisan test` hit the local 128MB PHP memory ceiling near the end of the full suite; direct PHPUnit with 512MB completed cleanly.
