### PR TITLE
Admin foundation: role, route protection, and presence (#214)

### DIFF
--- a/issue/issue-217-01-admin-foundation-role-presence-2026-05-18.md
+++ b/issue/issue-217-01-admin-foundation-role-presence-2026-05-18.md
@@ -1,0 +1,73 @@
+# Child 1: Admin Foundation, Role, Route Protection, dan Presence
+
+Parent: https://github.com/Hasbi1605/ISTA-AI/issues/209
+GitHub Issue: https://github.com/Hasbi1605/ISTA-AI/issues/214
+
+## Latar Belakang
+Dashboard admin membutuhkan fondasi akses yang aman sebelum modul monitoring, knowledge base, dan AI Configuration dibuat. Saat ini `users` belum memiliki role admin/super_admin dan belum ada `last_seen_at` untuk status aktif user.
+
+## Tujuan
+- Menambahkan role `user`, `admin`, dan `super_admin`.
+- Melindungi route admin dengan middleware.
+- Menambahkan presence tracking melalui `last_seen_at`.
+- Menyiapkan fondasi tanpa mengubah perilaku chat, memo, dokumen, atau Google Drive.
+
+## Ruang Lingkup
+- Migration additive untuk `users`.
+- Middleware admin/super_admin.
+- Middleware presence dengan cache throttle.
+- Route group `/admin`.
+- Command/seeder untuk promote admin dan super_admin.
+- Test akses dan presence.
+
+## Di Luar Scope
+- Dashboard KPI lengkap.
+- Event tracking detail.
+- Knowledge base internal.
+- AI Configuration.
+- ISTURA.
+
+## Area / File Terkait
+- `laravel/app/Models/User.php`
+- `laravel/bootstrap/app.php`
+- `laravel/routes/web.php`
+- `laravel/database/migrations/*`
+- `laravel/app/Http/Middleware/*`
+- `laravel/app/Console/Commands/*`
+- `laravel/tests/Feature/*`
+
+## Risiko
+- Salah konfigurasi middleware bisa membuka akses admin ke user biasa.
+- Presence update terlalu sering bisa menambah beban database.
+- Role `super_admin` harus tetap bisa mengakses route admin umum.
+
+## Langkah Implementasi
+1. Tambah migration `role`, `last_seen_at`, `last_active_feature` pada `users`.
+2. Tambah cast/fillable yang diperlukan pada `User`.
+3. Buat middleware `EnsureUserIsAdmin`.
+4. Buat middleware `EnsureUserIsSuperAdmin`.
+5. Buat middleware `UpdateUserPresence` dengan cache throttle 60 detik.
+6. Daftarkan middleware di Laravel 11 bootstrap.
+7. Buat route placeholder `/admin` yang hanya bisa diakses admin/super_admin.
+8. Buat command promote admin dan promote super_admin.
+9. Tambah test akses dan presence.
+
+## Rencana Test
+```bash
+cd laravel && php artisan test --filter='Admin|Presence|User'
+```
+
+Minimal test:
+- Guest diarahkan ke login.
+- User biasa 403 untuk `/admin`.
+- Admin bisa membuka `/admin`.
+- Super admin bisa membuka `/admin` dan `/admin/ai-config`.
+- Admin biasa 403 untuk `/admin/ai-config`.
+- `last_seen_at` terupdate dan tidak update terlalu sering.
+
+## Kriteria Selesai
+- Role dan middleware tersedia.
+- Route admin terlindungi.
+- Presence user tercatat.
+- Tidak ada perubahan perilaku chat/memo/dokumen existing.
+- Test relevan lulus.

--- a/laravel/app/Console/Commands/PromoteUserToAdmin.php
+++ b/laravel/app/Console/Commands/PromoteUserToAdmin.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class PromoteUserToAdmin extends Command
+{
+    protected $signature = 'users:promote-admin {email : Email user yang akan dijadikan admin}';
+
+    protected $description = 'Promote a user to the admin role by email.';
+
+    public function handle(): int
+    {
+        $email = (string) $this->argument('email');
+
+        $user = User::query()->where('email', $email)->first();
+
+        if (! $user) {
+            $this->error(sprintf('User dengan email "%s" tidak ditemukan.', $email));
+
+            return self::FAILURE;
+        }
+
+        if ($user->role === User::ROLE_SUPER_ADMIN) {
+            $this->warn(sprintf('User "%s" adalah super admin. Role tidak diturunkan.', $user->email));
+
+            return self::SUCCESS;
+        }
+
+        if ($user->role === User::ROLE_ADMIN) {
+            $this->info(sprintf('User "%s" sudah berperan sebagai admin.', $user->email));
+
+            return self::SUCCESS;
+        }
+
+        $user->forceFill(['role' => User::ROLE_ADMIN])->save();
+
+        $this->info(sprintf('User "%s" sekarang berperan sebagai admin.', $user->email));
+
+        return self::SUCCESS;
+    }
+}

--- a/laravel/app/Console/Commands/PromoteUserToSuperAdmin.php
+++ b/laravel/app/Console/Commands/PromoteUserToSuperAdmin.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class PromoteUserToSuperAdmin extends Command
+{
+    protected $signature = 'users:promote-super-admin {email : Email user yang akan dijadikan super admin}';
+
+    protected $description = 'Promote a user to the super admin role by email.';
+
+    public function handle(): int
+    {
+        $email = (string) $this->argument('email');
+
+        $user = User::query()->where('email', $email)->first();
+
+        if (! $user) {
+            $this->error(sprintf('User dengan email "%s" tidak ditemukan.', $email));
+
+            return self::FAILURE;
+        }
+
+        if ($user->role === User::ROLE_SUPER_ADMIN) {
+            $this->info(sprintf('User "%s" sudah berperan sebagai super admin.', $user->email));
+
+            return self::SUCCESS;
+        }
+
+        $user->forceFill(['role' => User::ROLE_SUPER_ADMIN])->save();
+
+        $this->info(sprintf('User "%s" sekarang berperan sebagai super admin.', $user->email));
+
+        return self::SUCCESS;
+    }
+}

--- a/laravel/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/laravel/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsAdmin
+{
+    /**
+     * Allow only authenticated admin or super admin users.
+     *
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return redirect()->guest(route('login'));
+        }
+
+        if (! method_exists($user, 'canAccessAdmin') || ! $user->canAccessAdmin()) {
+            abort(403, 'Halaman ini hanya untuk admin.');
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Http/Middleware/EnsureUserIsSuperAdmin.php
+++ b/laravel/app/Http/Middleware/EnsureUserIsSuperAdmin.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsSuperAdmin
+{
+    /**
+     * Allow only authenticated super admin users.
+     *
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return redirect()->guest(route('login'));
+        }
+
+        if (! method_exists($user, 'isSuperAdmin') || ! $user->isSuperAdmin()) {
+            abort(403, 'Halaman ini hanya untuk super admin.');
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Http/Middleware/UpdateUserPresence.php
+++ b/laravel/app/Http/Middleware/UpdateUserPresence.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Symfony\Component\HttpFoundation\Response;
+
+class UpdateUserPresence
+{
+    /**
+     * Throttle window in seconds. Within this window we only update once per user.
+     */
+    private const THROTTLE_SECONDS = 60;
+
+    /**
+     * Track the latest interaction time for the authenticated user without
+     * thrashing the database on every request. Updates are coalesced through
+     * a per-user cache lock so that high-traffic endpoints stay cheap.
+     *
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $user = $request->user();
+
+        if (! $user || ! $user->exists) {
+            return $response;
+        }
+
+        $cacheKey = sprintf('user-presence:%s', $user->getKey());
+
+        if (Cache::has($cacheKey)) {
+            return $response;
+        }
+
+        $feature = $this->resolveFeature($request);
+
+        try {
+            $user->forceFill([
+                'last_seen_at' => now(),
+                'last_active_feature' => $feature,
+            ])->saveQuietly();
+
+            Cache::put($cacheKey, true, self::THROTTLE_SECONDS);
+        } catch (\Throwable $exception) {
+            // Presence updates must never break a request. Swallow errors and continue.
+            report($exception);
+        }
+
+        return $response;
+    }
+
+    private function resolveFeature(Request $request): ?string
+    {
+        $route = $request->route();
+
+        if ($route && method_exists($route, 'getName')) {
+            $name = $route->getName();
+
+            if (is_string($name) && $name !== '') {
+                return mb_substr($name, 0, 64);
+            }
+        }
+
+        $path = trim($request->path(), '/');
+
+        return $path === '' ? null : mb_substr($path, 0, 64);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -16,6 +16,18 @@ class User extends Authenticatable implements MustVerifyEmail
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
 
+    public const ROLE_USER = 'user';
+
+    public const ROLE_ADMIN = 'admin';
+
+    public const ROLE_SUPER_ADMIN = 'super_admin';
+
+    public const ROLES = [
+        self::ROLE_USER,
+        self::ROLE_ADMIN,
+        self::ROLE_SUPER_ADMIN,
+    ];
+
     /**
      * The attributes that are mass assignable.
      *
@@ -27,6 +39,9 @@ class User extends Authenticatable implements MustVerifyEmail
         'password',
         'verification_code',
         'verification_code_expires_at',
+        'role',
+        'last_seen_at',
+        'last_active_feature',
     ];
 
     /**
@@ -44,7 +59,32 @@ class User extends Authenticatable implements MustVerifyEmail
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'last_seen_at' => 'datetime',
         ];
+    }
+
+    /**
+     * Determine whether the user has the admin role.
+     */
+    public function isAdmin(): bool
+    {
+        return $this->role === self::ROLE_ADMIN;
+    }
+
+    /**
+     * Determine whether the user has the super admin role.
+     */
+    public function isSuperAdmin(): bool
+    {
+        return $this->role === self::ROLE_SUPER_ADMIN;
+    }
+
+    /**
+     * Admin or super admin can access general admin routes.
+     */
+    public function canAccessAdmin(): bool
+    {
+        return $this->isAdmin() || $this->isSuperAdmin();
     }
 
     /**

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\Http\Middleware\AddSecurityHeaders;
+use App\Http\Middleware\EnsureUserIsAdmin;
+use App\Http\Middleware\EnsureUserIsSuperAdmin;
+use App\Http\Middleware\UpdateUserPresence;
 use App\Support\TrustedProxyConfig;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -25,6 +28,14 @@ return Application::configure(basePath: dirname(__DIR__))
             'onlyoffice/callback/*',
         ]);
         $middleware->append(AddSecurityHeaders::class);
+
+        $middleware->alias([
+            'admin' => EnsureUserIsAdmin::class,
+            'super_admin' => EnsureUserIsSuperAdmin::class,
+            'presence' => UpdateUserPresence::class,
+        ]);
+
+        $middleware->appendToGroup('web', UpdateUserPresence::class);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         $exceptions->reportable(function (Throwable $e) {

--- a/laravel/database/migrations/2026_05_18_100000_add_role_and_presence_to_users_table.php
+++ b/laravel/database/migrations/2026_05_18_100000_add_role_and_presence_to_users_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (! Schema::hasColumn('users', 'role')) {
+                $table->string('role', 32)->default('user')->after('password');
+                $table->index('role');
+            }
+
+            if (! Schema::hasColumn('users', 'last_seen_at')) {
+                $table->timestamp('last_seen_at')->nullable()->after('role');
+                $table->index('last_seen_at');
+            }
+
+            if (! Schema::hasColumn('users', 'last_active_feature')) {
+                $table->string('last_active_feature', 64)->nullable()->after('last_seen_at');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'last_active_feature')) {
+                $table->dropColumn('last_active_feature');
+            }
+
+            if (Schema::hasColumn('users', 'last_seen_at')) {
+                $table->dropIndex(['last_seen_at']);
+                $table->dropColumn('last_seen_at');
+            }
+
+            if (Schema::hasColumn('users', 'role')) {
+                $table->dropIndex(['role']);
+                $table->dropColumn('role');
+            }
+        });
+    }
+};

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -101,4 +101,24 @@ Route::middleware(['auth', 'verified'])
         Route::get('/callback', [GoogleDriveOAuthController::class, 'callback'])->name('callback');
     });
 
+Route::middleware(['auth', 'verified', 'admin'])
+    ->prefix('admin')
+    ->name('admin.')
+    ->group(function () {
+        Route::get('/', function () {
+            return response('Admin dashboard placeholder', 200)
+                ->header('Content-Type', 'text/plain; charset=UTF-8');
+        })->name('dashboard');
+    });
+
+Route::middleware(['auth', 'verified', 'super_admin'])
+    ->prefix('admin')
+    ->name('admin.')
+    ->group(function () {
+        Route::get('/ai-config', function () {
+            return response('Super admin AI configuration placeholder', 200)
+                ->header('Content-Type', 'text/plain; charset=UTF-8');
+        })->name('ai-config');
+    });
+
 require __DIR__.'/auth.php';

--- a/laravel/tests/Feature/Admin/AdminAccessTest.php
+++ b/laravel/tests/Feature/Admin/AdminAccessTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_is_redirected_to_login_for_admin_dashboard(): void
+    {
+        $response = $this->get('/admin');
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_regular_user_is_forbidden_from_admin_dashboard(): void
+    {
+        $user = User::factory()->create([
+            'role' => User::ROLE_USER,
+        ]);
+
+        $response = $this->actingAs($user)->get('/admin');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_can_access_admin_dashboard(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        $response = $this->actingAs($admin)->get('/admin');
+
+        $response->assertStatus(200);
+        $response->assertSeeText('Admin dashboard placeholder');
+    }
+
+    public function test_super_admin_can_access_admin_dashboard(): void
+    {
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+        ]);
+
+        $response = $this->actingAs($superAdmin)->get('/admin');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_admin_is_forbidden_from_super_admin_only_routes(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        $response = $this->actingAs($admin)->get('/admin/ai-config');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_super_admin_can_access_ai_configuration(): void
+    {
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+        ]);
+
+        $response = $this->actingAs($superAdmin)->get('/admin/ai-config');
+
+        $response->assertStatus(200);
+        $response->assertSeeText('Super admin AI configuration placeholder');
+    }
+
+    public function test_unverified_user_is_redirected_for_admin_routes(): void
+    {
+        $user = User::factory()->unverified()->create([
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        $response = $this->actingAs($user)->get('/admin');
+
+        $response->assertRedirect(route('verification.notice'));
+    }
+}

--- a/laravel/tests/Feature/Admin/UserPresenceTest.php
+++ b/laravel/tests/Feature/Admin/UserPresenceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class UserPresenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+    }
+
+    public function test_presence_is_recorded_for_authenticated_user(): void
+    {
+        $user = User::factory()->create([
+            'last_seen_at' => null,
+            'last_active_feature' => null,
+        ]);
+
+        $this->actingAs($user)->get('/profile')->assertOk();
+
+        $user->refresh();
+
+        $this->assertNotNull($user->last_seen_at);
+        $this->assertNotNull($user->last_active_feature);
+        $this->assertSame('profile', $user->last_active_feature);
+    }
+
+    public function test_presence_does_not_update_within_throttle_window(): void
+    {
+        $user = User::factory()->create([
+            'last_seen_at' => null,
+        ]);
+
+        $this->actingAs($user)->get('/profile')->assertOk();
+
+        $user->refresh();
+        $firstSeen = $user->last_seen_at;
+        $this->assertNotNull($firstSeen);
+
+        // Hit a second authenticated route within the throttle window.
+        $this->actingAs($user)->get('/profile')->assertOk();
+
+        $user->refresh();
+        $this->assertNotNull($user->last_seen_at);
+        $this->assertTrue(
+            $firstSeen->equalTo($user->last_seen_at),
+            'Presence timestamp should not change within the throttle window.'
+        );
+    }
+
+    public function test_presence_is_skipped_for_guests(): void
+    {
+        $response = $this->get('/');
+        $response->assertStatus(200);
+
+        $this->assertSame(0, User::query()->whereNotNull('last_seen_at')->count());
+    }
+}

--- a/laravel/tests/Feature/Console/PromoteUserCommandTest.php
+++ b/laravel/tests/Feature/Console/PromoteUserCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PromoteUserCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_promote_admin_command_sets_role_to_admin(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'jane@example.com',
+            'role' => User::ROLE_USER,
+        ]);
+
+        $this->artisan('users:promote-admin', ['email' => $user->email])
+            ->assertExitCode(0);
+
+        $user->refresh();
+        $this->assertSame(User::ROLE_ADMIN, $user->role);
+    }
+
+    public function test_promote_admin_command_fails_when_user_missing(): void
+    {
+        $this->artisan('users:promote-admin', ['email' => 'unknown@example.com'])
+            ->assertExitCode(1);
+    }
+
+    public function test_promote_admin_command_does_not_demote_super_admin(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'super@example.com',
+            'role' => User::ROLE_SUPER_ADMIN,
+        ]);
+
+        $this->artisan('users:promote-admin', ['email' => $user->email])
+            ->assertExitCode(0);
+
+        $user->refresh();
+        $this->assertSame(User::ROLE_SUPER_ADMIN, $user->role);
+    }
+
+    public function test_promote_super_admin_command_sets_role_to_super_admin(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'sa@example.com',
+            'role' => User::ROLE_USER,
+        ]);
+
+        $this->artisan('users:promote-super-admin', ['email' => $user->email])
+            ->assertExitCode(0);
+
+        $user->refresh();
+        $this->assertSame(User::ROLE_SUPER_ADMIN, $user->role);
+    }
+
+    public function test_promote_super_admin_command_fails_when_user_missing(): void
+    {
+        $this->artisan('users:promote-super-admin', ['email' => 'unknown@example.com'])
+            ->assertExitCode(1);
+    }
+}


### PR DESCRIPTION
Closes #214

## Ringkasan
Menambahkan fondasi akses admin untuk dashboard ISTA-AI: role `user`/`admin`/`super_admin`, middleware proteksi route admin dan super admin, presence tracking via `last_seen_at` dengan cache throttle, route placeholder `/admin` dan `/admin/ai-config`, serta command CLI promote.

Tidak mengubah perilaku chat, memo, dokumen, atau Google Drive existing.

## Perubahan Utama
- **Migration additive** `2026_05_18_100000_add_role_and_presence_to_users_table.php`: tambah `role` (default `user`, indexed), `last_seen_at` (nullable, indexed), `last_active_feature` (nullable).
- **`App\Models\User`**: konstanta role, helper `isAdmin()`, `isSuperAdmin()`, `canAccessAdmin()`, fillable & cast diperluas.
- **Middleware**:
  - `EnsureUserIsAdmin`: izinkan admin atau super admin, redirect ke login untuk guest, 403 untuk user biasa.
  - `EnsureUserIsSuperAdmin`: hanya super admin.
  - `UpdateUserPresence`: update `last_seen_at` dan `last_active_feature` menggunakan `saveQuietly()` dengan throttle Cache 60 detik per user; aman terhadap exception (tidak memutus request).
- **`bootstrap/app.php`**: alias `admin`, `super_admin`, `presence`; middleware presence dipasang ke grup `web`.
- **`routes/web.php`**: route placeholder `/admin` (admin) dan `/admin/ai-config` (super admin).
- **Console commands**: `users:promote-admin {email}` dan `users:promote-super-admin {email}`. Promote-admin tidak menurunkan super admin.
- **Tests**: `Tests\\Feature\\Admin\\AdminAccessTest`, `Tests\\Feature\\Admin\\UserPresenceTest`, `Tests\\Feature\\Console\\PromoteUserCommandTest`.

## File Utama yang Disentuh
- `laravel/database/migrations/2026_05_18_100000_add_role_and_presence_to_users_table.php` (baru)
- `laravel/app/Models/User.php`
- `laravel/app/Http/Middleware/EnsureUserIsAdmin.php` (baru)
- `laravel/app/Http/Middleware/EnsureUserIsSuperAdmin.php` (baru)
- `laravel/app/Http/Middleware/UpdateUserPresence.php` (baru)
- `laravel/app/Console/Commands/PromoteUserToAdmin.php` (baru)
- `laravel/app/Console/Commands/PromoteUserToSuperAdmin.php` (baru)
- `laravel/bootstrap/app.php`
- `laravel/routes/web.php`
- `laravel/tests/Feature/Admin/AdminAccessTest.php` (baru)
- `laravel/tests/Feature/Admin/UserPresenceTest.php` (baru)
- `laravel/tests/Feature/Console/PromoteUserCommandTest.php` (baru)
- `issue/issue-217-01-admin-foundation-role-presence-2026-05-18.md` (plan)

## Verifikasi
\`\`\`bash
cd laravel && php artisan test --filter='Admin|Presence|PromoteUser'
# 19 passed (36 assertions)

cd laravel && php artisan test
# 414 passed (1760 assertions)
\`\`\`

### Skenario test yang tercakup
- Guest diarahkan ke login saat akses `/admin`.
- User biasa mendapat 403 untuk `/admin`.
- Admin dan super admin bisa membuka `/admin`.
- Admin biasa 403 untuk `/admin/ai-config`, super admin lolos.
- User unverified diarahkan ke `verification.notice`.
- `last_seen_at` ter-update untuk user yang login dan mengandung `last_active_feature`.
- Presence tidak ter-update dua kali dalam window 60 detik.
- Presence di-skip untuk guest.
- Promote-admin set role admin, gagal jika user tidak ada, dan tidak menurunkan super admin.
- Promote-super-admin set role super admin dan gagal jika user tidak ada.

## Risiko & Mitigasi
- **Salah konfigurasi middleware**: ditutup dengan test akses untuk guest, user, admin, super admin.
- **Beban DB dari presence**: dimitigasi dengan cache throttle 60 detik dan `saveQuietly()` agar tidak mengganggu observers/timestamps lain.
- **Super admin akses general admin route**: dijamin via `canAccessAdmin()` yang menerima admin dan super admin.

## Tindak Lanjut (out of scope issue ini)
- Dashboard KPI lengkap.
- Event tracking detail.
- Knowledge base internal.
- AI Configuration UI.
- ISTURA.