### PR TITLE
Sync memo manual edits before export

### DIFF
--- a/issue/issue-237-prod-e2e-qa-2026-05-18.md
+++ b/issue/issue-237-prod-e2e-qa-2026-05-18.md
@@ -59,3 +59,17 @@ Rencana fix:
 - Tambahkan guard frontend agar force-save hanya dijalankan ketika `window.memoOnlyOfficeState` menandai dokumen sebagai `dirty`.
 - Terapkan guard yang sama pada download/export, submit konfigurasi, revisi prompt, before-unload, dan perpindahan memo via JS.
 - Ulangi QA download DOCX/PDF dan alur memo setelah deploy.
+
+### Bug lanjutan: edit manual OnlyOffice bisa kembali `dirty=false` sebelum tersinkron ke Laravel
+
+Status: valid, perlu hotfix tambahan.
+
+Bukti:
+- Browser QA berhasil mengetik token `QA_MANUAL_*` di editor OnlyOffice.
+- `window.memoOnlyOfficeState` menunjukkan `lastChangeAt` terisi, tetapi `dirty=false` karena OnlyOffice menampilkan status internal `Semua perubahan tersimpan`.
+- Jika guard hanya melihat `dirty=true`, tombol download melewati force-save dan mengambil file Laravel versi lama.
+
+Rencana fix:
+- Ubah guard frontend menjadi sinkron jika state editor `dirty=true` atau `lastChangeAt > 0`.
+- Tetap skip force-save untuk editor yang belum pernah berubah (`lastChangeAt=0`), agar bug `error 1` pada force-save kosong tidak kembali.
+- Ulangi QA manual edit + download/export untuk memastikan force-save berjalan dan file tersinkron.

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -2093,7 +2093,7 @@ const registerChatPageData = (Alpine) => {
             this.loadingMemoId = memoId;
             const shouldSyncActiveEditor = Number.isFinite(previousMemoId)
                 && previousMemoId > 0
-                && this.hasUnsavedOnlyOfficeChanges();
+                && this.hasOnlyOfficeChangesToSync();
 
             return (shouldSyncActiveEditor ? this.waitForOnlyOfficeToSettle() : Promise.resolve())
                 .then(() => this.$wire.loadMemo(memoId, shouldSyncActiveEditor))
@@ -2158,8 +2158,10 @@ const registerChatPageData = (Alpine) => {
                 .sort((a, b) => Number(b?.lastChangeAt || b?.lastReadyAt || 0) - Number(a?.lastChangeAt || a?.lastReadyAt || 0))[0] || null;
         },
 
-        hasUnsavedOnlyOfficeChanges() {
-            return Boolean(this.latestOnlyOfficeState()?.dirty);
+        hasOnlyOfficeChangesToSync() {
+            const state = this.latestOnlyOfficeState();
+
+            return Boolean(state?.dirty || Number(state?.lastChangeAt || 0) > 0);
         },
 
         sleep(ms) {
@@ -2935,7 +2937,7 @@ const registerChatPageData = (Alpine) => {
             try {
                 await this.waitForOnlyOfficeToSettle();
 
-                if (this.hasUnsavedOnlyOfficeChanges()) {
+                if (this.hasOnlyOfficeChangesToSync()) {
                     this.downloadStatus = 'Menyimpan perubahan editor...';
                     await this.forceSaveMemo(forceSaveUrl, versionId);
                 }
@@ -2995,8 +2997,10 @@ const registerChatPageData = (Alpine) => {
                 .sort((a, b) => Number(b?.lastChangeAt || b?.lastReadyAt || 0) - Number(a?.lastChangeAt || a?.lastReadyAt || 0))[0] || null;
         },
 
-        hasUnsavedOnlyOfficeChanges() {
-            return Boolean(this.latestOnlyOfficeState()?.dirty);
+        hasOnlyOfficeChangesToSync() {
+            const state = this.latestOnlyOfficeState();
+
+            return Boolean(state?.dirty || Number(state?.lastChangeAt || 0) > 0);
         },
 
         sleep(ms) {
@@ -3142,7 +3146,7 @@ const registerChatPageData = (Alpine) => {
         async switchMemoVersion($wire, versionId) {
             await this.waitForOnlyOfficeToSettle();
 
-            return $wire.switchMemoVersion(versionId, this.hasUnsavedOnlyOfficeChanges());
+            return $wire.switchMemoVersion(versionId, this.hasOnlyOfficeChangesToSync());
         },
 
         async submitMemoRevision($wire, textarea) {
@@ -3208,7 +3212,7 @@ const registerChatPageData = (Alpine) => {
 
             await this.waitForOnlyOfficeToSettle();
 
-            if (!this.hasUnsavedOnlyOfficeChanges()) {
+            if (!this.hasOnlyOfficeChangesToSync()) {
                 return;
             }
 
@@ -3239,7 +3243,7 @@ const registerChatPageData = (Alpine) => {
             const state = this.latestOnlyOfficeState();
             const memoId = Number($wire?.activeMemoId || 0);
 
-            if (!memoId || !state?.dirty) {
+            if (!memoId || !(state?.dirty || Number(state?.lastChangeAt || 0) > 0)) {
                 return;
             }
 
@@ -3308,8 +3312,10 @@ const registerChatPageData = (Alpine) => {
                 .sort((a, b) => Number(b?.lastChangeAt || b?.lastReadyAt || 0) - Number(a?.lastChangeAt || a?.lastReadyAt || 0))[0] || null;
         },
 
-        hasUnsavedOnlyOfficeChanges() {
-            return Boolean(this.latestOnlyOfficeState()?.dirty);
+        hasOnlyOfficeChangesToSync() {
+            const state = this.latestOnlyOfficeState();
+
+            return Boolean(state?.dirty || Number(state?.lastChangeAt || 0) > 0);
         },
 
         sleep(ms) {

--- a/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
+++ b/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
@@ -219,7 +219,8 @@ class MemoWorkspaceTest extends TestCase
         $this->assertStringContainsString('isLoadingMemo(id)', $chatPageJs);
         $this->assertStringContainsString('loadMemo(id)', $chatPageJs);
         $this->assertStringContainsString('this.loadingMemoId = memoId', $chatPageJs);
-        $this->assertStringContainsString('&& this.hasUnsavedOnlyOfficeChanges()', $chatPageJs);
+        $this->assertStringContainsString('&& this.hasOnlyOfficeChangesToSync()', $chatPageJs);
+        $this->assertStringContainsString('Number(state?.lastChangeAt || 0) > 0', $chatPageJs);
         $this->assertStringContainsString('this.$wire.loadMemo(memoId, shouldSyncActiveEditor)', $chatPageJs);
         $this->assertStringContainsString('waitForOnlyOfficeToSettle()', $chatPageJs);
         $this->assertStringContainsString('this.loadingMemoId = null', $chatPageJs);


### PR DESCRIPTION
## Summary
- Extends the memo force-save guard to sync when OnlyOffice reports any editor change (`lastChangeAt > 0`), even if the editor is no longer dirty.
- Keeps skipping force-save for untouched editor sessions (`lastChangeAt = 0`) to avoid the empty force-save 409 regression.
- Records the manual-edit QA finding in the production E2E QA plan.

## Verification
- cd laravel && php artisan test --filter=MemoWorkspaceTest
- cd laravel && npm run build
- cd laravel && ./vendor/bin/pint --dirty --test

## Production QA Evidence
- Manual typing inserted `QA_MANUAL_*` into OnlyOffice and changed `lastChangeAt` while `dirty=false`.
- Previous guard skipped force-save in that state, so this patch treats any editor change as requiring sync before export/download.
