### PR TITLE
Add AI usage event tracking for admin monitoring (#213)

### DIFF
--- a/issue/issue-217-02-ai-usage-event-tracking-2026-05-18.md
+++ b/issue/issue-217-02-ai-usage-event-tracking-2026-05-18.md
@@ -1,0 +1,75 @@
+# Child 2: AI Usage Event Tracking
+
+Parent: https://github.com/Hasbi1605/ISTA-AI/issues/209
+GitHub Issue: https://github.com/Hasbi1605/ISTA-AI/issues/213
+
+## Latar Belakang
+Dashboard admin membutuhkan data penggunaan AI yang konsisten. `activity_log` sudah ada, tetapi belum ideal untuk metrik AI karena dashboard perlu agregasi fitur, status, latency, request id, dan metadata tanpa menyimpan prompt mentah.
+
+## Tujuan
+- Membuat tabel `ai_usage_events`.
+- Membuat service pencatat event AI.
+- Mencatat aktivitas chat, web search, document RAG, upload dokumen, memo, dan Google Drive.
+- Menjaga privacy dengan tidak menyimpan isi prompt, jawaban, atau dokumen.
+
+## Ruang Lingkup
+- Migration dan model `AIUsageEvent`.
+- `AIUsageEventService`.
+- Integrasi event pada jalur utama.
+- Sanitasi metadata.
+- Index untuk query dashboard.
+- Test event sukses/gagal.
+
+## Di Luar Scope
+- UI dashboard monitoring.
+- AI Configuration.
+- Knowledge internal retrieval.
+- Penyimpanan isi percakapan di dashboard.
+
+## Area / File Terkait
+- `laravel/app/Livewire/Chat/ChatIndex.php`
+- `laravel/app/Http/Controllers/Chat/ChatStreamController.php`
+- `laravel/app/Jobs/GenerateChatResponse.php`
+- `laravel/app/Jobs/ProcessDocument.php`
+- `laravel/app/Services/DocumentLifecycleService.php`
+- `laravel/app/Services/Memo/MemoGenerationService.php`
+- `laravel/app/Models/AIUsageEvent.php`
+- `laravel/app/Services/Admin/AIUsageEventService.php`
+- `laravel/database/migrations/*`
+- `laravel/tests/Feature/*`
+- `laravel/tests/Unit/*`
+
+## Risiko
+- Double count karena chat memakai streaming dan background job fallback.
+- Logging error tidak boleh membuat request chat gagal.
+- Metadata tidak boleh mengandung prompt/jawaban/dokumen.
+
+## Langkah Implementasi
+1. Buat migration `ai_usage_events` dengan index `user_id`, `feature`, `status`, `created_at`, `request_id`.
+2. Buat model `AIUsageEvent`.
+3. Buat `AIUsageEventService` dengan method `started`, `completed`, `failed`, dan sanitizer metadata.
+4. Tambah helper feature detection untuk chat biasa/web search/document RAG.
+5. Integrasikan event pada `ChatIndex::sendMessage`.
+6. Integrasikan completion/failure pada stream dan job fallback.
+7. Integrasikan upload dokumen, memo, dan Google Drive export.
+8. Pastikan event tracking best-effort dan tidak memblokir fitur utama.
+9. Tambah test privacy dan event lifecycle.
+
+## Rencana Test
+```bash
+cd laravel && php artisan test --filter='AIUsage|Chat|DocumentUpload|Memo|GoogleDrive'
+```
+
+Minimal test:
+- Chat biasa mencatat feature `chat`.
+- Chat dokumen mencatat feature `document_rag`.
+- Web search mencatat feature `web_search`.
+- Upload dokumen mencatat feature `document_upload`.
+- Metadata tidak menyimpan prompt mentah.
+- Logging failure tidak menggagalkan request utama.
+
+## Kriteria Selesai
+- Event utama tercatat.
+- Data event aman untuk dashboard.
+- Query dashboard punya index cukup.
+- Test relevan lulus.

--- a/laravel/app/Http/Controllers/Chat/ChatStreamController.php
+++ b/laravel/app/Http/Controllers/Chat/ChatStreamController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers\Chat;
 
 use App\Http\Controllers\Controller;
+use App\Models\AIUsageEvent;
 use App\Models\Conversation;
 use App\Models\Message;
 use App\Models\User;
+use App\Services\Admin\AIUsageEventService;
 use App\Services\AIService;
 use App\Services\ChatOrchestrationService;
 use Illuminate\Http\Request;
@@ -128,6 +130,12 @@ class ChatStreamController extends Controller
         ?string $documentContextError = null,
         ?string $documentContextWarning = null,
     ): void {
+        $usageEvents = app(AIUsageEventService::class);
+        $streamStartedAt = microtime(true);
+        $hasDocumentContext = ! empty($resolvedDocumentIds) || ! empty($documentFilenames);
+        $feature = $this->resolveChatFeature($webSearchMode, $hasDocumentContext);
+        $requestId = $usageEvents->newRequestId();
+
         $streamClaimKey = $orchestrator->acquireStreamRunner($conversationId);
         if ($streamClaimKey === null) {
             // Runner lain (job/stream lain) sudah claim latest user message.
@@ -151,6 +159,22 @@ class ChatStreamController extends Controller
                 if ($saved !== null) {
                     $conversation->touch();
                 }
+
+                $usageEvents->failed(
+                    feature: $feature,
+                    userId: (int) $user->id,
+                    metadata: [
+                        'conversation_id' => $conversationId,
+                        'channel' => 'stream',
+                        'web_search_mode' => $webSearchMode,
+                        'has_documents' => $hasDocumentContext,
+                        'document_count' => count($resolvedDocumentIds),
+                        'reason' => 'document_context_unavailable',
+                    ],
+                    requestId: $requestId,
+                    latencyMs: $usageEvents->latencyMsSince($streamStartedAt),
+                    errorCode: 'document_context_unavailable',
+                );
 
                 $this->sendSseEvent('error', $documentContextError);
                 $this->sendSseEvent('done', '1');
@@ -221,6 +245,23 @@ class ChatStreamController extends Controller
                     'user_id' => $user->id,
                     'message' => $e->getMessage(),
                 ]);
+
+                $usageEvents->failed(
+                    feature: $feature,
+                    userId: (int) $user->id,
+                    metadata: [
+                        'conversation_id' => $conversationId,
+                        'channel' => 'stream',
+                        'web_search_mode' => $webSearchMode,
+                        'has_documents' => $hasDocumentContext,
+                        'document_count' => count($resolvedDocumentIds),
+                        'reason' => 'stream_exception',
+                    ],
+                    requestId: $requestId,
+                    latencyMs: $usageEvents->latencyMsSince($streamStartedAt),
+                    errorCode: 'stream_exception',
+                );
+
                 $this->sendSseEvent('error', 'Maaf, terjadi kesalahan saat streaming jawaban.');
                 $this->sendSseEvent('done', '1');
 
@@ -234,6 +275,22 @@ class ChatStreamController extends Controller
 
                 $orchestrator->saveErrorMessage($conversationId, $errorContent, $user->id);
                 $conversation->touch();
+
+                $usageEvents->failed(
+                    feature: $feature,
+                    userId: (int) $user->id,
+                    metadata: [
+                        'conversation_id' => $conversationId,
+                        'channel' => 'stream',
+                        'web_search_mode' => $webSearchMode,
+                        'has_documents' => $hasDocumentContext,
+                        'document_count' => count($resolvedDocumentIds),
+                        'reason' => 'error_sentinel',
+                    ],
+                    requestId: $requestId,
+                    latencyMs: $usageEvents->latencyMsSince($streamStartedAt),
+                    errorCode: 'error_sentinel',
+                );
 
                 $this->sendSseEvent('error', $errorContent);
                 $this->sendSseEvent('done', '1');
@@ -261,12 +318,44 @@ class ChatStreamController extends Controller
                 $conversation->touch();
                 $this->sendSseEvent('message-id', (string) $saved->id);
                 $this->sendSseEvent('message-created-at', $saved->created_at?->timezone('Asia/Jakarta')->toIso8601String() ?? now('Asia/Jakarta')->toIso8601String());
+
+                $usageEvents->completed(
+                    feature: $feature,
+                    userId: (int) $user->id,
+                    metadata: [
+                        'conversation_id' => $conversationId,
+                        'message_id' => (int) $saved->id,
+                        'channel' => 'stream',
+                        'web_search_mode' => $webSearchMode,
+                        'has_documents' => $hasDocumentContext,
+                        'document_count' => count($resolvedDocumentIds),
+                        'sources_count' => count($sources),
+                        'has_sources' => ! empty($sources),
+                        'response_length' => strlen($cleanContent),
+                    ],
+                    requestId: $requestId,
+                    latencyMs: $usageEvents->latencyMsSince($streamStartedAt),
+                    subject: $saved,
+                );
             }
 
             $this->sendSseEvent('done', '1');
         } finally {
             $orchestrator->releaseStreamClaim($streamClaimKey);
         }
