### PR TITLE
Admin design system and layout shell (#216)

### DIFF
--- a/issue/issue-217-03-admin-design-system-layout-shell-2026-05-18.md
+++ b/issue/issue-217-03-admin-design-system-layout-shell-2026-05-18.md
@@ -1,0 +1,67 @@
+# Child 3: Admin Design System dan Layout Shell
+
+Parent: https://github.com/Hasbi1605/ISTA-AI/issues/209
+GitHub Issue: https://github.com/Hasbi1605/ISTA-AI/issues/216
+
+## Latar Belakang
+Dashboard admin harus konsisten dengan halaman ISTA AI yang sudah ada, bukan terasa seperti template admin generik. Sebelum membuat halaman monitoring lengkap, perlu disiapkan layout shell dan komponen dasar admin yang mengikuti visual system existing.
+
+## Tujuan
+- Membuat layout admin yang konsisten dengan ISTA AI.
+- Menyediakan sidebar admin dan komponen UI dasar.
+- Menjaga dark mode, typography, warna, radius, button, dan table pattern tetap selaras.
+- Memastikan halaman admin operasional, padat, dan mudah discan.
+
+## Ruang Lingkup
+- Admin layout/shell.
+- Sidebar admin.
+- Header/topbar admin.
+- Komponen KPI card, table, filter, status badge, tabs, empty state, loading state.
+- Responsive behavior.
+- Navigation guard hanya muncul untuk admin/super_admin.
+
+## Di Luar Scope
+- Query metrik dashboard lengkap.
+- Event tracking.
+- Knowledge base logic.
+- AI Configuration logic.
+
+## Area / File Terkait
+- `laravel/resources/views/layouts/app.blade.php`
+- `laravel/resources/views/livewire/layout/navigation.blade.php`
+- `laravel/resources/views/livewire/admin/*.blade.php`
+- `laravel/resources/css/app.css`
+- `laravel/app/Livewire/Admin/*`
+- `laravel/tests/Feature/*`
+
+## Risiko
+- Desain admin terlalu berbeda dari halaman chat/dashboard existing.
+- Nested cards dan spacing berlebihan membuat dashboard sulit discan.
+- Dark mode tidak konsisten.
+- Admin nav tidak boleh tampil untuk user biasa.
+
+## Langkah Implementasi
+1. Audit kelas dan pattern visual existing pada dashboard, chat, profile, memo.
+2. Buat admin layout shell dengan sidebar.
+3. Buat placeholder halaman admin overview.
+4. Buat komponen reusable untuk KPI, table, filter, badge, loading, empty state.
+5. Tambah responsive rules untuk desktop/mobile.
+6. Tambah admin nav hanya untuk role admin/super_admin.
+7. Tambah test render dan akses.
+
+## Rencana Test
+```bash
+cd laravel && php artisan test --filter='Admin|Dashboard'
+```
+
+Verifikasi manual:
+- Admin layout terlihat konsisten dengan ISTA AI.
+- Dark mode tidak rusak.
+- Mobile tidak overlap.
+- Chat/dashboard publik tidak berubah.
+
+## Kriteria Selesai
+- Layout admin tersedia.
+- Komponen dasar siap dipakai child dashboard lain.
+- Admin nav hanya muncul untuk role yang tepat.
+- Tidak ada regresi visual besar pada halaman existing.

--- a/laravel/resources/css/app.css
+++ b/laravel/resources/css/app.css
@@ -145,6 +145,180 @@
     .memo-config-error {
         @apply mt-1 text-[11px] font-semibold text-rose-600 dark:text-rose-400;
     }
+
+    /* ----- Admin Design System ----- */
+
+    .ista-display-sans {
+        font-family: "Plus Jakarta Sans", "Inter", system-ui, sans-serif;
+    }
+
+    .admin-shell {
+        background:
+            radial-gradient(circle at top left, rgba(245, 158, 11, 0.06) 0%, transparent 30%),
+            radial-gradient(circle at bottom right, rgba(139, 8, 54, 0.06) 0%, transparent 36%),
+            #fbfaf8;
+        @apply text-stone-800 dark:text-gray-100;
+    }
+
+    .dark .admin-shell {
+        background:
+            radial-gradient(circle at top left, rgba(245, 158, 11, 0.04) 0%, transparent 30%),
+            radial-gradient(circle at bottom right, rgba(139, 8, 54, 0.10) 0%, transparent 36%),
+            #0b1220;
+    }
+
+    .admin-sidebar {
+        @apply fixed inset-y-0 left-0 z-40 flex w-72 flex-col border-r border-stone-200/80 bg-white/95 backdrop-blur-xl transition-transform duration-200 dark:border-gray-800 dark:bg-gray-950/95 lg:static lg:z-auto lg:translate-x-0;
+    }
+
+    .admin-topbar {
+        @apply sticky top-0 z-20 flex w-full flex-wrap items-center justify-between gap-3 border-b border-stone-200/80 bg-white/85 px-4 py-3.5 backdrop-blur-xl dark:border-gray-800 dark:bg-gray-900/80 sm:px-6;
+    }
+
+    .admin-main {
+        @apply mx-auto w-full max-w-7xl flex-1 px-4 py-6 sm:px-6 lg:px-8;
+    }
+
+    .admin-nav-link {
+        @apply flex items-center gap-3 rounded-lg px-3 py-2 text-stone-600 transition hover:bg-stone-100 hover:text-ista-primary dark:text-gray-300 dark:hover:bg-gray-900 dark:hover:text-amber-300;
+    }
+
+    .admin-nav-link__icon {
+        @apply flex h-8 w-8 flex-none items-center justify-center rounded-md border border-stone-200 bg-white text-stone-500 transition group-hover:border-ista-primary/30 group-hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400 dark:group-hover:border-ista-primary/40 dark:group-hover:text-amber-300;
+    }
+
+    .admin-nav-link--active {
+        @apply bg-ista-primary/[0.08] text-ista-primary shadow-[inset_3px_0_0_0_theme(colors.ista-primary)] dark:bg-ista-primary/15 dark:text-amber-300;
+    }
+
+    .admin-nav-link--active .admin-nav-link__icon {
+        @apply border-ista-primary/30 bg-ista-primary/10 text-ista-primary dark:border-ista-primary/40 dark:bg-ista-primary/20 dark:text-amber-300;
+    }
+
+    .admin-section {
+        @apply rounded-2xl border border-stone-200/80 bg-white shadow-[0_1px_2px_rgba(28,25,23,0.04)] transition-colors dark:border-gray-800 dark:bg-gray-900/80;
+    }
+
+    .admin-section__header {
+        @apply flex flex-wrap items-start justify-between gap-3 border-b border-stone-100 px-5 py-4 dark:border-gray-800;
+    }
+
+    .admin-section__body {
+        @apply px-5 py-4;
+    }
+
+    .admin-section__footer {
+        @apply border-t border-stone-100 px-5 py-3 text-xs text-stone-500 dark:border-gray-800 dark:text-gray-400;
+    }
+
+    .admin-kpi {
+        @apply flex flex-col rounded-2xl border border-stone-200/80 bg-white p-5 shadow-[0_1px_2px_rgba(28,25,23,0.04)] transition-colors dark:border-gray-800 dark:bg-gray-900/80;
+    }
+
+    .admin-kpi__icon {
+        @apply flex h-9 w-9 items-center justify-center rounded-lg border border-stone-200 bg-stone-50 text-stone-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400;
+    }
+
+    .admin-kpi--primary { @apply border-ista-primary/20 bg-gradient-to-br from-ista-primary/[0.06] to-transparent dark:border-ista-primary/30; }
+    .admin-kpi--gold { @apply border-amber-200/70 bg-gradient-to-br from-amber-100/40 to-transparent dark:border-amber-500/20; }
+    .admin-kpi--success { @apply border-emerald-200/70 bg-gradient-to-br from-emerald-50 to-transparent dark:border-emerald-500/20; }
+    .admin-kpi--warning { @apply border-amber-200/70 bg-gradient-to-br from-amber-50 to-transparent dark:border-amber-500/20; }
+    .admin-kpi--danger { @apply border-rose-200/70 bg-gradient-to-br from-rose-50 to-transparent dark:border-rose-500/20; }
+
+    .admin-table-wrapper {
+        @apply overflow-x-auto rounded-xl border border-stone-200/80 bg-white dark:border-gray-800 dark:bg-gray-900/80;
+    }
+
+    .admin-table {
+        @apply w-full border-collapse text-sm text-stone-700 dark:text-gray-200;
+    }
+
+    .admin-table__th {
+        @apply border-b border-stone-200 bg-stone-50/60 px-4 py-2.5 text-left text-[11px] font-bold uppercase tracking-[0.08em] text-stone-500 dark:border-gray-800 dark:bg-gray-900/80 dark:text-gray-400;
+    }
+
+    .admin-table__th[data-align="right"], .admin-table__td[data-align="right"] { text-align: right; }
+    .admin-table__th[data-align="center"], .admin-table__td[data-align="center"] { text-align: center; }
+
+    .admin-table__td {
+        @apply border-b border-stone-100 px-4 py-3 align-middle dark:border-gray-800;
+    }
+
+    .admin-table tbody tr:last-child .admin-table__td {
+        @apply border-b-0;
+    }
+
+    .admin-table__empty {
+        @apply px-4 py-6 text-center text-xs font-medium text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-badge {
+        @apply inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-[11px] font-semibold;
+    }
+
+    .admin-badge--neutral { @apply border-stone-200 bg-stone-50 text-stone-600 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300; }
+    .admin-badge--success { @apply border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300; }
+    .admin-badge--warning { @apply border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300; }
+    .admin-badge--danger { @apply border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-300; }
+    .admin-badge--info { @apply border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-300; }
+    .admin-badge--gold { @apply border-amber-300 bg-amber-100/70 text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/15 dark:text-amber-300; }
+    .admin-badge--primary { @apply border-ista-primary/30 bg-ista-primary/10 text-ista-primary dark:border-ista-primary/40 dark:bg-ista-primary/20 dark:text-amber-300; }
+
+    .admin-empty-state {
+        @apply flex flex-col items-center justify-center rounded-xl border border-dashed border-stone-200 bg-stone-50/40 px-6 py-10 text-center dark:border-gray-800 dark:bg-gray-900/40;
+    }
+
+    .admin-empty-state__icon {
+        @apply mb-3 flex h-10 w-10 items-center justify-center rounded-full border border-stone-200 bg-white text-stone-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400;
+    }
+
+    .admin-loading {
+        @apply flex flex-col gap-2;
+    }
+
+    .admin-loading__bar {
+        @apply h-3 w-full overflow-hidden rounded bg-stone-100 dark:bg-gray-800;
+    }
+
+    .admin-loading__bar > span {
+        @apply block h-full w-1/2 animate-pulse rounded bg-gradient-to-r from-stone-200 via-stone-100 to-stone-200 dark:from-gray-700 dark:via-gray-800 dark:to-gray-700;
+    }
+
+    .admin-filter {
+        @apply flex flex-col gap-1.5;
+    }
+
+    .admin-filter__label {
+        @apply text-[11px] font-bold uppercase tracking-[0.08em] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-filter__control {
+        @apply h-10 rounded-lg border border-stone-200 bg-white px-3 text-sm text-stone-800 transition focus:border-ista-primary focus:outline-none focus:ring-2 focus:ring-ista-primary/15 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100;
+    }
+
+    .admin-tabs {
+        @apply border-b border-stone-200 dark:border-gray-800;
+    }
+
+    .admin-tabs__list {
+        @apply flex flex-wrap items-center gap-x-2 gap-y-1;
+    }
+
+    .admin-tabs__tab {
+        @apply -mb-px inline-flex items-center gap-2 border-b-2 border-transparent px-3 py-2 text-sm font-medium text-stone-500 transition hover:text-ista-primary dark:text-gray-400 dark:hover:text-amber-300;
+    }
+
+    .admin-tabs__tab--active {
+        @apply border-ista-primary text-ista-primary dark:border-amber-300 dark:text-amber-300;
+    }
+
+    .admin-tabs__count {
+        @apply rounded-full border border-stone-200 bg-stone-50 px-2 py-0.5 text-[10.5px] font-semibold text-stone-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300;
+    }
+
+    .admin-page-title {
+        @apply ista-brand-title text-2xl text-stone-900 not-italic dark:text-gray-100;
+    }
 }
 
 /* Loading label: fade-through magic saat fase berganti.

--- a/laravel/resources/views/admin/ai-config.blade.php
+++ b/laravel/resources/views/admin/ai-config.blade.php
@@ -1,0 +1,25 @@
+<x-layouts.admin title="AI Configuration" heading="AI Configuration">
+    <x-slot name="pageHeader">
+        <div class="flex flex-wrap items-end justify-between gap-3">
+            <div class="max-w-2xl">
+                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Super Admin</p>
+                <h2 class="admin-page-title mt-1">AI Configuration</h2>
+                <p class="mt-2 text-sm leading-relaxed text-stone-500 dark:text-gray-400">
+                    Halaman ini akan menjadi pusat konfigurasi prompt, model AI, dan parameter generasi. Implementasi penuh akan dikerjakan pada child khusus.
+                </p>
+            </div>
+            <x-admin.badge tone="gold">
+                <span class="h-1.5 w-1.5 rounded-full bg-amber-500"></span>
+                Akses terbatas
+            </x-admin.badge>
+        </div>
+    </x-slot>
+
+    <x-admin.section
+        title="Placeholder"
+        description="Form konfigurasi akan dibangun di sini.">
+        <x-admin.empty-state
+            title="Belum ada konfigurasi"
+            description="Formulir prompt, pemilih model, dan parameter generasi akan tersedia pada child AI Configuration." />
+    </x-admin.section>
+</x-layouts.admin>

--- a/laravel/resources/views/admin/overview.blade.php
+++ b/laravel/resources/views/admin/overview.blade.php
@@ -1,0 +1,100 @@
+<x-layouts.admin title="Overview" heading="Overview">
+    <x-slot name="pageHeader">
+        <div class="flex flex-wrap items-end justify-between gap-3">
+            <div class="max-w-2xl">
+                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Selamat datang</p>
+                <h2 class="admin-page-title mt-1">Ringkasan Operasional</h2>
+                <p class="mt-2 text-sm leading-relaxed text-stone-500 dark:text-gray-400">
+                    Pantau aktivitas user, performa AI, dan kesehatan platform dalam satu halaman. Layout ini akan menjadi kerangka dashboard penuh pada tahap berikutnya.
+                </p>
+            </div>
+            <div class="flex flex-wrap items-center gap-2">
+                <x-admin.badge tone="primary">
+                    <span class="h-1.5 w-1.5 rounded-full bg-ista-primary"></span>
+                    Live shell
+                </x-admin.badge>
+                <x-admin.badge tone="neutral">v1 Foundation</x-admin.badge>
+            </div>
+        </div>
+    </x-slot>
+
+    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <x-admin.kpi-card
+            label="User Aktif"
+            value="—"
+            tone="primary"
+            description="Akan diisi pada child dashboard monitoring." />
+
+        <x-admin.kpi-card
+            label="Pesan AI / Hari"
+            value="—"
+            tone="gold"
+            description="Pengukuran event tracking belum aktif." />
+
+        <x-admin.kpi-card
+            label="Latensi Rata-rata"
+            value="—"
+            tone="success"
+            description="Akan tersedia setelah event tracking." />
+
+        <x-admin.kpi-card
+            label="Error AI"
+            value="—"
+            tone="danger"
+            description="Threshold akan dikonfigurasi nanti." />
+    </div>
+
+    <div class="mt-6 grid gap-4 lg:grid-cols-3">
+        <div class="lg:col-span-2">
+            <x-admin.section
+                title="Aktivitas Terbaru"
+                description="Daftar interaksi user terbaru pada modul chat dan memo. Akan tersambung pada tahap monitoring.">
+                <x-slot name="actions">
+                    <x-admin.filter name="range" :options="['7d' => '7 hari', '30d' => '30 hari', '90d' => '90 hari']" placeholder="Periode" />
+                </x-slot>
+
+                <x-admin.table :columns="[
+                    ['key' => 'user', 'label' => 'User'],
+                    ['key' => 'feature', 'label' => 'Fitur'],
+                    ['key' => 'status', 'label' => 'Status'],
+                    ['key' => 'time', 'label' => 'Waktu', 'align' => 'right'],
+                ]">
+                    <tr>
+                        <td colspan="4" class="admin-table__empty">
+                            <x-admin.empty-state
+                                title="Belum ada aktivitas"
+                                description="Data akan muncul setelah event tracking aktif." />
+                        </td>
+                    </tr>
+                </x-admin.table>
+            </x-admin.section>
+        </div>
+
+        <div class="space-y-4">
+            <x-admin.section
+                title="Status Sistem"
+                description="Indikator kesehatan komponen utama.">
+                <ul class="space-y-3 text-sm">
+                    <li class="flex items-center justify-between">
+                        <span class="text-stone-600 dark:text-gray-300">Laravel API</span>
+                        <x-admin.badge tone="success">Online</x-admin.badge>
+                    </li>
+                    <li class="flex items-center justify-between">
+                        <span class="text-stone-600 dark:text-gray-300">Python AI</span>
+                        <x-admin.badge tone="warning">Belum dipantau</x-admin.badge>
+                    </li>
+                    <li class="flex items-center justify-between">
+                        <span class="text-stone-600 dark:text-gray-300">Storage</span>
+                        <x-admin.badge tone="info">N/A</x-admin.badge>
+                    </li>
+                </ul>
+            </x-admin.section>
+
+            <x-admin.section
+                title="Loading State"
+                description="Skeleton siap pakai untuk panel monitoring lain.">
+                <x-admin.loading :rows="4" />
+            </x-admin.section>
+        </div>
+    </div>
+</x-layouts.admin>

--- a/laravel/resources/views/components/admin/badge.blade.php
+++ b/laravel/resources/views/components/admin/badge.blade.php
@@ -1,0 +1,19 @@
+@props([
+    'tone' => 'neutral',
+])
+
+@php
+    $toneClass = match ($tone) {
+        'success' => 'admin-badge--success',
+        'warning' => 'admin-badge--warning',
+        'danger' => 'admin-badge--danger',
+        'info' => 'admin-badge--info',
+        'gold' => 'admin-badge--gold',
+        'primary' => 'admin-badge--primary',
+        default => 'admin-badge--neutral',
+    };
+@endphp
+
+<span {{ $attributes->merge(['class' => "admin-badge {$toneClass}"]) }}>
+    {{ $slot }}
+</span>

--- a/laravel/resources/views/components/admin/empty-state.blade.php
+++ b/laravel/resources/views/components/admin/empty-state.blade.php
@@ -1,0 +1,27 @@
+@props([
+    'title' => 'Belum ada data',
+    'description' => null,
+    'icon' => null,
+])
+
+<div {{ $attributes->merge(['class' => 'admin-empty-state']) }}>
+    <div class="admin-empty-state__icon" aria-hidden="true">
+        @if ($icon)
+            {!! $icon !!}
+        @else
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 17V7a4 4 0 014-4h4l4 4v10a4 4 0 01-4 4H9zM4 7v14a2 2 0 002 2h2"/>
+            </svg>
+        @endif
+    </div>
+    <p class="text-sm font-semibold text-stone-700 dark:text-gray-200">{{ $title }}</p>
+    @if ($description)
+        <p class="mt-1 text-xs leading-relaxed text-stone-500 dark:text-gray-400">{{ $description }}</p>
+    @endif
+
+    @isset($actions)
+        <div class="mt-4 flex flex-wrap items-center justify-center gap-2">
+            {{ $actions }}
+        </div>
+    @endisset
+</div>

--- a/laravel/resources/views/components/admin/filter.blade.php
+++ b/laravel/resources/views/components/admin/filter.blade.php
@@ -1,0 +1,20 @@
+@props([
+    'name',
+    'options' => [],
+    'label' => null,
+    'placeholder' => 'Semua',
+])
+
+<label class="admin-filter">
+    @if ($label)
+        <span class="admin-filter__label">{{ $label }}</span>
+    @endif
+    <select name="{{ $name }}" {{ $attributes->merge(['class' => 'admin-filter__control']) }}>
+        @if ($placeholder)
+            <option value="">{{ $placeholder }}</option>
+        @endif
+        @foreach ($options as $key => $value)
+            <option value="{{ $key }}">{{ $value }}</option>
+        @endforeach
+    </select>
+</label>

--- a/laravel/resources/views/components/admin/kpi-card.blade.php
+++ b/laravel/resources/views/components/admin/kpi-card.blade.php
@@ -1,0 +1,52 @@
+@props([
+    'label',
+    'value',
+    'description' => null,
+    'icon' => null,
+    'tone' => 'default',
+    'trend' => null,
+    'trendDirection' => 'neutral',
+])
+
+@php
+    $toneClass = match ($tone) {
+        'primary' => 'admin-kpi--primary',
+        'gold' => 'admin-kpi--gold',
+        'success' => 'admin-kpi--success',
+        'warning' => 'admin-kpi--warning',
+        'danger' => 'admin-kpi--danger',
+        default => 'admin-kpi--default',
+    };
+
+    $trendClass = match ($trendDirection) {
+        'up' => 'text-emerald-600 dark:text-emerald-400',
+        'down' => 'text-rose-600 dark:text-rose-400',
+        default => 'text-stone-500 dark:text-gray-400',
+    };
+@endphp
+
+<div {{ $attributes->merge(['class' => "admin-kpi {$toneClass}"]) }}>
+    <div class="flex items-start justify-between gap-3">
+        <p class="text-[11px] font-bold uppercase tracking-[0.14em] text-stone-500 dark:text-gray-400">{{ $label }}</p>
+        @if ($icon)
+            <span class="admin-kpi__icon" aria-hidden="true">{!! $icon !!}</span>
+        @endif
+    </div>
+
+    <div class="mt-3 flex items-baseline gap-2">
+        <span class="text-3xl font-bold tracking-tight text-stone-900 dark:text-gray-100">{{ $value }}</span>
+        @if ($trend)
+            <span class="text-xs font-semibold {{ $trendClass }}">{{ $trend }}</span>
+        @endif
+    </div>
+
+    @if ($description)
+        <p class="mt-2 text-xs leading-relaxed text-stone-500 dark:text-gray-400">{{ $description }}</p>
+    @endif
+
+    @isset($footer)
+        <div class="mt-4 border-t border-stone-100 pt-3 text-[11px] font-medium text-stone-500 dark:border-gray-800 dark:text-gray-400">
+            {{ $footer }}
+        </div>
+    @endisset
+</div>

--- a/laravel/resources/views/components/admin/loading.blade.php
+++ b/laravel/resources/views/components/admin/loading.blade.php
@@ -1,0 +1,13 @@
+@props([
+    'label' => 'Memuat data',
+    'rows' => 3,
+])
+
+<div {{ $attributes->merge(['class' => 'admin-loading']) }} role="status" aria-live="polite">
+    <span class="sr-only">{{ $label }}</span>
+    @for ($i = 0; $i < (int) $rows; $i++)
+        <div class="admin-loading__bar" aria-hidden="true">
+            <span></span>
+        </div>
+    @endfor
+</div>

--- a/laravel/resources/views/components/admin/section.blade.php
+++ b/laravel/resources/views/components/admin/section.blade.php
@@ -1,0 +1,34 @@
+@props([
+    'title' => null,
+    'description' => null,
+])
+
+<section {{ $attributes->merge(['class' => 'admin-section']) }}>
+    @if ($title || $description || isset($actions))
+        <header class="admin-section__header">
+            <div class="min-w-0">
+                @if ($title)
+                    <h2 class="text-base font-semibold text-stone-900 dark:text-gray-100">{{ $title }}</h2>
+                @endif
+                @if ($description)
+                    <p class="mt-1 text-xs leading-relaxed text-stone-500 dark:text-gray-400">{{ $description }}</p>
+                @endif
+            </div>
+            @isset($actions)
+                <div class="flex flex-wrap items-center gap-2">
+                    {{ $actions }}
+                </div>
+            @endisset
+        </header>
+    @endif
+
+    <div class="admin-section__body">
+        {{ $slot }}
+    </div>
+
+    @isset($footer)
+        <footer class="admin-section__footer">
+            {{ $footer }}
+        </footer>
+    @endisset
+</section>

--- a/laravel/resources/views/components/admin/sidebar.blade.php
+++ b/laravel/resources/views/components/admin/sidebar.blade.php
@@ -1,0 +1,93 @@
+@php
+    $user = auth()->user();
+    $items = [
+        [
+            'label' => 'Overview',
+            'description' => 'Ringkasan dashboard',
+            'route' => 'admin.dashboard',
+            'icon' => 'M3 12l9-9 9 9M5 10v10a1 1 0 001 1h4a1 1 0 001-1v-5h2v5a1 1 0 001 1h4a1 1 0 001-1V10',
+            'visible' => true,
+        ],
+    ];
+
+    if ($user && method_exists($user, 'isSuperAdmin') && $user->isSuperAdmin()) {
+        $items[] = [
+            'label' => 'AI Configuration',
+            'description' => 'Hanya super admin',
+            'route' => 'admin.ai-config',
+            'icon' => 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.998.61 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z',
+            'visible' => true,
+        ];
+    }
+
+    $roleLabel = match (true) {
+        $user && method_exists($user, 'isSuperAdmin') && $user->isSuperAdmin() => 'Super Admin',
+        $user && method_exists($user, 'isAdmin') && $user->isAdmin() => 'Admin',
+        default => 'Admin',
+    };
+@endphp
+
+<div class="flex h-full flex-col">
+    <div class="flex items-center justify-between gap-3 border-b border-stone-200/80 px-6 py-5 dark:border-gray-800">
+        <a href="{{ route('admin.dashboard') }}" class="group flex items-center gap-3">
+            <img src="{{ asset('images/ista/logo.png') }}" alt="ISTA AI" class="h-8 w-8 object-contain transition-transform duration-300 group-hover:rotate-6 group-hover:scale-110">
+            <div class="ista-brand-title text-lg text-ista-primary not-italic">
+                ISTA <span class="font-light italic text-ista-gold">AI</span>
+            </div>
+        </a>
+        <button type="button"
+                @click="sidebarOpen = false"
+                class="inline-flex h-9 w-9 items-center justify-center rounded-lg text-stone-500 transition hover:bg-stone-100 dark:text-gray-300 dark:hover:bg-gray-800 lg:hidden"
+                aria-label="Tutup sidebar admin">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+        </button>
+    </div>
+
+    <nav class="flex-1 overflow-y-auto px-3 py-4" aria-label="Navigasi admin">
+        <p class="px-3 pb-2 text-[10.5px] font-bold uppercase tracking-[0.16em] text-stone-400 dark:text-gray-500">Menu</p>
+        <ul class="space-y-1" role="list">
+            @foreach ($items as $item)
+                @continue(! ($item['visible'] ?? false))
+                @php
+                    $active = request()->routeIs($item['route']);
+                @endphp
+                <li>
+                    <a href="{{ route($item['route']) }}"
+                       @class([
+                           'admin-nav-link group',
+                           'admin-nav-link--active' => $active,
+                       ])
+                       @if ($active) aria-current="page" @endif>
+                        <span class="admin-nav-link__icon" aria-hidden="true">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="{{ $item['icon'] }}"/>
+                            </svg>
+                        </span>
+                        <span class="flex-1">
+                            <span class="block text-sm font-semibold leading-tight">{{ $item['label'] }}</span>
+                            @if (! empty($item['description']))
+                                <span class="mt-0.5 block text-[11px] font-medium text-stone-400 group-hover:text-ista-primary/60 dark:text-gray-500 dark:group-hover:text-amber-300/70">{{ $item['description'] }}</span>
+                            @endif
+                        </span>
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+    </nav>
+
+    <div class="border-t border-stone-200/80 px-4 py-4 dark:border-gray-800">
+        @auth
+            <div class="flex items-center gap-3">
+                <div class="flex h-9 w-9 items-center justify-center rounded-full bg-ista-primary text-sm font-bold text-amber-300">
+                    {{ substr(auth()->user()->name, 0, 1) }}
+                </div>
+                <div class="min-w-0 flex-1">
+                    <p class="truncate text-sm font-semibold text-stone-800 dark:text-gray-100">{{ auth()->user()->name }}</p>
+                    <p class="truncate text-[11px] font-medium uppercase tracking-wider text-stone-400 dark:text-gray-500">{{ $roleLabel }}</p>
+                </div>
+            </div>
+        @endauth
+    </div>
+</div>

--- a/laravel/resources/views/components/admin/table.blade.php
+++ b/laravel/resources/views/components/admin/table.blade.php
@@ -1,0 +1,55 @@
+@props([
+    'columns' => [],
+    'rows' => [],
+    'emptyMessage' => 'Belum ada data.',
+])
+
+<div {{ $attributes->merge(['class' => 'admin-table-wrapper']) }}>
+    <table class="admin-table" role="table">
+        @if (! empty($columns))
+            <thead>
+                <tr>
+                    @foreach ($columns as $column)
+                        @php
+                            $align = $column['align'] ?? 'left';
+                            $width = $column['width'] ?? null;
+                        @endphp
+                        <th scope="col"
+                            class="admin-table__th"
+                            style="{{ $width ? "width: {$width};" : '' }}"
+                            data-align="{{ $align }}">
+                            {{ $column['label'] ?? '' }}
+                        </th>
+                    @endforeach
+                </tr>
+            </thead>
+        @endif
+        <tbody>
+            @if (! empty($rows))
+                @foreach ($rows as $row)
+                    <tr>
+                        @foreach ($columns as $column)
+                            @php
+                                $key = $column['key'] ?? null;
+                                $align = $column['align'] ?? 'left';
+                            @endphp
+                            <td class="admin-table__td" data-align="{{ $align }}">
+                                {{ $key ? ($row[$key] ?? '') : '' }}
+                            </td>
+                        @endforeach
+                    </tr>
+                @endforeach
+            @else
+                {{ $slot }}
+            @endif
+
+            @if (empty($rows) && trim($slot) === '')
+                <tr>
+                    <td colspan="{{ max(count($columns), 1) }}" class="admin-table__empty">
+                        {{ $emptyMessage }}
+                    </td>
+                </tr>
+            @endif
+        </tbody>
+    </table>
+</div>

--- a/laravel/resources/views/components/admin/tabs.blade.php
+++ b/laravel/resources/views/components/admin/tabs.blade.php
@@ -1,0 +1,31 @@
+@props([
+    'tabs' => [],
+    'current' => null,
+])
+
+<nav {{ $attributes->merge(['class' => 'admin-tabs']) }} aria-label="Tab navigasi">
+    <ul class="admin-tabs__list" role="tablist">
+        @foreach ($tabs as $tab)
+            @php
+                $isActive = ($current ?? null) === ($tab['key'] ?? null);
+                $href = $tab['route'] ?? '#';
+                $label = $tab['label'] ?? '';
+                $count = $tab['count'] ?? null;
+            @endphp
+            <li role="presentation">
+                <a href="{{ $href }}"
+                   role="tab"
+                   aria-selected="{{ $isActive ? 'true' : 'false' }}"
+                   @class([
+                       'admin-tabs__tab',
+                       'admin-tabs__tab--active' => $isActive,
+                   ])>
+                    <span>{{ $label }}</span>
+                    @if (! is_null($count))
+                        <span class="admin-tabs__count">{{ $count }}</span>
+                    @endif
+                </a>
+            </li>
+        @endforeach
+    </ul>
+</nav>

--- a/laravel/resources/views/components/layouts/admin.blade.php
+++ b/laravel/resources/views/components/layouts/admin.blade.php
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}"
+      x-data="{ darkMode: localStorage.getItem('theme') === 'dark', sidebarOpen: false }"
+      x-init="$watch('darkMode', value => { localStorage.setItem('theme', value ? 'dark' : 'light'); document.documentElement.classList.toggle('dark', value); })"
+      :class="{ 'dark': darkMode }">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    <title>{{ $title ?? 'Admin' }} · ISTA AI</title>
+
+    <link rel="icon" type="image/png" href="{{ asset('images/ista/logo.png') }}">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+    <script>
+        if (localStorage.theme === 'dark') {
+            document.documentElement.classList.add('dark');
+        } else {
+            document.documentElement.classList.remove('dark');
+        }
+    </script>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="ista-shell ista-display-sans text-stone-800 dark:text-gray-100 transition-colors duration-300">
+    <x-page-loader />
+
+    <div class="admin-shell relative flex min-h-[var(--app-viewport-height)] w-full">
+        <!-- Mobile sidebar backdrop -->
+        <div x-show="sidebarOpen"
+             x-transition.opacity
+             @click="sidebarOpen = false"
+             class="fixed inset-0 z-30 bg-stone-900/40 backdrop-blur-sm dark:bg-black/60 lg:hidden"
+             style="display: none;"
+             aria-hidden="true"></div>
+
+        <!-- Sidebar -->
+        <aside class="admin-sidebar"
+               :class="sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'"
+               aria-label="Navigasi admin">
+            <x-admin.sidebar />
+        </aside>
+
+        <!-- Main column -->
+        <div class="flex min-w-0 flex-1 flex-col">
+            <header class="admin-topbar">
+                <div class="flex items-center gap-3">
+                    <button type="button"
+                            @click="sidebarOpen = true"
+                            class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-stone-500 transition hover:bg-stone-100 dark:text-gray-300 dark:hover:bg-gray-800 lg:hidden"
+                            aria-label="Buka sidebar admin"
+                            :aria-expanded="sidebarOpen ? 'true' : 'false'">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 6h16M4 12h16M4 18h16" />
+                        </svg>
+                    </button>
+                    <div>
+                        <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Dashboard Admin</p>
+                        <h1 class="ista-brand-title text-xl text-stone-900 not-italic dark:text-gray-100">
+                            {{ $heading ?? ($title ?? 'Admin') }}
+                        </h1>
+                    </div>
+                </div>
+                <div class="flex items-center gap-2 sm:gap-3">
+                    <button type="button"
+                            @click="darkMode = !darkMode"
+                            class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-stone-500 transition hover:bg-stone-100 dark:text-gray-300 dark:hover:bg-gray-800"
+                            aria-label="Toggle dark mode">
+                        <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />
+                        </svg>
+                        <svg x-show="darkMode === true" style="display: none;" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z" />
+                        </svg>
+                    </button>
+                    <a href="{{ route('chat') }}"
+                       class="hidden h-10 items-center gap-2 rounded-lg border border-stone-200 bg-white px-3 text-xs font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-ista-primary/40 dark:hover:text-amber-300 sm:inline-flex">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12H3m0 0l6-6m-6 6l6 6"/>
+                        </svg>
+                        Kembali ke Chat
+                    </a>
+                    <livewire:dashboard-nav-profile />
+                </div>
+            </header>
+
+            <main class="admin-main">
+                @isset($pageHeader)
+                    <div class="mb-6">
+                        {{ $pageHeader }}
+                    </div>
+                @endisset
+
+                {{ $slot }}
+            </main>
+        </div>
+    </div>
+</body>
+</html>

--- a/laravel/resources/views/livewire/dashboard-nav-profile.blade.php
+++ b/laravel/resources/views/livewire/dashboard-nav-profile.blade.php
@@ -44,7 +44,16 @@ new class extends Component {
         <a href="{{ route('profile') }}" class="block px-4 py-2 text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-amber-300" role="menuitem">
             Profil
         </a>
-        
+
+        @if (auth()->user() && method_exists(auth()->user(), 'canAccessAdmin') && auth()->user()->canAccessAdmin())
+            <a href="{{ route('admin.dashboard') }}" class="flex items-center gap-2 border-t border-stone-100 px-4 py-2 text-sm font-medium text-ista-primary transition hover:bg-stone-50 dark:border-gray-800 dark:text-amber-300 dark:hover:bg-gray-800" role="menuitem">
+                <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
+                </svg>
+                Dashboard Admin
+            </a>
+        @endif
+
         <button wire:click="logout" class="block w-full px-4 py-2 text-left text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-amber-300" role="menuitem">
             Keluar
         </button>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -105,20 +105,14 @@ Route::middleware(['auth', 'verified', 'admin'])
     ->prefix('admin')
     ->name('admin.')
     ->group(function () {
-        Route::get('/', function () {
-            return response('Admin dashboard placeholder', 200)
-                ->header('Content-Type', 'text/plain; charset=UTF-8');
-        })->name('dashboard');
+        Route::view('/', 'admin.overview')->name('dashboard');
     });
 
 Route::middleware(['auth', 'verified', 'super_admin'])
     ->prefix('admin')
     ->name('admin.')
     ->group(function () {
-        Route::get('/ai-config', function () {
-            return response('Super admin AI configuration placeholder', 200)
-                ->header('Content-Type', 'text/plain; charset=UTF-8');
-        })->name('ai-config');
+        Route::view('/ai-config', 'admin.ai-config')->name('ai-config');
     });
 
 require __DIR__.'/auth.php';

--- a/laravel/tests/Feature/Admin/AdminAccessTest.php
+++ b/laravel/tests/Feature/Admin/AdminAccessTest.php
@@ -37,7 +37,8 @@ class AdminAccessTest extends TestCase
         $response = $this->actingAs($admin)->get('/admin');
 
         $response->assertStatus(200);
-        $response->assertSeeText('Admin dashboard placeholder');
+        $response->assertSee('Ringkasan Operasional', false);
+        $response->assertSee('Dashboard Admin', false);
     }
 
     public function test_super_admin_can_access_admin_dashboard(): void
@@ -49,6 +50,7 @@ class AdminAccessTest extends TestCase
         $response = $this->actingAs($superAdmin)->get('/admin');
 
         $response->assertStatus(200);
+        $response->assertSee('Ringkasan Operasional', false);
     }
 
     public function test_admin_is_forbidden_from_super_admin_only_routes(): void
@@ -71,7 +73,8 @@ class AdminAccessTest extends TestCase
         $response = $this->actingAs($superAdmin)->get('/admin/ai-config');
 
         $response->assertStatus(200);
-        $response->assertSeeText('Super admin AI configuration placeholder');
+        $response->assertSee('AI Configuration', false);
+        $response->assertSee('Akses terbatas', false);
     }
 
     public function test_unverified_user_is_redirected_for_admin_routes(): void

--- a/laravel/tests/Feature/Admin/AdminLayoutTest.php
+++ b/laravel/tests/Feature/Admin/AdminLayoutTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminLayoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_overview_renders_design_system_components(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        $response = $this->actingAs($admin)->get('/admin');
+
+        $response->assertStatus(200);
+
+        // Sidebar branding & nav.
+        $response->assertSee('admin-sidebar', false);
+        $response->assertSee('admin-nav-link', false);
+        $response->assertSee('Overview', false);
+
+        // Topbar.
+        $response->assertSee('admin-topbar', false);
+
+        // KPI cards & sections.
+        $response->assertSee('admin-kpi', false);
+        $response->assertSee('admin-section', false);
+
+        // Table & empty state.
+        $response->assertSee('admin-table', false);
+        $response->assertSee('admin-empty-state', false);
+
+        // Loading skeleton.
+        $response->assertSee('admin-loading', false);
+
+        // Filter component.
+        $response->assertSee('admin-filter', false);
+    }
+
+    public function test_super_admin_sees_ai_config_link_in_admin_sidebar(): void
+    {
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+        ]);
+
+        $response = $this->actingAs($superAdmin)->get('/admin');
+
+        $response->assertStatus(200);
+        $response->assertSee('AI Configuration', false);
+        $response->assertSee('Hanya super admin', false);
+    }
+
+    public function test_admin_does_not_see_ai_config_link_in_admin_sidebar(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        $response = $this->actingAs($admin)->get('/admin');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('AI Configuration', false);
+    }
+
+    public function test_dashboard_nav_profile_shows_admin_link_only_for_admin_roles(): void
+    {
+        $regular = User::factory()->create(['role' => User::ROLE_USER]);
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $superAdmin = User::factory()->create(['role' => User::ROLE_SUPER_ADMIN]);
+
+        $this->actingAs($regular)
+            ->get('/')
+            ->assertOk()
+            ->assertDontSee('Dashboard Admin', false);
+
+        $this->actingAs($admin)
+            ->get('/')
+            ->assertOk()
+            ->assertSee('Dashboard Admin', false);
+
+        $this->actingAs($superAdmin)
+            ->get('/')
+            ->assertOk()
+            ->assertSee('Dashboard Admin', false);
+    }
+
+    public function test_admin_layout_includes_dark_mode_and_ista_branding(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        $response = $this->actingAs($admin)->get('/admin');
+
+        $response->assertStatus(200);
+        $response->assertSee("'theme'", false);
+        $response->assertSee("'dark'", false);
+        $response->assertSee('ISTA', false);
+        $response->assertSee('AI', false);
+        $response->assertSee('ista-shell', false);
+    }
+
+    public function test_admin_layout_provides_link_back_to_chat(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        $response = $this->actingAs($admin)->get('/admin');
+
+        $response->assertStatus(200);
+        $response->assertSee(route('chat'), false);
+        $response->assertSee('Kembali ke Chat', false);
+    }
+}


### PR DESCRIPTION
Closes #216

> Stacked on top of #240 (issue #214). Base branch is `codex/issue-214-admin-foundation-role-presence`. Setelah #240 merge, base akan otomatis dipindah ke `main` dan PR ini bisa direview/merged.

## Ringkasan
Menyiapkan layout admin dan komponen UI dasar yang konsisten dengan visual ISTA AI existing (Fraunces + Plus Jakarta Sans, palette `ista-primary` / `ista-gold` / `ista-dark`, dark mode pattern, `ista-shell`). Layout ini menjadi kerangka untuk modul monitoring, knowledge base, dan AI Configuration berikutnya, tanpa mengubah tampilan halaman publik (chat, memo, dokumen, dashboard, profile).

## Perubahan Utama
- **Admin layout shell** `resources/views/components/layouts/admin.blade.php`: header brand, sidebar permanen di desktop + drawer di mobile, topbar dengan judul, tombol dark mode, link kembali ke Chat, dan dropdown profil existing (`<livewire:dashboard-nav-profile />`).
- **Sidebar role-aware** `components/admin/sidebar.blade.php`: nav `Overview` selalu muncul; `AI Configuration` hanya untuk super admin (mengikuti helper `User::canAccessAdmin()` / `isSuperAdmin()` dari child #214).
- **Komponen reusable** `components/admin/`:
  - `kpi-card`: KPI dengan tone variants (primary/gold/success/warning/danger), slot icon dan footer.
  - `section`: card section dengan header (title/description) + slot actions + slot footer.
  - `table`: wrapper tabel dengan column config, alignment, slot custom row, dan empty state otomatis.
  - `badge`: status badge (neutral/success/warning/danger/info/gold/primary).
  - `empty-state`: empty state konsisten dengan slot actions.
  - `loading`: skeleton bar count-able.
  - `filter`: select filter dengan label.
  - `tabs`: tab nav dengan count badge dan state aktif.
- **CSS tokens** `resources/css/app.css` (layer `components`): `admin-shell`, `admin-sidebar`, `admin-topbar`, `admin-nav-link`, `admin-section`, `admin-kpi`, `admin-table`, `admin-badge`, `admin-empty-state`, `admin-loading`, `admin-filter`, `admin-tabs`. Semua memakai token Tailwind/ISTA existing untuk konsistensi dark/light.
- **Halaman admin**:
  - `admin/overview.blade.php`: hero header + grid 4 KPI placeholder + tabel \"Aktivitas Terbaru\" (empty state) + panel \"Status Sistem\" + panel skeleton loading.
  - `admin/ai-config.blade.php`: hero \"AI Configuration\" + section placeholder.
- **Navigation entry**: dropdown profil dashboard (`livewire/dashboard-nav-profile.blade.php`) sekarang menampilkan link \"Dashboard Admin\" untuk admin dan super admin saja, lengkap dengan ikon.
- **Routes** (`routes/web.php`): mengganti placeholder text response dengan view-based routes (`Route::view`).
- **Build**: `npm run build` (Vite/Tailwind) sukses, tidak ada warning baru.

## File Utama yang Disentuh
- `laravel/resources/css/app.css`
- `laravel/resources/views/components/layouts/admin.blade.php` (baru)
- `laravel/resources/views/components/admin/{kpi-card,section,table,badge,empty-state,loading,filter,tabs,sidebar}.blade.php` (baru)
- `laravel/resources/views/admin/overview.blade.php` (baru)
- `laravel/resources/views/admin/ai-config.blade.php` (baru)
- `laravel/resources/views/livewire/dashboard-nav-profile.blade.php`
- `laravel/routes/web.php`
- `laravel/tests/Feature/Admin/AdminAccessTest.php` (update assert ke konten layout)
- `laravel/tests/Feature/Admin/AdminLayoutTest.php` (baru)
- `issue/issue-217-03-admin-design-system-layout-shell-2026-05-18.md` (plan)

## Verifikasi
\`\`\`bash
cd laravel && php artisan test --filter='Admin|Presence|Dashboard|Profile'
# 42 passed (151 assertions)

cd laravel && php artisan test
# 420 passed (1794 assertions)

cd laravel && npm run build
# vite build sukses, no errors
\`\`\`

### Skenario test yang ditambahkan / di-update
- `AdminLayoutTest`:
  - `/admin` merender komponen design system (`admin-sidebar`, `admin-nav-link`, `admin-topbar`, `admin-kpi`, `admin-section`, `admin-table`, `admin-empty-state`, `admin-loading`, `admin-filter`).
  - Super admin melihat link \"AI Configuration\" + tagline \"Hanya super admin\" di sidebar.
  - Admin biasa tidak melihat link \"AI Configuration\" di sidebar.
  - Dropdown nav profil dashboard menampilkan link \"Dashboard Admin\" hanya untuk admin/super admin (user biasa tidak melihatnya).
  - Layout memuat token tema dark dan branding ISTA, serta link kembali ke Chat.
- `AdminAccessTest` (update): assertion sekarang memeriksa heading \"Ringkasan Operasional\", judul \"AI Configuration\", dan badge \"Akses terbatas\" sebagai bukti page baru ter-render, bukan placeholder text response sebelumnya.

## Risiko & Mitigasi
- **Konsistensi visual**: layout dibangun di atas token yang sama dengan dashboard publik, profile, dan chat. Tidak ada palette atau font baru — hanya kombinasi baru.
- **Regresi visual halaman publik**: tidak ada perubahan pada `dashboard.blade.php`, `profile.blade.php`, `layouts/app.blade.php`, atau `livewire/layout/navigation.blade.php` selain penambahan link kondisional di dropdown profil dashboard, yang ter-cover oleh test.
- **Akses admin/super admin**: route, sidebar, dan dropdown semua memakai helper `canAccessAdmin()` / `isSuperAdmin()` dari child #214 sehingga gating konsisten.
- **Mobile**: sidebar collapse dengan backdrop dan tombol close; topbar wrap pada layar sempit.

## Tindak Lanjut (out of scope)
- Query KPI lengkap dan event tracking detail (child Monitoring Dashboard MVP).
- Knowledge base internal UI (child terpisah).
- AI Configuration logic dan form (child AI Configuration).
- ISTURA.