### PR TITLE
Fix memo export force-save guard

### DIFF
--- a/issue/issue-237-prod-e2e-qa-2026-05-18.md
+++ b/issue/issue-237-prod-e2e-qa-2026-05-18.md
@@ -1,0 +1,61 @@
+# Issue 237 Production E2E QA
+
+Tanggal: 2026-05-18
+
+## Tujuan
+
+Melakukan QA browser end-to-end pada production setelah hotfix UI/CSP `557d5d9`, dengan fokus mencari regresi dari perubahan security wave dan hotfix UI.
+
+## Scope QA
+
+- Dashboard publik, header, footer, dark mode, dan navigasi ke chat/memo.
+- Registrasi akun test, verifikasi OTP bila tersedia dari database production, login, logout, dan reset password.
+- Chat biasa, chat dengan dokumen, chat dengan web search.
+- Upload dokumen kecil, sedang, dan besar dengan konten teks banyak.
+- Preview dokumen dan export jawaban chat.
+- Memo: buat memo, ubah konfigurasi, generate via konfigurasi, edit/revisi via prompt, export/download memo.
+- Pemeriksaan error browser console, request gagal, overlay upload stuck, ikon dark mode dobel, layout header/footer, dan CSP block.
+
+## Batasan dan Asumsi
+
+- QA dilakukan pada production `https://ista-ai.app` menggunakan akun test baru.
+- Jika email reset/OTP tidak bisa diakses via inbox, token/kode test boleh diverifikasi lewat database production menggunakan SSH, tanpa menampilkan secret.
+- Jika ditemukan bug valid akibat security fix, buat branch hotfix, implementasikan perbaikan kecil, jalankan test relevan, PR/merge/deploy, lalu ulangi QA area terdampak.
+- Hindari mengubah atau menghapus data pengguna non-test.
+
+## Rencana Eksekusi
+
+1. Siapkan browser automation dan file fixture dokumen kecil/sedang/besar.
+2. Jalankan QA auth: register, OTP, logout/login, forgot/reset password, login password baru.
+3. Jalankan QA dashboard dan preferensi UI: header/footer, dark mode, tab chat/memo.
+4. Jalankan QA chat: chat biasa, web search, upload dokumen, chat dengan dokumen, preview, export.
+5. Jalankan QA memo: buat memo, konfigurasi, generate, revisi prompt, manual/editor surface, export/download.
+6. Catat bug dengan bukti screenshot/log/console.
+7. Jika perlu perbaikan, implementasikan di branch hotfix dan ulangi verifikasi lokal + deploy production.
+
+## Kriteria Selesai
+
+- Alur utama di atas berhasil atau limitation-nya jelas.
+- Tidak ada console error/CSP block yang terkait security fix pada alur utama.
+- Tidak ada overlay/upload/dark-mode/header/footer regresi yang terlihat.
+- Jika ada bug valid, bug sudah diperbaiki dan QA area tersebut diulang.
+
+## Temuan Selama QA
+
+### Bug: Export/download memo diblokir force-save kosong
+
+Status: valid, perlu hotfix.
+
+Bukti:
+- Browser QA untuk memo `753` timeout saat klik `Unduh DOCX`.
+- Direct authenticated GET `/chat/memos/753/download?version_id=968` berhasil `200` dan mengembalikan DOCX `38718` bytes.
+- POST `/chat/memos/753/force-save` mengembalikan `409` dengan pesan `OnlyOffice belum siap menyimpan dokumen. Kode error: 1`.
+
+Analisis:
+- UI selalu memanggil force-save sebelum download/export/config/revisi, walaupun editor tidak punya perubahan manual yang belum tersimpan.
+- Untuk kondisi tanpa perubahan aktif, file memo versi saat ini sudah aman diunduh langsung. Memaksa force-save justru membuat workflow gagal jika OnlyOffice tidak punya sesi dokumen aktif.
+
+Rencana fix:
+- Tambahkan guard frontend agar force-save hanya dijalankan ketika `window.memoOnlyOfficeState` menandai dokumen sebagai `dirty`.
+- Terapkan guard yang sama pada download/export, submit konfigurasi, revisi prompt, before-unload, dan perpindahan memo via JS.
+- Ulangi QA download DOCX/PDF dan alur memo setelah deploy.

--- a/laravel/app/Livewire/Memos/MemoWorkspace.php
+++ b/laravel/app/Livewire/Memos/MemoWorkspace.php
@@ -383,7 +383,7 @@ class MemoWorkspace extends Component
         }
     }
 