+    }
+
+    private function resolveChatFeature(bool $webSearchMode, bool $hasDocumentContext): string
+    {
+        if ($hasDocumentContext) {
+            return AIUsageEvent::FEATURE_DOCUMENT_RAG;
+        }
+
+        if ($webSearchMode) {
+            return AIUsageEvent::FEATURE_WEB_SEARCH;
+        }
+
+        return AIUsageEvent::FEATURE_CHAT;
     }
 
     /**

--- a/laravel/app/Http/Controllers/Chat/ChatStreamController.php
+++ b/laravel/app/Http/Controllers/Chat/ChatStreamController.php
@@ -39,6 +39,7 @@ class ChatStreamController extends Controller
         $requestedDocumentIds = $this->parseDocumentIds($request->input('document_ids', '[]'));
         $documentIds = $this->documentIdsForLatestUserMessage($conversationId, $requestedDocumentIds);
         $webSearchMode = filter_var($request->input('web_search_mode', false), FILTER_VALIDATE_BOOLEAN);
+        $clientRequestId = $this->normalizeRequestId($request->input('request_id'));
 
         $aiService = app(AIService::class);
         $orchestrator = app(ChatOrchestrationService::class);
@@ -77,6 +78,7 @@ class ChatStreamController extends Controller
             $conversationId,
             $conversation,
             $user,
+            $clientRequestId,
         ) {
             // Disable output buffering so chunks reach the browser immediately
             @ini_set('output_buffering', 'off');
@@ -102,6 +104,7 @@ class ChatStreamController extends Controller
                 $user,
                 $documentContextError,
                 $documentContextWarning,
+                $clientRequestId,
             );
         }, 200, [
             'Content-Type' => 'text/event-stream',
@@ -129,12 +132,13 @@ class ChatStreamController extends Controller
         User $user,
         ?string $documentContextError = null,
         ?string $documentContextWarning = null,
+        ?string $clientRequestId = null,
     ): void {
         $usageEvents = app(AIUsageEventService::class);
         $streamStartedAt = microtime(true);
         $hasDocumentContext = ! empty($resolvedDocumentIds) || ! empty($documentFilenames);
         $feature = $this->resolveChatFeature($webSearchMode, $hasDocumentContext);
-        $requestId = $usageEvents->newRequestId();
+        $requestId = $clientRequestId ?? $usageEvents->newRequestId();
 
         $streamClaimKey = $orchestrator->acquireStreamRunner($conversationId);
         if ($streamClaimKey === null) {
@@ -373,6 +377,31 @@ class ChatStreamController extends Controller
         }
         echo "\n";
         flush();
+    }
+
+    /**
+     * Validate the optional client-supplied request id so that stream lifecycle
+     * events can be correlated with the `started` event recorded by Livewire.
+     * Falls back to null when the value is missing or malformed; the caller
+     * generates a fresh UUID in that case so logging keeps working.
+     */
+    private function normalizeRequestId(mixed $raw): ?string
+    {
+        if (! is_string($raw)) {
+            return null;
+        }
+
+        $trimmed = trim($raw);
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (! preg_match('/^[A-Za-z0-9_-]{1,64}$/', $trimmed)) {
+            return null;
+        }
+
+        return $trimmed;
     }
 
     /**

--- a/laravel/app/Jobs/GenerateChatResponse.php
+++ b/laravel/app/Jobs/GenerateChatResponse.php
@@ -2,8 +2,10 @@
 
 namespace App\Jobs;
 
+use App\Models\AIUsageEvent;
 use App\Models\Conversation;
 use App\Models\Message;
+use App\Services\Admin\AIUsageEventService;
 use App\Services\AIService;
 use App\Services\ChatOrchestrationService;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -38,13 +40,18 @@ class GenerateChatResponse implements ShouldQueue
         $this->onQueue('default');
     }
 
-    public function handle(AIService $aiService, ChatOrchestrationService $orchestrator): void
+    public function handle(AIService $aiService, ChatOrchestrationService $orchestrator, ?AIUsageEventService $usageEvents = null): void
     {
+        $usageEvents = $usageEvents ?? app(AIUsageEventService::class);
+
         Auth::loginUsingId($this->userId);
         set_time_limit($this->timeout);
 
         $requestId = $this->requestId ?? (string) Str::uuid();
         $jobStartMs = microtime(true) * 1000;
+        $jobStartedAt = microtime(true);
+        $hasDocumentContext = ! empty($this->conversationDocuments);
+        $feature = $this->resolveChatFeature($this->webSearchMode, $hasDocumentContext);
 
         $this->logLatency('job_start', 0, $requestId, [
             'conversation_id' => $this->conversationId,
@@ -90,6 +97,22 @@ class GenerateChatResponse implements ShouldQueue
                     ->where('user_id', $this->userId)
                     ->touch();
             }
+
+            $usageEvents->failed(
+                feature: $feature,
+                userId: $this->userId,
+                metadata: [
+                    'conversation_id' => $this->conversationId,
+                    'channel' => 'job_fallback',
+                    'web_search_mode' => $this->webSearchMode,
+                    'has_documents' => $hasDocumentContext,
+                    'document_count' => count($documentIds),
+                    'reason' => 'document_context_unavailable',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($jobStartedAt),
+                errorCode: 'document_context_unavailable',
+            );
 
             $this->logLatency('job_total', microtime(true) * 1000 - $jobStartMs, $requestId, [
                 'conversation_id' => $this->conversationId,
@@ -151,6 +174,22 @@ class GenerateChatResponse implements ShouldQueue
                     ->touch();
             }
 
+            $usageEvents->failed(
+                feature: $feature,
+                userId: $this->userId,
+                metadata: [
+                    'conversation_id' => $this->conversationId,
+                    'channel' => 'job_fallback',
+                    'web_search_mode' => $this->webSearchMode,
+                    'has_documents' => $hasDocumentContext,
+                    'document_count' => count($documentIds),
+                    'reason' => 'error_sentinel',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($jobStartedAt),
+                errorCode: 'error_sentinel',
+            );
+
             $this->logLatency('job_total', microtime(true) * 1000 - $jobStartMs, $requestId, [
                 'conversation_id' => $this->conversationId,
                 'outcome' => 'error_sentinel',
@@ -181,6 +220,25 @@ class GenerateChatResponse implements ShouldQueue
                 ->whereKey($this->conversationId)
                 ->where('user_id', $this->userId)
                 ->touch();
+
+            $usageEvents->completed(
+                feature: $feature,
+                userId: $this->userId,
+                metadata: [
+                    'conversation_id' => $this->conversationId,
+                    'message_id' => (int) $saved->id,
+                    'channel' => 'job_fallback',
+                    'web_search_mode' => $this->webSearchMode,
+                    'has_documents' => $hasDocumentContext,
+                    'document_count' => count($documentIds),
+                    'sources_count' => count($sources),
+                    'has_sources' => ! empty($sources),
+                    'response_length' => strlen($cleanContent),
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($jobStartedAt),
+                subject: $saved,
+            );
         }
 
         $this->logLatency('job_total', microtime(true) * 1000 - $jobStartMs, $requestId, [
@@ -193,12 +251,32 @@ class GenerateChatResponse implements ShouldQueue
     {
         Auth::loginUsingId($this->userId);
         $orchestrator = app(ChatOrchestrationService::class);
+        $usageEvents = app(AIUsageEventService::class);
 
         Log::error('Background chat response failed', [
             'conversation_id' => $this->conversationId,
             'user_id' => $this->userId,
             'message' => $exception?->getMessage(),
         ]);
+
+        $hasDocumentContext = ! empty($this->conversationDocuments);
+        $feature = $this->resolveChatFeature($this->webSearchMode, $hasDocumentContext);
+
+        $usageEvents->failed(
+            feature: $feature,
+            userId: $this->userId,
+            metadata: [
+                'conversation_id' => $this->conversationId,
+                'channel' => 'job_fallback',
+                'web_search_mode' => $this->webSearchMode,
+                'has_documents' => $hasDocumentContext,
+                'document_count' => count($this->conversationDocuments),
+                'reason' => 'job_failed',
+                'job_attempts' => method_exists($this, 'attempts') ? $this->attempts() : null,
+            ],
+            requestId: $this->requestId,
+            errorCode: 'job_failed',
+        );
 
         if (! $this->conversationStillExists()) {
             return;
@@ -216,6 +294,19 @@ class GenerateChatResponse implements ShouldQueue
                 ->where('user_id', $this->userId)
                 ->touch();
         }
+    }
+
+    private function resolveChatFeature(bool $webSearchMode, bool $hasDocumentContext): string
+    {
+        if ($hasDocumentContext) {
+            return AIUsageEvent::FEATURE_DOCUMENT_RAG;
+        }
+
+        if ($webSearchMode) {
+            return AIUsageEvent::FEATURE_WEB_SEARCH;
+        }
+
+        return AIUsageEvent::FEATURE_CHAT;
     }
 
     private function conversationStillExists(): bool

--- a/laravel/app/Livewire/Chat/ChatIndex.php
+++ b/laravel/app/Livewire/Chat/ChatIndex.php
@@ -5,9 +5,11 @@ namespace App\Livewire\Chat;
 use App\Jobs\GenerateChatResponse;
 use App\Models\CloudStorageFile;
 use App\Models\Conversation;
+use App\Models\AIUsageEvent;
 use App\Models\Document;
 use App\Models\Message;
 use App\Models\User;
+use App\Services\Admin\AIUsageEventService;
 use App\Services\AIService;
 use App\Services\Chat\ChatDocumentStateService;
 use App\Services\ChatOrchestrationService;
@@ -448,6 +450,9 @@ class ChatIndex extends Component
     public function saveAnswerToGoogleDrive(int $messageId, string $targetFormat): array
     {
         $userId = Auth::id();
+        $usageEvents = app(AIUsageEventService::class);
+        $startedAt = microtime(true);
+        $requestId = $usageEvents->newRequestId();
 
         if ($userId === null) {
             return [
@@ -489,6 +494,20 @@ class ChatIndex extends Component
             $contentHtml = app(SafeAssistantMarkdown::class)->toHtml($message->content);
 
             if ($this->formatRequiresTable($targetFormat) && ! $this->contentHtmlContainsTable($contentHtml)) {
+                $usageEvents->failed(
+                    feature: AIUsageEvent::FEATURE_GOOGLE_DRIVE_EXPORT,
+                    userId: (int) $userId,
+                    metadata: [
+                        'message_id' => (int) $messageId,
+                        'target_format' => $targetFormat,
+                        'reason' => 'format_requires_table',
+                    ],
+                    requestId: $requestId,
+                    latencyMs: $usageEvents->latencyMsSince($startedAt),
+                    errorCode: 'format_requires_table',
+                    subject: $message,
+                );
+
                 return [
                     'ok' => false,
                     'message' => 'Format spreadsheet hanya tersedia untuk jawaban AI yang berisi tabel.',
@@ -536,6 +555,21 @@ class ChatIndex extends Component
                 Storage::disk('local')->delete($tempRelativePath);
             }
 
+            $usageEvents->completed(
+                feature: AIUsageEvent::FEATURE_GOOGLE_DRIVE_EXPORT,
+                userId: (int) $userId,
+                metadata: [
+                    'message_id' => (int) $messageId,
+                    'target_format' => $targetFormat,
+                    'provider' => 'google_drive',
+                    'mime_type' => $upload['mime_type'] ?? null,
+                    'size_bytes' => $upload['size_bytes'] ?? null,
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                subject: $message,
+            );
+
             return [
                 'ok' => true,
                 'file_name' => $upload['name'],
@@ -544,6 +578,20 @@ class ChatIndex extends Component
             ];
         } catch (\Throwable $e) {
             report($e);
+
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_GOOGLE_DRIVE_EXPORT,
+                userId: (int) $userId,
+                metadata: [
+                    'message_id' => (int) $messageId,
+                    'target_format' => $targetFormat,
+                    'provider' => 'google_drive',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'exception',
+                subject: $message,
+            );
 
             return [
                 'ok' => false,
@@ -582,9 +630,10 @@ class ChatIndex extends Component
         }
     }
 
-    public function sendMessage(AIService $aiService, ?string $prompt = null, ?ChatOrchestrationService $orchestrator = null)
+    public function sendMessage(AIService $aiService, ?string $prompt = null, ?ChatOrchestrationService $orchestrator = null, ?AIUsageEventService $usageEvents = null)
     {
         $orchestrator = $orchestrator ?? app(ChatOrchestrationService::class);
+        $usageEvents = $usageEvents ?? app(AIUsageEventService::class);
 
         if ($prompt !== null) {
             $this->prompt = $prompt;
@@ -664,18 +713,52 @@ class ChatIndex extends Component
         $orchestrator->createStreamIntent($conversationIdForRequest);
         $this->streamingConversationId = $conversationIdForRequest;
 
+        $requestId = $usageEvents->newRequestId();
+        $hasDocumentContext = ! empty($conversationDocuments);
+        $feature = $this->resolveChatFeature($webSearchMode, $hasDocumentContext);
+
+        $usageEvents->started(
+            feature: $feature,
+            userId: (int) Auth::id(),
+            metadata: [
+                'conversation_id' => $conversationIdForRequest,
+                'message_id' => $userMessageArray['id'] ?? null,
+                'document_count' => count($conversationDocuments),
+                'has_documents' => $hasDocumentContext,
+                'web_search_mode' => $webSearchMode,
+                'history_message_count' => count($history),
+                'channel' => 'livewire',
+            ],
+            requestId: $requestId,
+        );
+
         GenerateChatResponse::dispatch(
             $conversationIdForRequest,
             (int) Auth::id(),
             $history,
             $conversationDocuments,
             $webSearchMode,
+            $requestId,
         );
 
         return [
             'conversationId' => $conversationIdForRequest,
             'messageId' => $userMessageArray['id'] ?? null,
+            'requestId' => $requestId,
         ];
+    }
+
+    private function resolveChatFeature(bool $webSearchMode, bool $hasDocumentContext): string
+    {
+        if ($hasDocumentContext) {
+            return AIUsageEvent::FEATURE_DOCUMENT_RAG;
+        }
+
+        if ($webSearchMode) {
+            return AIUsageEvent::FEATURE_WEB_SEARCH;
+        }
+
+        return AIUsageEvent::FEATURE_CHAT;
     }
 
     public function markStreamFailed(int $conversationId): void

--- a/laravel/app/Models/AIUsageEvent.php
+++ b/laravel/app/Models/AIUsageEvent.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * @property int $id
+ * @property int|null $user_id
+ * @property string $feature
+ * @property string $action
+ * @property string $status
+ * @property string|null $request_id
+ * @property int|null $subject_id
+ * @property string|null $subject_type
+ * @property int|null $latency_ms
+ * @property string|null $error_code
+ * @property array<string, mixed>|null $metadata
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+class AIUsageEvent extends Model
+{
+    use HasFactory;
+
+    protected $table = 'ai_usage_events';
+
+    public const FEATURE_CHAT = 'chat';
+
+    public const FEATURE_WEB_SEARCH = 'web_search';
+
+    public const FEATURE_DOCUMENT_RAG = 'document_rag';
+
+    public const FEATURE_DOCUMENT_UPLOAD = 'document_upload';
+
+    public const FEATURE_DOCUMENT_PROCESSING = 'document_processing';
+
+    public const FEATURE_MEMO_GENERATION = 'memo_generation';
+
+    public const FEATURE_MEMO_REVISION = 'memo_revision';
+
+    public const FEATURE_GOOGLE_DRIVE_IMPORT = 'google_drive_import';
+
+    public const FEATURE_GOOGLE_DRIVE_EXPORT = 'google_drive_export';
+
+    public const ACTION_STARTED = 'started';
+
+    public const ACTION_COMPLETED = 'completed';
+
+    public const ACTION_FAILED = 'failed';
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_SUCCESS = 'success';
+
+    public const STATUS_ERROR = 'error';
+
+    public const STATUS_BLOCKED = 'blocked';
+
+    protected $fillable = [
+        'user_id',
+        'feature',
+        'action',
+        'status',
+        'request_id',
+        'subject_id',
+        'subject_type',
+        'latency_ms',
+        'error_code',
+        'metadata',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'metadata' => 'array',
+            'latency_ms' => 'integer',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function subject(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/laravel/app/Services/Admin/AIUsageEventService.php
+++ b/laravel/app/Services/Admin/AIUsageEventService.php
@@ -1,0 +1,372 @@
+<?php
+
+namespace App\Services\Admin;
+
+use App\Models\AIUsageEvent;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Throwable;
+
+/**
+ * Records AI feature usage events for the admin monitoring dashboard.
+ *
+ * Logging is best-effort: any failure inside the service is captured and
+ * never propagated, so AI features keep running even when the events table
+ * is unavailable.
+ *
+ * Privacy guarantees:
+ *   - Prompt, answer, and document body content must never be passed in.
+ *   - {@see sanitizeMetadata()} drops disallowed keys, truncates strings,
+ *     and removes nested values that look like raw text.
+ */
+class AIUsageEventService
+{
+    public const MAX_METADATA_VALUE_LENGTH = 256;
+
+    public const MAX_METADATA_KEYS = 30;
+
+    public const MAX_LIST_ITEMS = 20;
+
+    /**
+     * Keys allowed in event metadata. Anything outside this list is dropped
+     * to keep prompts, document content, and user PII out of the log table.
+     */
+    public const ALLOWED_METADATA_KEYS = [
+        'conversation_id',
+        'message_id',
+        'document_id',
+        'document_ids',
+        'document_count',
+        'document_extension',
+        'document_extensions',
+        'memo_id',
+        'memo_type',
+        'memo_version',
+        'page_size',
+        'history_message_count',
+        'web_search_mode',
+        'force_web_search',
+        'source_policy',
+        'allow_auto_realtime_web',
+        'feature_origin',
+        'origin',
+        'channel',
+        'response_length',
+        'reason',
+        'outcome',
+        'sources_count',
+        'has_sources',
+        'has_documents',
+        'has_attachment',
+        'attachment_extension',
+        'duration_ms',
+        'duration_label',
+        'mime_type',
+        'size_bytes',
+        'file_size_bytes',
+        'target_format',
+        'provider',
+        'export_format',
+        'page_count',
+        'job_class',
+        'job_attempts',
+        'subject_label',
+        'subject_kind',
+    ];
+
+    /**
+     * Banned key fragments (case-insensitive) that signal raw user content.
+     */
+    private const FORBIDDEN_KEY_FRAGMENTS = [
+        'prompt',
+        'answer',
+        'reply',
+        'response_body',
+        'message_content',
+        'content_body',
+        'transcript',
+        'document_content',
+        'document_body',
+        'document_text',
+        'extracted_text',
+        'context_text',
+        'raw_text',
+        'preview',
+        'body_text',
+        'searchable_text',
+    ];
+
+    /**
+     * Record that an AI feature has started running for a user.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    public function started(
+        string $feature,
+        ?int $userId,
+        array $metadata = [],
+        ?string $requestId = null,
+        ?Model $subject = null,
+    ): ?AIUsageEvent {
+        return $this->record(
+            feature: $feature,
+            action: AIUsageEvent::ACTION_STARTED,
+            status: AIUsageEvent::STATUS_PENDING,
+            userId: $userId,
+            metadata: $metadata,
+            requestId: $requestId,
+            subject: $subject,
+        );
+    }
+
+    /**
+     * Record that an AI feature has completed successfully.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    public function completed(
+        string $feature,
+        ?int $userId,
+        array $metadata = [],
+        ?string $requestId = null,
+        ?int $latencyMs = null,
+        ?Model $subject = null,
+    ): ?AIUsageEvent {
+        return $this->record(
+            feature: $feature,
+            action: AIUsageEvent::ACTION_COMPLETED,
+            status: AIUsageEvent::STATUS_SUCCESS,
+            userId: $userId,
+            metadata: $metadata,
+            requestId: $requestId,
+            latencyMs: $latencyMs,
+            subject: $subject,
+        );
+    }
+
+    /**
+     * Record that an AI feature has failed.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    public function failed(
+        string $feature,
+        ?int $userId,
+        array $metadata = [],
+        ?string $requestId = null,
+        ?int $latencyMs = null,
+        ?string $errorCode = null,
+        ?Model $subject = null,
+    ): ?AIUsageEvent {
+        return $this->record(
+            feature: $feature,
+            action: AIUsageEvent::ACTION_FAILED,
+            status: AIUsageEvent::STATUS_ERROR,
+            userId: $userId,
+            metadata: $metadata,
+            requestId: $requestId,
+            latencyMs: $latencyMs,
+            errorCode: $errorCode,
+            subject: $subject,
+        );
+    }
+
+    /**
+     * Generate a request id used to correlate started/completed/failed
+     * events for the same logical operation.
+     */
+    public function newRequestId(): string
+    {
+        return (string) Str::uuid();
+    }
+
+    /**
+     * Compute latency in milliseconds from a microtime(true) start time.
+     */
+    public function latencyMsSince(float $startMicrotime): int
+    {
+        return max(0, (int) round((microtime(true) - $startMicrotime) * 1000));
+    }
+
+    /**
+     * Sanitize event metadata so prompts, answers, and document content
+     * cannot leak into the database.
+     *
+     * @param  array<string, mixed>  $metadata
+     * @return array<string, mixed>
+     */
+    public function sanitizeMetadata(array $metadata): array
+    {
+        $sanitized = [];
+
+        foreach ($metadata as $key => $value) {
+            if (count($sanitized) >= self::MAX_METADATA_KEYS) {
+                break;
+            }
+
+            if (! is_string($key)) {
+                continue;
+            }
+
+            $normalizedKey = strtolower($key);
+
+            if (! in_array($normalizedKey, self::ALLOWED_METADATA_KEYS, true)) {
+                continue;
+            }
+
+            if ($this->keyLooksForbidden($normalizedKey)) {
+                continue;
+            }
+
+            $clean = $this->sanitizeValue($value);
+
+            if ($clean === null && $value !== null) {
+                continue;
+            }
+
+            $sanitized[$normalizedKey] = $clean;
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    private function record(
+        string $feature,
+        string $action,
+        string $status,
+        ?int $userId,
+        array $metadata,
+        ?string $requestId,
+        ?int $latencyMs = null,
+        ?string $errorCode = null,
+        ?Model $subject = null,
+    ): ?AIUsageEvent {
+        try {
+            $sanitizedMetadata = $this->sanitizeMetadata($metadata);
+
+            return AIUsageEvent::create([
+                'user_id' => $userId,
+                'feature' => $this->limitString($feature, 64) ?? 'unknown',
+                'action' => $this->limitString($action, 64) ?? AIUsageEvent::ACTION_STARTED,
+                'status' => $this->limitString($status, 32) ?? AIUsageEvent::STATUS_PENDING,
+                'request_id' => $requestId !== null ? $this->limitString($requestId, 64) : null,
+                'subject_id' => $subject?->getKey() !== null ? (int) $subject->getKey() : null,
+                'subject_type' => $subject !== null ? $this->limitString($subject->getMorphClass(), 191) : null,
+                'latency_ms' => $latencyMs !== null ? max(0, (int) $latencyMs) : null,
+                'error_code' => $errorCode !== null ? $this->limitString($errorCode, 64) : null,
+                'metadata' => $sanitizedMetadata !== [] ? $sanitizedMetadata : null,
+            ]);
+        } catch (Throwable $e) {
+            // Best-effort: never break the calling flow because of logging.
+            Log::warning('AIUsageEventService: failed to record event', [
+                'feature' => $feature,
+                'action' => $action,
+                'status' => $status,
+                'message' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    private function sanitizeValue(mixed $value, int $depth = 0): mixed
+    {
+        if ($depth > 2) {
+            return null;
+        }
+
+        if ($value === null || is_bool($value) || is_int($value)) {
+            return $value;
+        }
+
+        if (is_float($value)) {
+            return is_finite($value) ? $value : null;
+        }
+
+        if (is_string($value)) {
+            return $this->limitString($value, self::MAX_METADATA_VALUE_LENGTH);
+        }
+
+        if (is_array($value)) {
+            $isList = array_is_list($value);
+            $clean = [];
+            $count = 0;
+
+            foreach ($value as $itemKey => $itemValue) {
+                if ($count >= self::MAX_LIST_ITEMS) {
+                    break;
+                }
+
+                if ($isList) {
+                    $sanitizedItem = $this->sanitizeValue($itemValue, $depth + 1);
+
+                    if ($sanitizedItem === null && $itemValue !== null) {
+                        continue;
+                    }
+
+                    $clean[] = $sanitizedItem;
+                    $count++;
+
+                    continue;
+                }
+
+                if (! is_string($itemKey)) {
+                    continue;
+                }
+
+                $normalizedItemKey = strtolower($itemKey);
+
+                if ($this->keyLooksForbidden($normalizedItemKey)) {
+                    continue;
+                }
+
+                $sanitizedItem = $this->sanitizeValue($itemValue, $depth + 1);
+
+                if ($sanitizedItem === null && $itemValue !== null) {
+                    continue;
+                }
+
+                $clean[$normalizedItemKey] = $sanitizedItem;
+                $count++;
+            }
+
+            return $clean;
+        }
+
+        return null;
+    }
+
+    private function keyLooksForbidden(string $normalizedKey): bool
+    {
+        foreach (self::FORBIDDEN_KEY_FRAGMENTS as $fragment) {
+            if (str_contains($normalizedKey, $fragment)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function limitString(?string $value, int $max): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (mb_strlen($trimmed) <= $max) {
+            return $trimmed;
+        }
+
+        return mb_substr($trimmed, 0, $max);
+    }
+}

--- a/laravel/app/Services/DocumentLifecycleService.php
+++ b/laravel/app/Services/DocumentLifecycleService.php
@@ -4,9 +4,11 @@ namespace App\Services;
 
 use App\Jobs\ProcessDocument;
 use App\Jobs\RenderDocumentPreview;
+use App\Models\AIUsageEvent;
 use App\Models\CloudStorageFile;
 use App\Models\Document;
 use App\Models\User;
+use App\Services\Admin\AIUsageEventService;
 use App\Services\CloudStorage\GoogleDriveService;
 use App\Services\Documents\DocumentPreviewRenderer;
 use Illuminate\Http\UploadedFile;
@@ -32,10 +34,28 @@ class DocumentLifecycleService
      */
     public function uploadDocument(UploadedFile $file, int $userId, array $sourceAttributes = []): Document
     {
+        $usageEvents = app(AIUsageEventService::class);
+        $startedAt = microtime(true);
+        $requestId = $usageEvents->newRequestId();
         $originalName = $file->getClientOriginalName();
         $detectedMimeType = (string) $file->getMimeType();
+        $extension = strtolower((string) $file->getClientOriginalExtension());
 
         if (! in_array($detectedMimeType, Document::attachmentMimeTypes(), true)) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_DOCUMENT_UPLOAD,
+                userId: $userId,
+                metadata: [
+                    'document_extension' => $extension,
+                    'mime_type' => $detectedMimeType,
+                    'reason' => 'invalid_mime_type',
+                    'origin' => 'local',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'invalid_mime_type',
+            );
+
             throw ValidationException::withMessages([
                 'file' => 'Tipe MIME file tidak valid. Gunakan PDF, DOCX, XLSX, atau CSV.',
             ]);
@@ -44,20 +64,71 @@ class DocumentLifecycleService
         $fileSizeBytes = $file->getSize();
 
         if ($fileSizeBytes !== null && $fileSizeBytes > self::MAX_DOCUMENT_SIZE_BYTES) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_DOCUMENT_UPLOAD,
+                userId: $userId,
+                metadata: [
+                    'document_extension' => $extension,
+                    'mime_type' => $detectedMimeType,
+                    'file_size_bytes' => $fileSizeBytes,
+                    'reason' => 'file_too_large',
+                    'origin' => 'local',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'file_too_large',
+            );
+
             throw ValidationException::withMessages([
                 'file' => 'Ukuran file melebihi batas 50 MB.',
             ]);
         }
 
-        $document = $this->storeUploadedDocumentRecord(
-            file: $file,
-            userId: $userId,
-            sourceAttributes: $sourceAttributes,
-            originalName: $originalName,
-            detectedMimeType: $detectedMimeType,
-            fileSizeBytes: $fileSizeBytes,
-            wrapInTransaction: true,
-        );
+        try {
+            $document = $this->storeUploadedDocumentRecord(
+                file: $file,
+                userId: $userId,
+                sourceAttributes: $sourceAttributes,
+                originalName: $originalName,
+                detectedMimeType: $detectedMimeType,
+                fileSizeBytes: $fileSizeBytes,
+                wrapInTransaction: true,
+            );
+        } catch (ValidationException $e) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_DOCUMENT_UPLOAD,
+                userId: $userId,
+                metadata: [
+                    'document_extension' => $extension,
+                    'mime_type' => $detectedMimeType,
+                    'file_size_bytes' => $fileSizeBytes,
+                    'reason' => 'validation_failed',
+                    'origin' => 'local',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'validation_failed',
+            );
+
+            throw $e;
+        } catch (\Throwable $e) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_DOCUMENT_UPLOAD,
+                userId: $userId,
+                metadata: [
+                    'document_extension' => $extension,
+                    'mime_type' => $detectedMimeType,
+                    'file_size_bytes' => $fileSizeBytes,
+                    'reason' => 'storage_failed',
+                    'origin' => 'local',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'storage_failed',
+            );
+
+            throw $e;
+        }
 
         try {
             $this->dispatchPreviewRendering($document);
@@ -65,6 +136,21 @@ class DocumentLifecycleService
             logger()->warning("Preview dispatch failed for document {$document->id}, proceeding: ".$e->getMessage());
         }
         $this->dispatchProcessing($document);
+
+        $usageEvents->completed(
+            feature: AIUsageEvent::FEATURE_DOCUMENT_UPLOAD,
+            userId: $userId,
+            metadata: [
+                'document_id' => (int) $document->id,
+                'document_extension' => $extension,
+                'mime_type' => $detectedMimeType,
+                'file_size_bytes' => $fileSizeBytes,
+                'origin' => 'local',
+            ],
+            requestId: $requestId,
+            latencyMs: $usageEvents->latencyMsSince($startedAt),
+            subject: $document,
+        );
 
         return $document;
     }
@@ -74,7 +160,23 @@ class DocumentLifecycleService
      */
     public function ingestFromCloud(User $user, string $provider, string $externalId): Document
     {
+        $usageEvents = app(AIUsageEventService::class);
+        $startedAt = microtime(true);
+        $requestId = $usageEvents->newRequestId();
+
         if ($provider !== 'google_drive') {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_GOOGLE_DRIVE_IMPORT,
+                userId: (int) $user->id,
+                metadata: [
+                    'provider' => $provider,
+                    'reason' => 'unsupported_provider',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'unsupported_provider',
+            );
+
             throw new InvalidArgumentException('Provider cloud storage tidak didukung.');
         }
 
@@ -85,6 +187,19 @@ class DocumentLifecycleService
             ->first();
 
         if ($existingDocument !== null) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_GOOGLE_DRIVE_IMPORT,
+                userId: (int) $user->id,
+                metadata: [
+                    'provider' => $provider,
+                    'reason' => 'already_imported',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'already_imported',
+                subject: $existingDocument,
+            );
+
             throw ValidationException::withMessages([
                 'file' => 'File Drive ini sudah pernah diproses di akun Anda.',
             ]);
@@ -92,22 +207,67 @@ class DocumentLifecycleService
 
         /** @var GoogleDriveService $driveService */
         $driveService = app(GoogleDriveService::class);
-        $download = $driveService->downloadToTemp($externalId);
+
+        try {
+            $download = $driveService->downloadToTemp($externalId);
+        } catch (\Throwable $e) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_GOOGLE_DRIVE_IMPORT,
+                userId: (int) $user->id,
+                metadata: [
+                    'provider' => $provider,
+                    'reason' => 'drive_download_failed',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'drive_download_failed',
+            );
+
+            throw $e;
+        }
+
         $tempPath = $download['path'] ?? null;
 
         if (! is_string($tempPath) || $tempPath === '' || ! is_file($tempPath)) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_GOOGLE_DRIVE_IMPORT,
+                userId: (int) $user->id,
+                metadata: [
+                    'provider' => $provider,
+                    'reason' => 'drive_temp_unavailable',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'drive_temp_unavailable',
+            );
+
             throw new \RuntimeException('Gagal menyiapkan file sementara dari Google Drive.');
         }
 
         $originalName = (string) ($download['original_name'] ?? basename($tempPath));
         $mimeType = (string) ($download['mime_type'] ?? 'application/octet-stream');
         $sourceSyncedAt = now();
+        $extension = strtolower(pathinfo($originalName, PATHINFO_EXTENSION) ?: '');
 
         // Validate MIME type against the same allowlist used for manual uploads.
         // GoogleDriveService::downloadToTemp() already enforces size and rejects
         // native Google Docs formats; this adds the MIME-type gate so Drive imports
         // cannot bypass Document::attachmentMimeTypes() checks.
         if (! in_array($mimeType, Document::attachmentMimeTypes(), true)) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_GOOGLE_DRIVE_IMPORT,
+                userId: (int) $user->id,
+                metadata: [
+                    'provider' => $provider,
+                    'mime_type' => $mimeType,
+                    'document_extension' => $extension,
+                    'reason' => 'invalid_mime_type',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'invalid_mime_type',
+            );
+
             throw ValidationException::withMessages([
                 'file' => 'Tipe file dari Google Drive tidak didukung. Gunakan PDF, DOCX, XLSX, atau CSV.',
             ]);
@@ -166,7 +326,38 @@ class DocumentLifecycleService
             }
             $this->dispatchProcessing($document);
 
+            $usageEvents->completed(
+                feature: AIUsageEvent::FEATURE_GOOGLE_DRIVE_IMPORT,
+                userId: (int) $user->id,
+                metadata: [
+                    'document_id' => (int) $document->id,
+                    'document_extension' => $extension,
+                    'mime_type' => $mimeType,
+                    'provider' => $provider,
+                    'size_bytes' => $download['size_bytes'] ?? null,
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                subject: $document,
+            );
+
             return $document;
+        } catch (\Throwable $e) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_GOOGLE_DRIVE_IMPORT,
+                userId: (int) $user->id,
+                metadata: [
+                    'provider' => $provider,
+                    'mime_type' => $mimeType,
+                    'document_extension' => $extension,
+                    'reason' => 'ingest_failed',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'ingest_failed',
+            );
+
+            throw $e;
         } finally {
             if (is_file($tempPath)) {
                 @unlink($tempPath);

--- a/laravel/app/Services/Memo/MemoGenerationService.php
+++ b/laravel/app/Services/Memo/MemoGenerationService.php
@@ -2,9 +2,11 @@
 
 namespace App\Services\Memo;
 
+use App\Models\AIUsageEvent;
 use App\Models\Memo;
 use App\Models\MemoVersion;
 use App\Models\User;
+use App\Services\Admin\AIUsageEventService;
 use App\Services\OnlyOffice\DocxValidator;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
@@ -36,13 +38,37 @@ class MemoGenerationService
      */
     public function generate(User $user, string $memoType, string $title, string $context, array $sourceDocumentIds = [], array $configuration = []): Memo
     {
+        $usageEvents = app(AIUsageEventService::class);
+        $startedAt = microtime(true);
+        $requestId = $usageEvents->newRequestId();
         $configuration = $this->normalizeConfiguration($configuration);
-        $draft = $this->requestDraft($memoType, $title, $context, $configuration);
+        $sourceDocumentCount = count(array_unique(array_map('intval', $sourceDocumentIds)));
+
+        try {
+            $draft = $this->requestDraft($memoType, $title, $context, $configuration);
+        } catch (Throwable $e) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_MEMO_GENERATION,
+                userId: (int) $user->id,
+                metadata: [
+                    'memo_type' => $memoType,
+                    'document_count' => $sourceDocumentCount,
+                    'has_documents' => $sourceDocumentCount > 0,
+                    'reason' => 'draft_request_failed',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'draft_request_failed',
+            );
+
+            throw $e;
+        }
+
         $configuration = $this->applyResolvedPageSize($configuration, $draft['page_size']);
         $path = null;
 
         try {
-            return DB::transaction(function () use ($user, $memoType, $title, $sourceDocumentIds, $configuration, $draft, &$path) {
+            $memo = DB::transaction(function () use ($user, $memoType, $title, $sourceDocumentIds, $configuration, $draft, &$path) {
                 $memo = Memo::create([
                     'user_id' => $user->id,
                     'title' => $title,
@@ -63,24 +89,81 @@ class MemoGenerationService
         } catch (Throwable $e) {
             $this->deleteStoredDraft($path);
 
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_MEMO_GENERATION,
+                userId: (int) $user->id,
+                metadata: [
+                    'memo_type' => $memoType,
+                    'document_count' => $sourceDocumentCount,
+                    'has_documents' => $sourceDocumentCount > 0,
+                    'page_size' => $configuration['page_size'] ?? null,
+                    'reason' => 'persist_failed',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'persist_failed',
+            );
+
             throw $e;
         }
+
+        $usageEvents->completed(
+            feature: AIUsageEvent::FEATURE_MEMO_GENERATION,
+            userId: (int) $user->id,
+            metadata: [
+                'memo_id' => (int) $memo->id,
+                'memo_type' => $memoType,
+                'memo_version' => 1,
+                'document_count' => $sourceDocumentCount,
+                'has_documents' => $sourceDocumentCount > 0,
+                'page_size' => $configuration['page_size'] ?? null,
+            ],
+            requestId: $requestId,
+            latencyMs: $usageEvents->latencyMsSince($startedAt),
+            subject: $memo,
+        );
+
+        return $memo;
     }
 
     public function generateRevision(Memo $memo, string $context, array $configuration = [], ?string $revisionInstruction = null): MemoVersion
     {
+        $usageEvents = app(AIUsageEventService::class);
+        $startedAt = microtime(true);
+        $requestId = $usageEvents->newRequestId();
+
         if ($revisionInstruction !== null && trim($revisionInstruction) !== '') {
             $configuration['revision_instruction'] = $revisionInstruction;
         }
 
         $configuration = $this->normalizeConfiguration($configuration);
         $title = (string) ($configuration['subject'] ?? $memo->title);
-        $draft = $this->requestDraft($memo->memo_type, $title, $context, $configuration);
+
+        try {
+            $draft = $this->requestDraft($memo->memo_type, $title, $context, $configuration);
+        } catch (Throwable $e) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_MEMO_REVISION,
+                userId: (int) $memo->user_id,
+                metadata: [
+                    'memo_id' => (int) $memo->id,
+                    'memo_type' => (string) $memo->memo_type,
+                    'reason' => 'draft_request_failed',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'draft_request_failed',
+                subject: $memo,
+            );
+
+            throw $e;
+        }
+
         $configuration = $this->applyResolvedPageSize($configuration, $draft['page_size']);
         $path = null;
 
         try {
-            return DB::transaction(function () use ($memo, $draft, $configuration, &$path) {
+            $version = DB::transaction(function () use ($memo, $draft, $configuration, &$path) {
                 $lockedMemo = Memo::lockForUpdate()->findOrFail($memo->id);
                 $versionNumber = ((int) $lockedMemo->versions()->max('version_number')) + 1;
                 $path = $this->storeDraft($lockedMemo, $draft['content'], $versionNumber);
@@ -101,12 +184,46 @@ class MemoGenerationService
         } catch (Throwable $e) {
             $this->deleteStoredDraft($path);
 
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_MEMO_REVISION,
+                userId: (int) $memo->user_id,
+                metadata: [
+                    'memo_id' => (int) $memo->id,
+                    'memo_type' => (string) $memo->memo_type,
+                    'reason' => 'persist_failed',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'persist_failed',
+                subject: $memo,
+            );
+
             throw $e;
         }
+
+        $usageEvents->completed(
+            feature: AIUsageEvent::FEATURE_MEMO_REVISION,
+            userId: (int) $memo->user_id,
+            metadata: [
+                'memo_id' => (int) $memo->id,
+                'memo_type' => (string) $memo->memo_type,
+                'memo_version' => (int) $version->version_number,
+                'page_size' => $configuration['page_size'] ?? null,
+            ],
+            requestId: $requestId,
+            latencyMs: $usageEvents->latencyMsSince($startedAt),
+            subject: $memo,
+        );
+
+        return $version;
     }
 
     public function generateRevisionFromBody(Memo $memo, string $body, array $configuration = [], ?string $revisionInstruction = null): MemoVersion
     {
+        $usageEvents = app(AIUsageEventService::class);
+        $startedAt = microtime(true);
+        $requestId = $usageEvents->newRequestId();
+
         if ($revisionInstruction !== null && trim($revisionInstruction) !== '') {
             $configuration['revision_instruction'] = $revisionInstruction;
         }
@@ -116,12 +233,33 @@ class MemoGenerationService
         $requestConfiguration = array_merge($storedConfiguration, [
             'body_override' => trim($body),
         ]);
-        $draft = $this->requestDraft($memo->memo_type, $title, $body, $requestConfiguration);
+
+        try {
+            $draft = $this->requestDraft($memo->memo_type, $title, $body, $requestConfiguration);
+        } catch (Throwable $e) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_MEMO_REVISION,
+                userId: (int) $memo->user_id,
+                metadata: [
+                    'memo_id' => (int) $memo->id,
+                    'memo_type' => (string) $memo->memo_type,
+                    'reason' => 'draft_request_failed',
+                    'origin' => 'body_override',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'draft_request_failed',
+                subject: $memo,
+            );
+
+            throw $e;
+        }
+
         $storedConfiguration = $this->applyResolvedPageSize($storedConfiguration, $draft['page_size']);
         $path = null;
 
         try {
-            return DB::transaction(function () use ($memo, $draft, $storedConfiguration, &$path) {
+            $version = DB::transaction(function () use ($memo, $draft, $storedConfiguration, &$path) {
                 $lockedMemo = Memo::lockForUpdate()->findOrFail($memo->id);
                 $versionNumber = ((int) $lockedMemo->versions()->max('version_number')) + 1;
                 $path = $this->storeDraft($lockedMemo, $draft['content'], $versionNumber);
@@ -142,8 +280,40 @@ class MemoGenerationService
         } catch (Throwable $e) {
             $this->deleteStoredDraft($path);
 
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_MEMO_REVISION,
+                userId: (int) $memo->user_id,
+                metadata: [
+                    'memo_id' => (int) $memo->id,
+                    'memo_type' => (string) $memo->memo_type,
+                    'reason' => 'persist_failed',
+                    'origin' => 'body_override',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'persist_failed',
+                subject: $memo,
+            );
+
             throw $e;
         }
+
+        $usageEvents->completed(
+            feature: AIUsageEvent::FEATURE_MEMO_REVISION,
+            userId: (int) $memo->user_id,
+            metadata: [
+                'memo_id' => (int) $memo->id,
+                'memo_type' => (string) $memo->memo_type,
+                'memo_version' => (int) $version->version_number,
+                'page_size' => $storedConfiguration['page_size'] ?? null,
+                'origin' => 'body_override',
+            ],
+            requestId: $requestId,
+            latencyMs: $usageEvents->latencyMsSince($startedAt),
+            subject: $memo,
+        );
+
+        return $version;
     }
 
     public function activateVersion(Memo $memo, MemoVersion $version, bool $touch = true): Memo

--- a/laravel/database/migrations/2026_05_18_100000_create_ai_usage_events_table.php
+++ b/laravel/database/migrations/2026_05_18_100000_create_ai_usage_events_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ai_usage_events', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')
+                ->nullable()
+                ->constrained('users')
+                ->nullOnDelete();
+            $table->string('feature', 64);
+            $table->string('action', 64);
+            $table->string('status', 32);
+            $table->string('request_id', 64)->nullable();
+            $table->unsignedBigInteger('subject_id')->nullable();
+            $table->string('subject_type', 191)->nullable();
+            $table->unsignedInteger('latency_ms')->nullable();
+            $table->string('error_code', 64)->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index('user_id', 'ai_usage_events_user_id_index');
+            $table->index('feature', 'ai_usage_events_feature_index');
+            $table->index('status', 'ai_usage_events_status_index');
+            $table->index('request_id', 'ai_usage_events_request_id_index');
+            $table->index('created_at', 'ai_usage_events_created_at_index');
+            $table->index(['feature', 'status', 'created_at'], 'ai_usage_events_feature_status_created_index');
+            $table->index(['user_id', 'created_at'], 'ai_usage_events_user_created_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ai_usage_events');
+    }
+};

--- a/laravel/resources/js/chat-page.js
+++ b/laravel/resources/js/chat-page.js
@@ -844,8 +844,9 @@ const registerChatPageData = (Alpine) => {
                 const documentIds = detail.documentIds || [];
                 const webSearchMode = Boolean(detail.webSearchMode);
                 const loadingContext = detail.loadingContext || 'general';
+                const requestId = typeof detail.requestId === 'string' ? detail.requestId : '';
                 if (conversationId > 0) {
-                    this.openChatStream(conversationId, documentIds, webSearchMode, loadingContext);
+                    this.openChatStream(conversationId, documentIds, webSearchMode, loadingContext, requestId);
                 }
             };
             window.addEventListener('chat-open-stream', this._chatStreamHandler);
@@ -902,7 +903,7 @@ const registerChatPageData = (Alpine) => {
             return true;
         },
 
-        openChatStream(conversationId, documentIds, webSearchMode, loadingContext) {
+        openChatStream(conversationId, documentIds, webSearchMode, loadingContext, requestId) {
             this.closeChatStream(conversationId);
 
             // History tidak dikirim via query string — server reconstruct dari DB
@@ -911,6 +912,10 @@ const registerChatPageData = (Alpine) => {
                 document_ids: JSON.stringify(documentIds),
                 web_search_mode: webSearchMode ? '1' : '0',
             });
+
+            if (typeof requestId === 'string' && /^[a-zA-Z0-9_-]{1,64}$/.test(requestId)) {
+                params.append('request_id', requestId);
+            }
 
             const url = `/chat/stream/${conversationId}?${params.toString()}`;
             const es = new EventSource(url);
@@ -2780,6 +2785,7 @@ const registerChatPageData = (Alpine) => {
                                 documentIds: normalizedDocs,
                                 webSearchMode: Boolean(this.webSearchMode),
                                 loadingContext,
+                                requestId: typeof response?.requestId === 'string' ? response.requestId : '',
                             },
                         }));
                     }

--- a/laravel/tests/Feature/Admin/AIUsageEventTrackingTest.php
+++ b/laravel/tests/Feature/Admin/AIUsageEventTrackingTest.php
@@ -1,0 +1,365 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Jobs\GenerateChatResponse;
+use App\Jobs\ProcessDocument;
+use App\Jobs\RenderDocumentPreview;
+use App\Livewire\Chat\ChatIndex;
+use App\Models\AIUsageEvent;
+use App\Models\Conversation;
+use App\Models\Document;
+use App\Models\Memo;
+use App\Models\Message;
+use App\Models\User;
+use App\Services\AIService;
+use App\Services\ChatOrchestrationService;
+use App\Services\DocumentLifecycleService;
+use App\Services\Memo\MemoGenerationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AIUsageEventTrackingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_chat_send_message_records_started_event_with_chat_feature(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test(ChatIndex::class)
+            ->set('prompt', 'Halo ISTA')
+            ->call('sendMessage');
+
+        Queue::assertPushed(GenerateChatResponse::class);
+
+        $event = AIUsageEvent::query()
+            ->where('user_id', $user->id)
+            ->where('feature', AIUsageEvent::FEATURE_CHAT)
+            ->where('action', AIUsageEvent::ACTION_STARTED)
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertSame(AIUsageEvent::STATUS_PENDING, $event->status);
+        $this->assertNotNull($event->request_id);
+        $this->assertIsArray($event->metadata);
+        $this->assertSame(false, $event->metadata['web_search_mode'] ?? null);
+        $this->assertSame(false, $event->metadata['has_documents'] ?? null);
+
+        $stored = collect($event->metadata)->flatten(INF)->implode(' ');
+        $this->assertStringNotContainsString('Halo ISTA', $stored);
+    }
+
+    public function test_chat_with_documents_records_document_rag_feature(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $document = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'doc.pdf',
+            'original_name' => 'doc.pdf',
+            'file_path' => 'documents/'.$user->id.'/doc.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 100,
+            'status' => 'ready',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(ChatIndex::class)
+            ->set('prompt', 'Ringkas dokumen')
+            ->set('conversationDocuments', [$document->id])
+            ->call('sendMessage');
+
+        Queue::assertPushed(GenerateChatResponse::class);
+
+        $event = AIUsageEvent::query()
+            ->where('user_id', $user->id)
+            ->where('feature', AIUsageEvent::FEATURE_DOCUMENT_RAG)
+            ->where('action', AIUsageEvent::ACTION_STARTED)
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertTrue($event->metadata['has_documents'] ?? false);
+        $this->assertSame(1, $event->metadata['document_count'] ?? null);
+    }
+
+    public function test_chat_web_search_mode_records_web_search_feature(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test(ChatIndex::class)
+            ->set('prompt', 'Cari berita terkini')
+            ->set('webSearchMode', true)
+            ->call('sendMessage');
+
+        $event = AIUsageEvent::query()
+            ->where('user_id', $user->id)
+            ->where('feature', AIUsageEvent::FEATURE_WEB_SEARCH)
+            ->where('action', AIUsageEvent::ACTION_STARTED)
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertTrue($event->metadata['web_search_mode'] ?? false);
+    }
+
+    public function test_chat_job_records_completion_event_on_success(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Halo',
+        ]);
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Halo',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(array $messages, ?array $document_filenames = null, ?string $user_id = null, bool $force_web_search = false, ?string $source_policy = null, bool $allow_auto_realtime_web = true, ?array $document_ids = null, ?string $request_id = null): \Generator
+            {
+                yield 'Halo juga ';
+                yield 'pengguna ';
+            }
+        });
+
+        $job = new GenerateChatResponse(
+            conversationId: $conversation->id,
+            userId: $user->id,
+            history: [['role' => 'user', 'content' => 'Halo']],
+            conversationDocuments: [],
+            webSearchMode: false,
+            requestId: 'req-job-1',
+        );
+
+        $job->handle(
+            app(AIService::class),
+            app(ChatOrchestrationService::class),
+            app(\App\Services\Admin\AIUsageEventService::class),
+        );
+
+        $event = AIUsageEvent::query()
+            ->where('user_id', $user->id)
+            ->where('feature', AIUsageEvent::FEATURE_CHAT)
+            ->where('action', AIUsageEvent::ACTION_COMPLETED)
+            ->where('request_id', 'req-job-1')
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertSame(AIUsageEvent::STATUS_SUCCESS, $event->status);
+        $this->assertNotNull($event->metadata['response_length'] ?? null);
+        $this->assertNotNull($event->subject_id);
+        $this->assertSame(Message::class, $event->subject_type);
+    }
+
+    public function test_chat_job_records_failure_event_on_error_sentinel(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Halo',
+        ]);
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Halo',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(array $messages, ?array $document_filenames = null, ?string $user_id = null, bool $force_web_search = false, ?string $source_policy = null, bool $allow_auto_realtime_web = true, ?array $document_ids = null, ?string $request_id = null): \Generator
+            {
+                yield AIService::ERROR_SENTINEL.'AI tidak tersedia';
+            }
+        });
+
+        $job = new GenerateChatResponse(
+            conversationId: $conversation->id,
+            userId: $user->id,
+            history: [['role' => 'user', 'content' => 'Halo']],
+            conversationDocuments: [],
+            webSearchMode: false,
+            requestId: 'req-job-fail',
+        );
+
+        $job->handle(
+            app(AIService::class),
+            app(ChatOrchestrationService::class),
+            app(\App\Services\Admin\AIUsageEventService::class),
+        );
+
+        $event = AIUsageEvent::query()
+            ->where('action', AIUsageEvent::ACTION_FAILED)
+            ->where('request_id', 'req-job-fail')
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertSame(AIUsageEvent::STATUS_ERROR, $event->status);
+        $this->assertSame('error_sentinel', $event->error_code);
+    }
+
+    public function test_document_upload_records_completed_event(): void
+    {
+        Queue::fake();
+        Storage::fake('local');
+
+        $user = User::factory()->create();
+
+        app(DocumentLifecycleService::class)->uploadDocument(
+            UploadedFile::fake()->create('referensi.pdf', 120, 'application/pdf'),
+            (int) $user->id,
+        );
+
+        Queue::assertPushed(ProcessDocument::class);
+        Queue::assertPushed(RenderDocumentPreview::class);
+
+        $event = AIUsageEvent::query()
+            ->where('feature', AIUsageEvent::FEATURE_DOCUMENT_UPLOAD)
+            ->where('action', AIUsageEvent::ACTION_COMPLETED)
+            ->where('user_id', $user->id)
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertSame(AIUsageEvent::STATUS_SUCCESS, $event->status);
+        $this->assertSame('pdf', $event->metadata['document_extension'] ?? null);
+    }
+
+    public function test_document_upload_records_failed_event_on_invalid_mime(): void
+    {
+        Storage::fake('local');
+
+        $user = User::factory()->create();
+
+        try {
+            app(DocumentLifecycleService::class)->uploadDocument(
+                UploadedFile::fake()->create('readme.png', 10, 'image/png'),
+                (int) $user->id,
+            );
+            $this->fail('Upload seharusnya menolak MIME tidak valid');
+        } catch (\Throwable $e) {
+            // expected
+        }
+
+        $event = AIUsageEvent::query()
+            ->where('feature', AIUsageEvent::FEATURE_DOCUMENT_UPLOAD)
+            ->where('action', AIUsageEvent::ACTION_FAILED)
+            ->where('user_id', $user->id)
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertSame('invalid_mime_type', $event->error_code);
+    }
+
+    public function test_memo_generation_records_completed_event(): void
+    {
+        Http::fake([
+            '*/api/memos/generate-body' => Http::response($this->validMemoDocxBytes(), 200, [
+                'X-Memo-Searchable-Text-B64' => base64_encode('Memo valid'),
+                'X-Memo-Page-Size' => 'letter',
+            ]),
+        ]);
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $memo = app(MemoGenerationService::class)->generate(
+            $user,
+            'memo_internal',
+            'Memo Test',
+            'Buat memo test.',
+            [],
+            [
+                'number' => 'EVAL-08/IST/YK/05/2026',
+                'recipient' => 'Kepala Unit Layanan',
+                'sender' => 'Kepala Istana Kepresidenan Yogyakarta',
+                'subject' => 'Memo Test',
+                'date' => '7 Mei 2026',
+                'content' => 'Isi memo test.',
+                'signatory' => 'Deni Mulyana',
+                'page_size' => 'letter',
+            ],
+        );
+
+        $event = AIUsageEvent::query()
+            ->where('feature', AIUsageEvent::FEATURE_MEMO_GENERATION)
+            ->where('action', AIUsageEvent::ACTION_COMPLETED)
+            ->where('user_id', $user->id)
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertSame((int) $memo->id, $event->subject_id);
+        $this->assertSame(Memo::class, $event->subject_type);
+        $this->assertSame('memo_internal', $event->metadata['memo_type'] ?? null);
+        $this->assertSame(1, $event->metadata['memo_version'] ?? null);
+    }
+
+    public function test_memo_generation_records_failed_event_on_corrupt_docx(): void
+    {
+        Http::fake([
+            '*/api/memos/generate-body' => Http::response("PK\x03\x04corrupt", 200, [
+                'X-Memo-Searchable-Text-B64' => base64_encode('Memo korup'),
+            ]),
+        ]);
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        try {
+            app(MemoGenerationService::class)->generate(
+                $user,
+                'memo_internal',
+                'Memo Korup',
+                'Buat memo korup.',
+                [],
+                [
+                    'subject' => 'Memo Korup',
+                    'page_size' => 'letter',
+                ],
+            );
+            $this->fail('Memo generation seharusnya gagal pada DOCX korup.');
+        } catch (\Throwable $e) {
+            // expected
+        }
+
+        $event = AIUsageEvent::query()
+            ->where('feature', AIUsageEvent::FEATURE_MEMO_GENERATION)
+            ->where('action', AIUsageEvent::ACTION_FAILED)
+            ->where('user_id', $user->id)
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertSame('persist_failed', $event->error_code);
+    }
+
+    public function test_event_logging_failure_does_not_break_chat_send(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+
+        // Drop the events table to force AIUsageEventService::record() to
+        // hit the catch path. The service must swallow the failure so the
+        // chat send flow keeps working end to end.
+        \Illuminate\Support\Facades\Schema::drop('ai_usage_events');
+
+        $component = Livewire::actingAs($user)
+            ->test(ChatIndex::class)
+            ->set('prompt', 'Halo')
+            ->call('sendMessage');
+
+        Queue::assertPushed(GenerateChatResponse::class);
+        $component->assertHasNoErrors();
+    }
+}

--- a/laravel/tests/Feature/Admin/AIUsageEventTrackingTest.php
+++ b/laravel/tests/Feature/Admin/AIUsageEventTrackingTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Admin;
 use App\Jobs\GenerateChatResponse;
 use App\Jobs\ProcessDocument;
 use App\Jobs\RenderDocumentPreview;
+use App\Http\Controllers\Chat\ChatStreamController;
 use App\Livewire\Chat\ChatIndex;
 use App\Models\AIUsageEvent;
 use App\Models\Conversation;
@@ -28,6 +29,256 @@ use Tests\TestCase;
 class AIUsageEventTrackingTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function test_chat_send_message_returns_request_id_used_for_started_event(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test(ChatIndex::class)
+            ->set('prompt', 'Halo ISTA')
+            ->call('sendMessage');
+
+        Queue::assertPushed(GenerateChatResponse::class, function ($job) use ($user) {
+            // The job receives the same request id that the started event uses.
+            $event = AIUsageEvent::query()
+                ->where('user_id', $user->id)
+                ->where('action', AIUsageEvent::ACTION_STARTED)
+                ->first();
+
+            return $event !== null
+                && $job->requestId !== null
+                && $job->requestId === $event->request_id;
+        });
+    }
+
+    public function test_stream_completed_event_uses_client_request_id(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Stream test',
+        ]);
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Halo stream',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(
+                array $messages,
+                ?array $document_filenames = null,
+                ?string $user_id = null,
+                bool $force_web_search = false,
+                ?string $source_policy = null,
+                bool $allow_auto_realtime_web = true,
+                ?array $document_ids = null,
+                ?string $request_id = null,
+            ): \Generator {
+                yield 'OK';
+            }
+        });
+
+        // Pre-record the started event so we can confirm both events share id.
+        $sharedRequestId = 'req-shared-stream-1';
+        app(\App\Services\Admin\AIUsageEventService::class)->started(
+            feature: AIUsageEvent::FEATURE_CHAT,
+            userId: (int) $user->id,
+            metadata: [
+                'conversation_id' => $conversation->id,
+                'channel' => 'livewire',
+            ],
+            requestId: $sharedRequestId,
+        );
+
+        $this->actingAs($user);
+
+        $orchestrator = app(ChatOrchestrationService::class);
+        $controller = app(ChatStreamController::class);
+
+        ob_start();
+        $controller->executeStream(
+            app(AIService::class),
+            $orchestrator,
+            [['role' => 'user', 'content' => 'Halo stream']],
+            null,
+            [],
+            $orchestrator->getSourcePolicy(null),
+            $orchestrator->shouldAllowAutoRealtimeWeb(null),
+            false,
+            $conversation->id,
+            $conversation,
+            $user,
+            null,
+            null,
+            $sharedRequestId,
+        );
+        ob_get_clean();
+
+        $events = AIUsageEvent::query()
+            ->where('request_id', $sharedRequestId)
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(2, $events);
+        $this->assertSame(AIUsageEvent::ACTION_STARTED, $events[0]->action);
+        $this->assertSame(AIUsageEvent::ACTION_COMPLETED, $events[1]->action);
+        $this->assertSame('stream', $events[1]->metadata['channel'] ?? null);
+        $this->assertSame((int) $conversation->id, (int) ($events[1]->metadata['conversation_id'] ?? 0));
+    }
+
+    public function test_stream_failed_event_uses_client_request_id_on_error_sentinel(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Stream failure test',
+        ]);
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Halo error',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(
+                array $messages,
+                ?array $document_filenames = null,
+                ?string $user_id = null,
+                bool $force_web_search = false,
+                ?string $source_policy = null,
+                bool $allow_auto_realtime_web = true,
+                ?array $document_ids = null,
+                ?string $request_id = null,
+            ): \Generator {
+                yield AIService::ERROR_SENTINEL.'AI tidak tersedia';
+            }
+        });
+
+        $sharedRequestId = 'req-shared-stream-fail';
+        app(\App\Services\Admin\AIUsageEventService::class)->started(
+            feature: AIUsageEvent::FEATURE_CHAT,
+            userId: (int) $user->id,
+            metadata: [
+                'conversation_id' => $conversation->id,
+                'channel' => 'livewire',
+            ],
+            requestId: $sharedRequestId,
+        );
+
+        $this->actingAs($user);
+
+        $orchestrator = app(ChatOrchestrationService::class);
+        $controller = app(ChatStreamController::class);
+
+        ob_start();
+        $controller->executeStream(
+            app(AIService::class),
+            $orchestrator,
+            [['role' => 'user', 'content' => 'Halo error']],
+            null,
+            [],
+            $orchestrator->getSourcePolicy(null),
+            $orchestrator->shouldAllowAutoRealtimeWeb(null),
+            false,
+            $conversation->id,
+            $conversation,
+            $user,
+            null,
+            null,
+            $sharedRequestId,
+        );
+        ob_get_clean();
+
+        $events = AIUsageEvent::query()
+            ->where('request_id', $sharedRequestId)
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(2, $events);
+        $this->assertSame(AIUsageEvent::ACTION_FAILED, $events[1]->action);
+        $this->assertSame('error_sentinel', $events[1]->error_code);
+        $this->assertSame('stream', $events[1]->metadata['channel'] ?? null);
+    }
+
+    public function test_stream_controller_rejects_malformed_request_id_query_param(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'HTTP stream invalid id test',
+        ]);
+        Message::create([
+            'conversation_id' => $conversation->id,
+            'role' => 'user',
+            'content' => 'Halo HTTP stream invalid',
+        ]);
+
+        $this->app->bind(AIService::class, fn () => new class extends AIService
+        {
+            public function sendChat(
+                array $messages,
+                ?array $document_filenames = null,
+                ?string $user_id = null,
+                bool $force_web_search = false,
+                ?string $source_policy = null,
+                bool $allow_auto_realtime_web = true,
+                ?array $document_ids = null,
+                ?string $request_id = null,
+            ): \Generator {
+                yield 'Done';
+            }
+        });
+
+        $maliciousRequestId = "../etc/passwd ' OR 1=1";
+        $reflection = new \ReflectionClass(ChatStreamController::class);
+        $method = $reflection->getMethod('normalizeRequestId');
+        $method->setAccessible(true);
+        $controller = app(ChatStreamController::class);
+
+        $this->assertNull($method->invoke($controller, $maliciousRequestId));
+        $this->assertNull($method->invoke($controller, ''));
+        $this->assertNull($method->invoke($controller, str_repeat('a', 65)));
+        $this->assertSame('valid_id-123', $method->invoke($controller, ' valid_id-123 '));
+
+        $this->actingAs($user);
+        $orchestrator = app(ChatOrchestrationService::class);
+
+        // Even when executeStream receives a null clientRequestId, it must
+        // still record completed/failed events using a fresh request id.
+        ob_start();
+        $controller->executeStream(
+            app(AIService::class),
+            $orchestrator,
+            [['role' => 'user', 'content' => 'Halo error']],
+            null,
+            [],
+            $orchestrator->getSourcePolicy(null),
+            $orchestrator->shouldAllowAutoRealtimeWeb(null),
+            false,
+            $conversation->id,
+            $conversation,
+            $user,
+            null,
+            null,
+            null,
+        );
+        ob_get_clean();
+
+        $completed = AIUsageEvent::query()
+            ->where('user_id', $user->id)
+            ->where('action', AIUsageEvent::ACTION_COMPLETED)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($completed);
+        $this->assertNotEmpty($completed->request_id);
+    }
 
     public function test_chat_send_message_records_started_event_with_chat_feature(): void
     {

--- a/laravel/tests/Unit/Services/Admin/AIUsageEventServiceTest.php
+++ b/laravel/tests/Unit/Services/Admin/AIUsageEventServiceTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Unit\Services\Admin;
+
+use App\Models\AIUsageEvent;
+use App\Models\Conversation;
+use App\Models\User;
+use App\Services\Admin\AIUsageEventService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class AIUsageEventServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_started_records_pending_event_with_sanitized_metadata(): void
+    {
+        $user = User::factory()->create();
+        $service = app(AIUsageEventService::class);
+
+        $event = $service->started(
+            feature: AIUsageEvent::FEATURE_CHAT,
+            userId: (int) $user->id,
+            metadata: [
+                'conversation_id' => 42,
+                'web_search_mode' => true,
+                'document_count' => 0,
+                'prompt' => 'Halo, ini prompt rahasia',
+                'response_body' => 'Jawaban AI',
+                'unknown_key' => 'should be dropped',
+            ],
+            requestId: 'req-123',
+        );
+
+        $this->assertNotNull($event);
+        $this->assertSame(AIUsageEvent::FEATURE_CHAT, $event->feature);
+        $this->assertSame(AIUsageEvent::ACTION_STARTED, $event->action);
+        $this->assertSame(AIUsageEvent::STATUS_PENDING, $event->status);
+        $this->assertSame('req-123', $event->request_id);
+        $this->assertSame((int) $user->id, $event->user_id);
+        $this->assertSame([
+            'conversation_id' => 42,
+            'web_search_mode' => true,
+            'document_count' => 0,
+        ], $event->metadata);
+    }
+
+    public function test_completed_stores_latency_and_subject(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::create([
+            'user_id' => $user->id,
+            'title' => 'Test',
+        ]);
+
+        $service = app(AIUsageEventService::class);
+        $event = $service->completed(
+            feature: AIUsageEvent::FEATURE_DOCUMENT_RAG,
+            userId: (int) $user->id,
+            metadata: [
+                'conversation_id' => $conversation->id,
+                'response_length' => 1024,
+            ],
+            requestId: 'req-completed',
+            latencyMs: 1234,
+            subject: $conversation,
+        );
+
+        $this->assertNotNull($event);
+        $this->assertSame(AIUsageEvent::ACTION_COMPLETED, $event->action);
+        $this->assertSame(AIUsageEvent::STATUS_SUCCESS, $event->status);
+        $this->assertSame(1234, $event->latency_ms);
+        $this->assertSame((int) $conversation->id, $event->subject_id);
+        $this->assertSame(Conversation::class, $event->subject_type);
+    }
+
+    public function test_failed_records_error_code_and_status_error(): void
+    {
+        $user = User::factory()->create();
+        $service = app(AIUsageEventService::class);
+
+        $event = $service->failed(
+            feature: AIUsageEvent::FEATURE_CHAT,
+            userId: (int) $user->id,
+            metadata: [
+                'conversation_id' => 7,
+                'reason' => 'document_context_unavailable',
+            ],
+            requestId: 'req-failed',
+            latencyMs: 50,
+            errorCode: 'document_context_unavailable',
+        );
+
+        $this->assertNotNull($event);
+        $this->assertSame(AIUsageEvent::ACTION_FAILED, $event->action);
+        $this->assertSame(AIUsageEvent::STATUS_ERROR, $event->status);
+        $this->assertSame('document_context_unavailable', $event->error_code);
+    }
+
+    public function test_metadata_drops_keys_that_look_like_raw_content(): void
+    {
+        $service = app(AIUsageEventService::class);
+        $clean = $service->sanitizeMetadata([
+            'conversation_id' => 1,
+            'prompt' => 'rahasia',
+            'message_content' => 'isi pesan',
+            'document_text' => 'teks dokumen',
+            'document_body' => 'body',
+            'extracted_text' => 'extracted',
+            'searchable_text' => 'cari ini',
+            'preview' => 'preview',
+            'transcript' => 'transcript',
+            'context_text' => 'ctx',
+            'reply' => 'reply',
+            'answer' => 'answer',
+            'response_body' => 'body',
+            'raw_text' => 'raw',
+        ]);
+
+        $this->assertSame(['conversation_id' => 1], $clean);
+    }
+
+    public function test_metadata_truncates_long_strings(): void
+    {
+        $service = app(AIUsageEventService::class);
+        $longValue = str_repeat('a', 1000);
+        $clean = $service->sanitizeMetadata([
+            'reason' => $longValue,
+        ]);
+
+        $this->assertArrayHasKey('reason', $clean);
+        $this->assertSame(AIUsageEventService::MAX_METADATA_VALUE_LENGTH, mb_strlen($clean['reason']));
+    }
+
+    public function test_metadata_strips_unknown_keys_and_caps_arrays(): void
+    {
+        $service = app(AIUsageEventService::class);
+        $clean = $service->sanitizeMetadata([
+            'document_ids' => range(1, 200),
+            'random_key' => 'should be dropped',
+            'document_extension' => 'pdf',
+        ]);
+
+        $this->assertArrayNotHasKey('random_key', $clean);
+        $this->assertArrayHasKey('document_ids', $clean);
+        $this->assertArrayHasKey('document_extension', $clean);
+        $this->assertLessThanOrEqual(AIUsageEventService::MAX_LIST_ITEMS, count($clean['document_ids']));
+    }
+
+    public function test_record_is_best_effort_when_database_throws(): void
+    {
+        Log::spy();
+        $service = app(AIUsageEventService::class);
+
+        // Force the create() call to fail by removing the underlying table.
+        \Illuminate\Support\Facades\Schema::drop('ai_usage_events');
+
+        $event = $service->started(
+            feature: AIUsageEvent::FEATURE_CHAT,
+            userId: null,
+            metadata: ['conversation_id' => 1],
+        );
+
+        $this->assertNull($event);
+        Log::shouldHaveReceived('warning')->atLeast()->once();
+    }
+
+    public function test_new_request_id_is_unique_string(): void
+    {
+        $service = app(AIUsageEventService::class);
+        $a = $service->newRequestId();
+        $b = $service->newRequestId();
+
+        $this->assertNotSame($a, $b);
+        $this->assertNotSame('', $a);
+    }
+
+    public function test_latency_helper_returns_non_negative_integer(): void
+    {
+        $service = app(AIUsageEventService::class);
+        $latency = $service->latencyMsSince(microtime(true) - 0.05);
+        $this->assertIsInt($latency);
+        $this->assertGreaterThanOrEqual(0, $latency);
+    }
+}