-    public function switchMemoVersion(int|string $versionId): void
+    public function switchMemoVersion(int|string $versionId, bool $syncActiveEditor = true): void
     {
         if (! $this->activeMemoId || ! is_numeric($versionId)) {
             return;
@@ -391,7 +391,7 @@ class MemoWorkspace extends Component
 
         $targetVersionId = (int) $versionId;
 
-        if ((int) $this->activeMemoVersionId !== $targetVersionId && ! $this->syncActiveMemoEditorBeforeLeaving()) {
+        if ($syncActiveEditor && (int) $this->activeMemoVersionId !== $targetVersionId && ! $this->syncActiveMemoEditorBeforeLeaving()) {
             return;
         }
 

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -2091,7 +2091,9 @@ const registerChatPageData = (Alpine) => {
             const memoLoadToken = this.memoLoadToken + 1;
             this.memoLoadToken = memoLoadToken;
             this.loadingMemoId = memoId;
-            const shouldSyncActiveEditor = Number.isFinite(previousMemoId) && previousMemoId > 0;
+            const shouldSyncActiveEditor = Number.isFinite(previousMemoId)
+                && previousMemoId > 0
+                && this.hasUnsavedOnlyOfficeChanges();
 
             return (shouldSyncActiveEditor ? this.waitForOnlyOfficeToSettle() : Promise.resolve())
                 .then(() => this.$wire.loadMemo(memoId, shouldSyncActiveEditor))
@@ -2154,6 +2156,10 @@ const registerChatPageData = (Alpine) => {
             return states
                 .filter((state) => !state?.destroyedAt || Number(state.destroyedAt) < Number(state.lastReadyAt || state.lastChangeAt || 0))
                 .sort((a, b) => Number(b?.lastChangeAt || b?.lastReadyAt || 0) - Number(a?.lastChangeAt || a?.lastReadyAt || 0))[0] || null;
+        },
+
+        hasUnsavedOnlyOfficeChanges() {
+            return Boolean(this.latestOnlyOfficeState()?.dirty);
         },
 
         sleep(ms) {
@@ -2923,12 +2929,17 @@ const registerChatPageData = (Alpine) => {
             }
 
             this.downloadLoading = type;
-            this.downloadStatus = 'Menyimpan perubahan editor...';
+            this.downloadStatus = 'Menyiapkan unduhan...';
             this.downloadError = '';
 
             try {
                 await this.waitForOnlyOfficeToSettle();
-                await this.forceSaveMemo(forceSaveUrl, versionId);
+
+                if (this.hasUnsavedOnlyOfficeChanges()) {
+                    this.downloadStatus = 'Menyimpan perubahan editor...';
+                    await this.forceSaveMemo(forceSaveUrl, versionId);
+                }
+
                 this.downloadStatus = type === 'pdf' ? 'Menyiapkan PDF...' : 'Menyiapkan DOCX...';
 
                 const response = await fetch(this.versionedUrl(url, versionId), {
@@ -2982,6 +2993,10 @@ const registerChatPageData = (Alpine) => {
             return states
                 .filter((state) => !state?.destroyedAt || Number(state.destroyedAt) < Number(state.lastReadyAt || state.lastChangeAt || 0))
                 .sort((a, b) => Number(b?.lastChangeAt || b?.lastReadyAt || 0) - Number(a?.lastChangeAt || a?.lastReadyAt || 0))[0] || null;
+        },
+
+        hasUnsavedOnlyOfficeChanges() {
+            return Boolean(this.latestOnlyOfficeState()?.dirty);
         },
 
         sleep(ms) {
@@ -3124,6 +3139,12 @@ const registerChatPageData = (Alpine) => {
             this.showMemoSidebar = false;
         },
 
+        async switchMemoVersion($wire, versionId) {
+            await this.waitForOnlyOfficeToSettle();
+
+            return $wire.switchMemoVersion(versionId, this.hasUnsavedOnlyOfficeChanges());
+        },
+
         async submitMemoRevision($wire, textarea) {
             const message = (textarea?.value || '').trim();
 
@@ -3187,6 +3208,10 @@ const registerChatPageData = (Alpine) => {
 
             await this.waitForOnlyOfficeToSettle();
 
+            if (!this.hasUnsavedOnlyOfficeChanges()) {
+                return;
+            }
+
             const baseUrl = this.$root?.dataset?.memoForceSaveBaseUrl || '/chat/memos';
             const versionId = $wire.activeMemoVersionId || document.getElementById('memo-version-select')?.value || null;
             const response = await fetch(`${baseUrl}/${memoId}/force-save`, {
@@ -3212,10 +3237,9 @@ const registerChatPageData = (Alpine) => {
 
         forceSaveActiveMemoBeforeUnload($wire) {
             const state = this.latestOnlyOfficeState();
-            const lastChangeAt = Number(state?.lastChangeAt || 0);
             const memoId = Number($wire?.activeMemoId || 0);
 
-            if (!memoId || !lastChangeAt) {
+            if (!memoId || !state?.dirty) {
                 return;
             }
 
@@ -3282,6 +3306,10 @@ const registerChatPageData = (Alpine) => {
             return states
                 .filter((state) => !state?.destroyedAt || Number(state.destroyedAt) < Number(state.lastReadyAt || state.lastChangeAt || 0))
                 .sort((a, b) => Number(b?.lastChangeAt || b?.lastReadyAt || 0) - Number(a?.lastChangeAt || a?.lastReadyAt || 0))[0] || null;
+        },
+
+        hasUnsavedOnlyOfficeChanges() {
+            return Boolean(this.latestOnlyOfficeState()?.dirty);
         },
 
         sleep(ms) {

--- a/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
+++ b/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
@@ -75,7 +75,7 @@
                     <div class="mt-3 flex items-center gap-2 border-t border-stone-100 pt-3 dark:border-gray-800">
                         <label for="memo-version-select" class="shrink-0 text-[10.5px] font-bold uppercase tracking-wider text-stone-400 dark:text-gray-500">Versi memo</label>
                         <select id="memo-version-select"
-                                wire:change="switchMemoVersion($event.target.value)"
+                                x-on:change.stop.prevent="switchMemoVersion($wire, $event.target.value)"
                                 class="min-w-0 flex-1 rounded-md border border-stone-200 bg-white px-2.5 py-1.5 text-[12px] font-semibold text-stone-700 shadow-sm outline-none focus:border-ista-primary focus:outline-none focus:ring-1 focus:ring-ista-primary focus-visible:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100">
                             @foreach ($activeMemoVersions as $version)
                                 <option value="{{ $version->id }}" @selected((int) $activeMemoVersionId === (int) $version->id)>

--- a/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
+++ b/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
@@ -219,6 +219,7 @@ class MemoWorkspaceTest extends TestCase
         $this->assertStringContainsString('isLoadingMemo(id)', $chatPageJs);
         $this->assertStringContainsString('loadMemo(id)', $chatPageJs);
         $this->assertStringContainsString('this.loadingMemoId = memoId', $chatPageJs);
+        $this->assertStringContainsString('&& this.hasUnsavedOnlyOfficeChanges()', $chatPageJs);
         $this->assertStringContainsString('this.$wire.loadMemo(memoId, shouldSyncActiveEditor)', $chatPageJs);
         $this->assertStringContainsString('waitForOnlyOfficeToSettle()', $chatPageJs);
         $this->assertStringContainsString('this.loadingMemoId = null', $chatPageJs);
@@ -1341,6 +1342,40 @@ class MemoWorkspaceTest extends TestCase
             ->assertSee('Buat ulang dari konfigurasi', false)
             ->assertDontSee('Memo "Memo Panjang Format Folio Eksplisit" dimuat.', false)
             ->assertDontSee('Tulis revisi untuk memo ini', false);
+    }
+
+    public function test_switch_memo_version_can_skip_editor_sync_when_no_unsaved_changes(): void
+    {
+        Storage::fake('local');
+        Http::fake([
+            '*' => fn () => throw new \RuntimeException('OnlyOffice force-save should not be called without unsaved editor changes.'),
+        ]);
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        [$memo, $versionOne] = $this->memoWithVersion($user, 'Memo Versi Tanpa Edit Manual', 'memos/'.$user->id.'/version-one.docx');
+        $versionTwoPath = 'memos/'.$user->id.'/version-two.docx';
+        Storage::disk('local')->put($versionTwoPath, $this->validMemoDocxBytes());
+        $versionTwo = $memo->versions()->create([
+            'version_number' => 2,
+            'label' => 'Versi 2',
+            'file_path' => $versionTwoPath,
+            'status' => Memo::STATUS_GENERATED,
+            'configuration' => [],
+            'searchable_text' => 'Memo Versi Tanpa Edit Manual v2',
+        ]);
+        $memo->forceFill([
+            'current_version_id' => $versionTwo->id,
+            'file_path' => $versionTwoPath,
+        ])->save();
+
+        Livewire::actingAs($user)
+            ->test(MemoWorkspace::class)
+            ->call('loadMemo', $memo->id)
+            ->assertSet('activeMemoVersionId', $versionTwo->id)
+            ->call('switchMemoVersion', $versionOne->id, false)
+            ->assertSet('activeMemoVersionId', $versionOne->id);
+
+        Http::assertNothingSent();
     }
 
     /**


### PR DESCRIPTION
## Summary
- Adds production E2E QA plan and records the memo export regression found during QA.
- Skips OnlyOffice force-save when the editor has no unsaved manual changes.
- Keeps force-save behavior for dirty editor state before memo export, config regenerate, prompt revision, before-unload, and memo/version switching.

## Verification
- cd laravel && php artisan test --filter=MemoWorkspaceTest
- cd laravel && php artisan test tests/Feature/Memos/OnlyOfficeCallbackTest.php
- cd laravel && npm run build
- cd laravel && ./vendor/bin/pint --dirty --test

## Production QA Evidence
- Direct DOCX download for QA memo 753 returned 200 and 38,718 bytes.
- Previous pre-download force-save returned 409 with OnlyOffice error 1 when no unsaved editor changes existed.