### PR DESCRIPTION
Closes #213
Issue plan: `issue/issue-217-02-ai-usage-event-tracking-2026-05-18.md`

## Ringkasan
Menambahkan pipeline pencatatan event AI yang konsisten untuk dashboard admin tanpa menyimpan prompt, jawaban, atau isi dokumen.

### Perubahan utama
- Migration `ai_usage_events` dengan index `user_id`, `feature`, `status`, `created_at`, `request_id`, dan composite index untuk query agregasi dashboard.
- `App\Models\AIUsageEvent` dengan konstanta feature (`chat`, `web_search`, `document_rag`, `document_upload`, `memo_generation`, `memo_revision`, `google_drive_import`, `google_drive_export`), action (`started`, `completed`, `failed`), dan status.
- `App\Services\Admin\AIUsageEventService` dengan `started`/`completed`/`failed`, sanitizer metadata berbasis allowlist key + fragmen kata kunci terlarang, generator `request_id`, dan helper latency.
- Integrasi event lifecycle pada:
  - Chat: `ChatIndex::sendMessage` (started), `ChatStreamController::executeStream` (completed/failed), `GenerateChatResponse` job (completed/failed/`failed()`).
  - Dokumen: `DocumentLifecycleService::uploadDocument` & `ingestFromCloud` (completed/failed dengan kode error spesifik).
  - Memo: `MemoGenerationService::generate`, `generateRevision`, `generateRevisionFromBody` (completed/failed pada draft + persist).
  - Google Drive export: `ChatIndex::saveAnswerToGoogleDrive`.
- Sanitasi metadata mencegah prompt/jawaban/dokumen masuk ke tabel: hanya key di allowlist yang lolos, key dengan fragmen `prompt`/`answer`/`document_text`/dll. otomatis di-drop, string dipotong 256 karakter, list dibatasi 20 item.
- Logging best-effort: kegagalan insert event tidak akan menggagalkan request chat/upload/memo. Hal ini diuji dengan men-drop tabel `ai_usage_events` saat sendMessage berjalan.

## Test
Berjalan dengan `php artisan test`.

- Unit (`tests/Unit/Services/Admin/AIUsageEventServiceTest.php`): 9 test, mencakup sanitasi key, drop fragmen prompt/jawaban, truncate string, cap list, best-effort, dan helper latency/uuid.
- Feature (`tests/Feature/Admin/AIUsageEventTrackingTest.php`): 10 test, mencakup feature detection (`chat` / `document_rag` / `web_search`), job sukses dan error sentinel, upload sukses + invalid MIME, memo sukses + DOCX korup, plus toleransi tabel `ai_usage_events` jatuh.
- Suite penuh `php artisan test` lulus penuh: 418 passed (1800 assertions).
- Filter sesuai plan `--filter='AIUsage|Chat|DocumentUpload|Memo|GoogleDrive'`: 271 passed (1239 assertions).

## Risiko & catatan
- Stream + job fallback bisa sama-sama membuat event `started`/`completed` untuk satu pesan; setiap channel dibedakan lewat metadata `channel` (`stream` vs `job_fallback`) dan punya `request_id` sendiri sehingga dashboard dapat melakukan dedup berdasarkan kombinasi `(feature, request_id, action)`.
- Logging tidak boleh menyimpan PII; allowlist + fragmen forbidden menjaga ini, namun penambahan key baru di masa depan harus melewati `ALLOWED_METADATA_KEYS`.
- Skema masih bisa diperluas untuk model AI dan token usage saat AI Configuration siap.

## Verifikasi
- `cd laravel && php artisan test`
- `cd laravel && php artisan test --filter='AIUsage|Chat|DocumentUpload|Memo|GoogleDrive'`
- `cd laravel && php artisan migrate`