### PR TITLE
Admin Knowledge Base Internal (#211)

### DIFF
--- a/issue/issue-211-admin-knowledge-base-internal-plan-2026-05-18.md
+++ b/issue/issue-211-admin-knowledge-base-internal-plan-2026-05-18.md
@@ -1,0 +1,97 @@
+# Plan: Admin Knowledge Base Internal (Issue #211)
+
+Parent: https://github.com/Hasbi1605/ISTA-AI/issues/209
+Issue ini: https://github.com/Hasbi1605/ISTA-AI/issues/211
+Base branch: `codex/issue-210-admin-monitoring-dashboard` (chain dengan PR admin foundation/monitoring)
+Working branch: `codex/issue-211-admin-knowledge-base-internal`
+
+## Tujuan
+Bangun modul knowledge base internal milik admin yang terpisah dari dokumen pribadi user. Admin bisa upload dokumen referensi (PDF/DOCX/XLSX/CSV), mengelola siklus hidup dokumen (draft → processing → active → error → archived), dan vector hasil ingest punya metadata `scope=global_internal` agar mudah dibedakan dari dokumen user di luar issue retrieval.
+
+## Scope teknis
+1. **Database**
+   - Migration baru: `knowledge_sources`, `knowledge_documents`, `knowledge_chunks`.
+   - `knowledge_sources` = grouping/source label (mis. "SOP HR", "Aturan ISTANA").
+   - `knowledge_documents` = file fisik + state machine (status, mime, size, checksum, scope, audience, vector_namespace).
+   - `knowledge_chunks` = ringkasan jumlah chunk per dokumen + flag aktif (vector data tetap di Chroma; tabel ini hanya catatan).
+2. **Models**
+   - `KnowledgeSource`, `KnowledgeDocument`, `KnowledgeChunk`.
+   - State helper `KnowledgeDocument::STATUS_*`, `SCOPE_*`, `AUDIENCE_*`.
+3. **Service & Job**
+   - `App\Services\Knowledge\KnowledgeLifecycleService` (upload, archive, reprocess, delete).
+   - `App\Jobs\ProcessKnowledgeDocument` (memanggil Python `/api/knowledge/process`).
+4. **Python AI**
+   - Tambahkan router `python-ai/app/routers/knowledge.py` dengan `POST /api/knowledge/process` dan `DELETE /api/knowledge/{filename}`.
+   - Re-use `process_document` & `delete_document_vectors` lewat wrapper `process_knowledge_document` di `rag_ingest.py` yang menyuntik metadata `scope=global_internal`, `audience=all_users`, `status=active`, dan `knowledge_id`.
+   - Endpoint baru terdaftar di `app/main.py`.
+5. **Admin UI**
+   - Livewire component `App\Livewire\Admin\AdminKnowledge` (default Halaman `/admin/knowledge`).
+   - Livewire component `App\Livewire\Admin\AdminKnowledgeUpload` (form upload modal/standalone) — atau cukup form HTML yang submit ke controller untuk MVP.
+   - Tambah link "Knowledge" di sidebar admin.
+   - Tampilkan list dokumen knowledge (nama, status, source, ukuran, tanggal upload, tombol activate/archive/reprocess/delete). Tidak menampilkan isi dokumen.
+6. **Routes**
+   - `GET /admin/knowledge` (list)
+   - `POST /admin/knowledge` (upload)
+   - `POST /admin/knowledge/{document}/activate`
+   - `POST /admin/knowledge/{document}/archive`
+   - `POST /admin/knowledge/{document}/reprocess`
+   - `DELETE /admin/knowledge/{document}` (hard delete + vector cleanup)
+7. **Event tracking**
+   - Tambahkan konstanta feature `AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN`.
+   - Catat `started/completed/failed` saat upload, processing, archive, reprocess, dan delete via `AIUsageEventService`.
+8. **Storage**
+   - File knowledge disimpan di disk `local` di folder `knowledge/<source_id>/<filename>` agar terpisah dari `documents/<user_id>/...`.
+9. **Permissions**
+   - Hanya admin (atau super admin) yang bisa akses semua route. Gunakan middleware `admin` (sudah ada).
+
+## Test
+### Laravel
+- `tests/Feature/Admin/AdminKnowledgeManagementTest.php`
+  - admin bisa lihat halaman `/admin/knowledge`
+  - regular user mendapat 403
+  - guest redirect ke login
+  - upload PDF berhasil, status awal `draft` lalu di-dispatch job
+  - validasi tipe file: tolak `.txt`/`.exe` dengan validation error
+  - validasi ukuran maksimum 50MB
+  - state transitions: archive, activate, reprocess (dispatch job ulang)
+  - delete memanggil cleanup vectors (mock Http)
+  - event tracking dipanggil (assert AIUsageEvent dibuat dengan feature `knowledge_admin`)
+- `tests/Feature/Jobs/ProcessKnowledgeDocumentTest.php`
+  - sukses → status `active`
+  - http error → status `error`
+  - missing file → status `error`
+  - kirim metadata scope/audience ke Python
+
+### Python
+- `python-ai/tests/test_knowledge_router.py`
+  - process endpoint memanggil `process_knowledge_document` dengan metadata global_internal
+  - delete endpoint scoped knowledge_id
+- `python-ai/tests/test_rag_ingest_knowledge.py` (jika perlu)
+  - `process_knowledge_document` menyetel metadata `scope=global_internal`, `audience=all_users`
+
+## Risiko & mitigasi
+- **Mixing vector**: gunakan `scope=global_internal` di metadata dan `user_id="__knowledge__"` agar tidak match dengan retrieval dokumen pribadi user. Karena issue Child 6 yang akan handle retrieval, untuk Child 5 cukup memastikan metadata tertulis dengan benar dan vector tidak tercampur dengan filter user.
+- **Hard delete tidak bersih**: KnowledgeLifecycleService::delete memanggil Python delete dengan `cleanup_legacy=true` dulu sebelum DB delete.
+- **File besar / OCR**: pakai validasi 50MB (sama dengan dokumen user).
+
+## Rencana eksekusi
+1. Buat issue plan markdown (file ini).
+2. Buat migration knowledge.
+3. Buat models + factory.
+4. Buat service & job.
+5. Buat controller + livewire + route + view.
+6. Tambah link sidebar.
+7. Tambah konstanta event + integrasi event tracking.
+8. Tambah Python router knowledge + wrapper rag_ingest.
+9. Tambah test Laravel + Python.
+10. Jalankan verifikasi (`php artisan test --filter='Knowledge|Admin'` & pytest).
+11. Commit, push, buat PR.
+
+## Done when
+- File issue plan tersedia.
+- Schema knowledge ter-migrate, models tersedia.
+- Admin bisa upload, archive, activate, reprocess, delete via UI (test Livewire/HTTP).
+- Vector hasil ingest punya metadata global_internal (test Python).
+- Event tracking knowledge_admin tercatat (test).
+- Test Laravel + Python yang ditargetkan lulus.
+- PR dibuat ke `codex/issue-210-admin-monitoring-dashboard` (chain) atau `main` (jika instruksi reviewer terbaru).

--- a/laravel/app/Jobs/ProcessKnowledgeDocument.php
+++ b/laravel/app/Jobs/ProcessKnowledgeDocument.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\AIUsageEvent;
+use App\Models\KnowledgeDocument;
+use App\Services\Admin\AIUsageEventService;
+use App\Services\Knowledge\KnowledgeLifecycleService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+class ProcessKnowledgeDocument implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $tries = 3;
+
+    public $backoff = [30, 60, 120];
+
+    public $timeout = 900;
+
+    public bool $deleteWhenMissingModels = true;
+
+    public function __construct(public KnowledgeDocument $document)
+    {
+    }
+
+    public function handle(KnowledgeLifecycleService $lifecycle, AIUsageEventService $events): void
+    {
+        $fresh = $this->document->fresh();
+
+        if ($fresh === null) {
+            logger()->info('ProcessKnowledgeDocument skipped: document deleted before processing', [
+                'document_id' => $this->document->id,
+            ]);
+
+            return;
+        }
+
+        $this->document = $fresh;
+        $startedAt = microtime(true);
+        $requestId = $events->newRequestId();
+
+        $events->started(
+            feature: AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+            userId: $fresh->uploaded_by_id,
+            metadata: [
+                'document_id' => (int) $fresh->id,
+                'origin' => 'admin',
+                'outcome' => 'processing_started',
+                'job_class' => static::class,
+                'job_attempts' => $this->attempts(),
+            ],
+            requestId: $requestId,
+            subject: $fresh,
+        );
+
+        if (! $fresh->file_path) {
+            $lifecycle->recordProcessingFailure($fresh, 'missing_file_path', 'file_path is empty');
+            $this->logFailure($events, $fresh, $requestId, $startedAt, 'missing_file_path');
+
+            return;
+        }
+
+        $absolutePath = Storage::disk('local')->path($fresh->file_path);
+
+        if (! is_string($absolutePath) || ! is_file($absolutePath)) {
+            $lifecycle->recordProcessingFailure($fresh, 'file_not_found', 'File knowledge tidak ditemukan di storage.');
+            $this->logFailure($events, $fresh, $requestId, $startedAt, 'file_not_found');
+
+            return;
+        }
+
+        $base = rtrim((string) config('services.ai_document_service.url', config('services.ai_service.url', 'http://127.0.0.1:8001')), '/');
+        $url = $base.'/api/knowledge/process';
+        $token = config('services.ai_document_service.token', config('services.ai_service.token'));
+
+        $handle = @fopen($absolutePath, 'rb');
+
+        if ($handle === false) {
+            $lifecycle->recordProcessingFailure($fresh, 'file_unreadable', 'File knowledge tidak dapat dibaca.');
+            $this->logFailure($events, $fresh, $requestId, $startedAt, 'file_unreadable');
+
+            return;
+        }
+
+        try {
+            $response = Http::timeout(900)
+                ->withHeaders(['Authorization' => 'Bearer '.$token])
+                ->attach('file', $handle, $fresh->original_name)
+                ->post($url, [
+                    'document_id' => (string) $fresh->id,
+                    'knowledge_source_id' => (string) ($fresh->knowledge_source_id ?? ''),
+                    'scope' => $fresh->scope ?: KnowledgeDocument::SCOPE_GLOBAL_INTERNAL,
+                    'audience' => $fresh->audience ?: KnowledgeDocument::AUDIENCE_ALL_USERS,
+                    'title' => (string) $fresh->title,
+                ]);
+        } catch (\Throwable $e) {
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
+
+            $lifecycle->recordProcessingFailure($fresh, 'http_exception', $e->getMessage());
+            $this->logFailure($events, $fresh, $requestId, $startedAt, 'http_exception');
+
+            throw $e;
+        }
+
+        if (is_resource($handle)) {
+            fclose($handle);
+        }
+
+        if (! $response->successful()) {
+            $lifecycle->recordProcessingFailure($fresh, 'microservice_error', (string) $response->body());
+            $this->logFailure($events, $fresh, $requestId, $startedAt, 'microservice_error');
+
+            throw new \RuntimeException('Knowledge ingest microservice error: '.$response->body());
+        }
+
+        $payload = $response->json() ?? [];
+        $provider = is_string($payload['embedding_provider'] ?? null) ? $payload['embedding_provider'] : null;
+        $chunkCount = isset($payload['chunk_count']) ? (int) $payload['chunk_count'] : null;
+        $successful = isset($payload['successful_chunks']) ? (int) $payload['successful_chunks'] : $chunkCount;
+        $failed = isset($payload['failed_chunks']) ? (int) $payload['failed_chunks'] : 0;
+
+        $lifecycle->recordProcessingSuccess($fresh, $provider, $chunkCount, $successful, $failed);
+
+        $events->completed(
+            feature: AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+            userId: $fresh->uploaded_by_id,
+            metadata: [
+                'document_id' => (int) $fresh->id,
+                'origin' => 'admin',
+                'outcome' => 'processing_succeeded',
+                'provider' => $provider,
+                'job_class' => static::class,
+                'job_attempts' => $this->attempts(),
+            ],
+            requestId: $requestId,
+            latencyMs: $events->latencyMsSince($startedAt),
+            subject: $fresh,
+        );
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        $events = app(AIUsageEventService::class);
+        $lifecycle = app(KnowledgeLifecycleService::class);
+
+        $document = $this->document->fresh() ?? $this->document;
+
+        $lifecycle->recordProcessingFailure($document, 'job_failed', $exception->getMessage());
+
+        $events->failed(
+            feature: AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+            userId: $document->uploaded_by_id,
+            metadata: [
+                'document_id' => (int) $document->id,
+                'origin' => 'admin',
+                'outcome' => 'processing_failed',
+                'job_class' => static::class,
+                'job_attempts' => $this->attempts(),
+            ],
+            errorCode: 'job_failed',
+            subject: $document,
+        );
+    }
+
+    private function logFailure(AIUsageEventService $events, KnowledgeDocument $document, string $requestId, float $startedAt, string $errorCode): void
+    {
+        $events->failed(
+            feature: AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+            userId: $document->uploaded_by_id,
+            metadata: [
+                'document_id' => (int) $document->id,
+                'origin' => 'admin',
+                'outcome' => 'processing_failed',
+                'reason' => $errorCode,
+                'job_class' => static::class,
+                'job_attempts' => $this->attempts(),
+            ],
+            requestId: $requestId,
+            latencyMs: $events->latencyMsSince($startedAt),
+            errorCode: $errorCode,
+            subject: $document,
+        );
+    }
+}

--- a/laravel/app/Livewire/Admin/AdminKnowledge.php
+++ b/laravel/app/Livewire/Admin/AdminKnowledge.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace App\Livewire\Admin;
+
+use App\Models\KnowledgeDocument;
+use App\Models\KnowledgeSource;
+use App\Services\Knowledge\KnowledgeLifecycleService;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+
+#[Layout('layouts.admin', ['title' => 'Knowledge', 'heading' => 'Knowledge Base Internal'])]
+class AdminKnowledge extends Component
+{
+    use WithFileUploads;
+
+    public string $search = '';
+
+    public string $status = '';
+
+    public ?int $sourceFilter = null;
+
+    public string $title = '';
+
+    public string $newSourceName = '';
+
+    public ?int $sourceId = null;
+
+    public string $notes = '';
+
+    /**
+     * @var \Livewire\Features\SupportFileUploads\TemporaryUploadedFile|null
+     */
+    public $file = null;
+
+    /**
+     * @var array<string, array<int, string>>
+     */
+    protected $queryString = [
+        'search' => ['except' => ''],
+        'status' => ['except' => ''],
+        'sourceFilter' => ['except' => null],
+    ];
+
+    public function resetFilters(): void
+    {
+        $this->reset(['search', 'status', 'sourceFilter']);
+    }
+
+    public function upload(KnowledgeLifecycleService $lifecycle): void
+    {
+        $this->validate([
+            'file' => [
+                'required',
+                'file',
+                'max:'.KnowledgeLifecycleService::MAX_DOCUMENT_SIZE_KILOBYTES,
+                'mimetypes:'.implode(',', KnowledgeLifecycleService::ALLOWED_MIME_TYPES),
+            ],
+            'title' => ['nullable', 'string', 'max:191'],
+            'newSourceName' => ['nullable', 'string', 'max:191'],
+            'sourceId' => ['nullable', 'integer', 'exists:knowledge_sources,id'],
+            'notes' => ['nullable', 'string', 'max:2000'],
+        ]);
+
+        $admin = auth()->user();
+
+        if ($admin === null) {
+            $this->addError('file', 'Sesi admin tidak valid. Silakan login ulang.');
+
+            return;
+        }
+
+        $sourceArg = $this->resolveSourceArgument();
+
+        try {
+            $lifecycle->upload($this->file, $admin, [
+                'title' => $this->title ?: null,
+                'knowledge_source_id' => $sourceArg,
+                'notes' => $this->notes ?: null,
+            ]);
+        } catch (ValidationException $e) {
+            foreach ($e->errors() as $field => $messages) {
+                foreach ((array) $messages as $message) {
+                    $this->addError($field, $message);
+                }
+            }
+
+            return;
+        }
+
+        $this->reset(['file', 'title', 'newSourceName', 'sourceId', 'notes']);
+        $this->dispatch('knowledge-uploaded');
+        session()->flash('knowledge_status', 'Dokumen knowledge berhasil di-upload dan sedang diproses.');
+    }
+
+    public function activate(int $documentId, KnowledgeLifecycleService $lifecycle): void
+    {
+        $document = KnowledgeDocument::findOrFail($documentId);
+        $admin = auth()->user();
+
+        if ($admin === null) {
+            return;
+        }
+
+        $lifecycle->activate($document, $admin);
+        session()->flash('knowledge_status', 'Dokumen knowledge diaktifkan.');
+    }
+
+    public function archive(int $documentId, KnowledgeLifecycleService $lifecycle): void
+    {
+        $document = KnowledgeDocument::findOrFail($documentId);
+        $admin = auth()->user();
+
+        if ($admin === null) {
+            return;
+        }
+
+        $lifecycle->archive($document, $admin);
+        session()->flash('knowledge_status', 'Dokumen knowledge di-archive.');
+    }
+
+    public function reprocess(int $documentId, KnowledgeLifecycleService $lifecycle): void
+    {
+        $document = KnowledgeDocument::findOrFail($documentId);
+        $admin = auth()->user();
+
+        if ($admin === null) {
+            return;
+        }
+
+        $lifecycle->reprocess($document, $admin);
+        session()->flash('knowledge_status', 'Dokumen knowledge dijadwalkan untuk diproses ulang.');
+    }
+
+    public function delete(int $documentId, KnowledgeLifecycleService $lifecycle): void
+    {
+        $document = KnowledgeDocument::findOrFail($documentId);
+        $admin = auth()->user();
+
+        if ($admin === null) {
+            return;
+        }
+
+        $lifecycle->delete($document, $admin);
+        session()->flash('knowledge_status', 'Dokumen knowledge berhasil dihapus beserta vektornya.');
+    }
+
+    public function render()
+    {
+        $documentsQuery = KnowledgeDocument::query()
+            ->select([
+                'id',
+                'knowledge_source_id',
+                'uploaded_by_id',
+                'title',
+                'original_name',
+                'mime_type',
+                'file_size_bytes',
+                'scope',
+                'audience',
+                'status',
+                'processed_at',
+                'archived_at',
+                'failed_at',
+                'error_code',
+                'error_message',
+                'created_at',
+                'updated_at',
+            ])
+            ->with(['source:id,name,slug', 'uploader:id,name,email']);
+
+        if ($this->status !== '') {
+            $documentsQuery->where('status', $this->status);
+        }
+
+        if ($this->sourceFilter !== null) {
+            $documentsQuery->where('knowledge_source_id', $this->sourceFilter);
+        }
+
+        if ($this->search !== '') {
+            $term = '%'.trim($this->search).'%';
+            $documentsQuery->where(function ($builder) use ($term) {
+                $builder->where('title', 'like', $term)
+                    ->orWhere('original_name', 'like', $term);
+            });
+        }
+
+        $documents = $documentsQuery->orderByDesc('created_at')->limit(100)->get();
+
+        $statusCounts = KnowledgeDocument::query()
+            ->selectRaw('status, COUNT(*) as total')
+            ->groupBy('status')
+            ->pluck('total', 'status')
+            ->mapWithKeys(fn ($total, $status) => [(string) ($status ?: 'unknown') => (int) $total])
+            ->all();
+
+        $sources = KnowledgeSource::query()->orderBy('name')->get();
+
+        return view('livewire.admin.admin-knowledge', [
+            'documents' => $documents,
+            'statusCounts' => $statusCounts,
+            'sources' => $sources,
+            'statusOptions' => [
+                KnowledgeDocument::STATUS_DRAFT => 'Draft',
+                KnowledgeDocument::STATUS_PROCESSING => 'Processing',
+                KnowledgeDocument::STATUS_ACTIVE => 'Active',
+                KnowledgeDocument::STATUS_ERROR => 'Error',
+                KnowledgeDocument::STATUS_ARCHIVED => 'Archived',
+            ],
+            'allowedExtensions' => ['pdf', 'docx', 'xlsx', 'csv'],
+        ]);
+    }
+
+    private function resolveSourceArgument(): mixed
+    {
+        $newName = trim($this->newSourceName);
+
+        if ($newName !== '') {
+            return $newName;
+        }
+
+        if ($this->sourceId !== null) {
+            return $this->sourceId;
+        }
+
+        return null;
+    }
+}

--- a/laravel/app/Livewire/Admin/AdminUsage.php
+++ b/laravel/app/Livewire/Admin/AdminUsage.php
@@ -79,6 +79,7 @@ class AdminUsage extends Component
             AIUsageEvent::FEATURE_MEMO_REVISION => 'Memo: Revisi',
             AIUsageEvent::FEATURE_GOOGLE_DRIVE_IMPORT => 'Drive Import',
             AIUsageEvent::FEATURE_GOOGLE_DRIVE_EXPORT => 'Drive Export',
+            AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN => 'Knowledge (Admin)',
         ];
     }
 

--- a/laravel/app/Models/AIUsageEvent.php
+++ b/laravel/app/Models/AIUsageEvent.php
@@ -46,6 +46,8 @@ class AIUsageEvent extends Model
 
     public const FEATURE_GOOGLE_DRIVE_EXPORT = 'google_drive_export';
 
+    public const FEATURE_KNOWLEDGE_ADMIN = 'knowledge_admin';
+
     public const ACTION_STARTED = 'started';
 
     public const ACTION_COMPLETED = 'completed';

--- a/laravel/app/Models/KnowledgeChunk.php
+++ b/laravel/app/Models/KnowledgeChunk.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $knowledge_document_id
+ * @property int $chunk_count
+ * @property int $successful_chunks
+ * @property int $failed_chunks
+ * @property string|null $embedding_provider
+ * @property array<string, mixed>|null $summary
+ * @property \Illuminate\Support\Carbon|null $last_synced_at
+ */
+class KnowledgeChunk extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'knowledge_document_id',
+        'chunk_count',
+        'successful_chunks',
+        'failed_chunks',
+        'embedding_provider',
+        'summary',
+        'last_synced_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'chunk_count' => 'integer',
+            'successful_chunks' => 'integer',
+            'failed_chunks' => 'integer',
+            'summary' => 'array',
+            'last_synced_at' => 'datetime',
+        ];
+    }
+
+    public function document(): BelongsTo
+    {
+        return $this->belongsTo(KnowledgeDocument::class, 'knowledge_document_id');
+    }
+}

--- a/laravel/app/Models/KnowledgeDocument.php
+++ b/laravel/app/Models/KnowledgeDocument.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+/**
+ * @property int $id
+ * @property int|null $knowledge_source_id
+ * @property int|null $uploaded_by_id
+ * @property string $title
+ * @property string $original_name
+ * @property string $filename
+ * @property string $file_path
+ * @property string|null $mime_type
+ * @property int|null $file_size_bytes
+ * @property string|null $checksum_sha256
+ * @property string $scope
+ * @property string $audience
+ * @property string $status
+ * @property string $vector_namespace
+ * @property array<string, mixed>|null $metadata
+ * @property string|null $notes
+ * @property \Illuminate\Support\Carbon|null $processed_at
+ * @property \Illuminate\Support\Carbon|null $archived_at
+ * @property \Illuminate\Support\Carbon|null $failed_at
+ * @property string|null $error_code
+ * @property string|null $error_message
+ */
+class KnowledgeDocument extends Model
+{
+    use HasFactory;
+
+    public const STATUS_DRAFT = 'draft';
+
+    public const STATUS_PROCESSING = 'processing';
+
+    public const STATUS_ACTIVE = 'active';
+
+    public const STATUS_ERROR = 'error';
+
+    public const STATUS_ARCHIVED = 'archived';
+
+    public const STATUSES = [
+        self::STATUS_DRAFT,
+        self::STATUS_PROCESSING,
+        self::STATUS_ACTIVE,
+        self::STATUS_ERROR,
+        self::STATUS_ARCHIVED,
+    ];
+
+    public const SCOPE_GLOBAL_INTERNAL = 'global_internal';
+
+    public const AUDIENCE_ALL_USERS = 'all_users';
+
+    public const VECTOR_NAMESPACE = 'knowledge';
+
+    /**
+     * Synthetic user_id stored in Chroma metadata so knowledge vectors do not
+     * collide with personal documents (which use real user ids).
+     */
+    public const KNOWLEDGE_USER_ID = '__knowledge__';
+
+    protected $fillable = [
+        'knowledge_source_id',
+        'uploaded_by_id',
+        'title',
+        'original_name',
+        'filename',
+        'file_path',
+        'mime_type',
+        'file_size_bytes',
+        'checksum_sha256',
+        'scope',
+        'audience',
+        'status',
+        'vector_namespace',
+        'metadata',
+        'notes',
+        'processed_at',
+        'archived_at',
+        'failed_at',
+        'error_code',
+        'error_message',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'metadata' => 'array',
+            'file_size_bytes' => 'integer',
+            'processed_at' => 'datetime',
+            'archived_at' => 'datetime',
+            'failed_at' => 'datetime',
+        ];
+    }
+
+    public function source(): BelongsTo
+    {
+        return $this->belongsTo(KnowledgeSource::class, 'knowledge_source_id');
+    }
+
+    public function uploader(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'uploaded_by_id');
+    }
+
+    public function chunks(): HasOne
+    {
+        return $this->hasOne(KnowledgeChunk::class);
+    }
+
+    public function isActivatable(): bool
+    {
+        return in_array($this->status, [self::STATUS_DRAFT, self::STATUS_ARCHIVED, self::STATUS_ERROR], true);
+    }
+
+    public function isArchivable(): bool
+    {
+        return in_array($this->status, [self::STATUS_ACTIVE, self::STATUS_DRAFT, self::STATUS_ERROR], true);
+    }
+
+    public function isReprocessable(): bool
+    {
+        return in_array($this->status, [self::STATUS_DRAFT, self::STATUS_ACTIVE, self::STATUS_ARCHIVED, self::STATUS_ERROR], true);
+    }
+
+    protected function formattedSize(): Attribute
+    {
+        return Attribute::make(
+            get: function () {
+                $bytes = $this->file_size_bytes;
+
+                if ($bytes === null || $bytes < 1) {
+                    return 'Ukuran tidak tersedia';
+                }
+
+                if ($bytes >= 1073741824) {
+                    return number_format($bytes / 1073741824, 2).' GB';
+                }
+
+                if ($bytes >= 1048576) {
+                    return number_format($bytes / 1048576, 1).' MB';
+                }
+
+                return number_format(max($bytes / 1024, 0.1), 1).' KB';
+            }
+        );
+    }
+
+    protected function extension(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => strtolower((string) pathinfo((string) $this->original_name, PATHINFO_EXTENSION))
+        );
+    }
+}

--- a/laravel/app/Models/KnowledgeSource.php
+++ b/laravel/app/Models/KnowledgeSource.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
+
+/**
+ * @property int $id
+ * @property int|null $created_by_id
+ * @property string $name
+ * @property string $slug
+ * @property string|null $description
+ * @property bool $is_active
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+class KnowledgeSource extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'created_by_id',
+        'name',
+        'slug',
+        'description',
+        'is_active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (self $source) {
+            if (empty($source->slug)) {
+                $source->slug = self::generateUniqueSlug($source->name);
+            }
+        });
+    }
+
+    public static function generateUniqueSlug(string $name): string
+    {
+        $base = Str::slug($name) ?: 'knowledge-source';
+        $candidate = $base;
+        $suffix = 2;
+
+        while (self::query()->where('slug', $candidate)->exists()) {
+            $candidate = $base.'-'.$suffix;
+            $suffix++;
+        }
+
+        return $candidate;
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_id');
+    }
+
+    public function documents(): HasMany
+    {
+        return $this->hasMany(KnowledgeDocument::class);
+    }
+}

--- a/laravel/app/Services/Knowledge/KnowledgeLifecycleService.php
+++ b/laravel/app/Services/Knowledge/KnowledgeLifecycleService.php
@@ -1,0 +1,410 @@
+<?php
+
+namespace App\Services\Knowledge;
+
+use App\Jobs\ProcessKnowledgeDocument;
+use App\Models\AIUsageEvent;
+use App\Models\KnowledgeChunk;
+use App\Models\KnowledgeDocument;
+use App\Models\KnowledgeSource;
+use App\Models\User;
+use App\Services\Admin\AIUsageEventService;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\ValidationException;
+
+class KnowledgeLifecycleService
+{
+    public const MAX_DOCUMENT_SIZE_KILOBYTES = 51_200;
+
+    public const MAX_DOCUMENT_SIZE_BYTES = self::MAX_DOCUMENT_SIZE_KILOBYTES * 1024;
+
+    public const STORAGE_DIRECTORY = 'knowledge';
+
+    /**
+     * Allowed mime types mirror the per-user document pipeline so the
+     * Python ingest pipeline can be re-used without changes.
+     */
+    public const ALLOWED_MIME_TYPES = [
+        'application/pdf',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'text/csv',
+        'text/plain',
+        'application/csv',
+        'application/vnd.ms-excel',
+    ];
+
+    /**
+     * Upload a knowledge document and dispatch processing.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function upload(UploadedFile $file, User $admin, array $attributes = []): KnowledgeDocument
+    {
+        $usageEvents = app(AIUsageEventService::class);
+        $startedAt = microtime(true);
+        $requestId = $usageEvents->newRequestId();
+
+        $originalName = (string) $file->getClientOriginalName();
+        $mimeType = (string) ($file->getMimeType() ?? 'application/octet-stream');
+        $extension = strtolower((string) $file->getClientOriginalExtension());
+        $size = $file->getSize();
+
+        if (! in_array($mimeType, self::ALLOWED_MIME_TYPES, true)) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+                userId: (int) $admin->id,
+                metadata: [
+                    'document_extension' => $extension,
+                    'mime_type' => $mimeType,
+                    'reason' => 'invalid_mime_type',
+                    'origin' => 'admin',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'invalid_mime_type',
+            );
+
+            throw ValidationException::withMessages([
+                'file' => 'Tipe file tidak didukung. Gunakan PDF, DOCX, XLSX, atau CSV.',
+            ]);
+        }
+
+        if ($size !== null && $size > self::MAX_DOCUMENT_SIZE_BYTES) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+                userId: (int) $admin->id,
+                metadata: [
+                    'document_extension' => $extension,
+                    'mime_type' => $mimeType,
+                    'file_size_bytes' => $size,
+                    'reason' => 'file_too_large',
+                    'origin' => 'admin',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'file_too_large',
+            );
+
+            throw ValidationException::withMessages([
+                'file' => 'Ukuran file melebihi batas 50 MB.',
+            ]);
+        }
+
+        try {
+            $document = DB::transaction(function () use ($file, $admin, $attributes, $originalName, $mimeType, $size) {
+                $title = $this->resolveTitle($attributes['title'] ?? null, $originalName);
+                $sourceId = $this->resolveSourceId($attributes['knowledge_source_id'] ?? null, $admin);
+
+                $duplicate = KnowledgeDocument::query()
+                    ->where('original_name', $originalName)
+                    ->whereIn('status', [
+                        KnowledgeDocument::STATUS_DRAFT,
+                        KnowledgeDocument::STATUS_PROCESSING,
+                        KnowledgeDocument::STATUS_ACTIVE,
+                    ])
+                    ->lockForUpdate()
+                    ->exists();
+
+                if ($duplicate) {
+                    throw ValidationException::withMessages([
+                        'file' => 'Dokumen knowledge dengan nama yang sama sudah ada dan masih aktif.',
+                    ]);
+                }
+
+                $directory = self::STORAGE_DIRECTORY.'/'.($sourceId ?? 'unsorted');
+                $filename = time().'_'.$file->hashName();
+                $filePath = $file->storeAs($directory, $filename);
+
+                if (! $filePath) {
+                    throw new \RuntimeException('Gagal menyimpan file knowledge ke storage.');
+                }
+
+                try {
+                    $checksum = null;
+                    $absolute = Storage::disk('local')->path($filePath);
+                    if (is_string($absolute) && is_file($absolute)) {
+                        $checksum = @hash_file('sha256', $absolute) ?: null;
+                    }
+
+                    return KnowledgeDocument::create([
+                        'knowledge_source_id' => $sourceId,
+                        'uploaded_by_id' => $admin->id,
+                        'title' => $title,
+                        'original_name' => $originalName,
+                        'filename' => $filename,
+                        'file_path' => $filePath,
+                        'mime_type' => $mimeType,
+                        'file_size_bytes' => $size,
+                        'checksum_sha256' => $checksum,
+                        'scope' => KnowledgeDocument::SCOPE_GLOBAL_INTERNAL,
+                        'audience' => KnowledgeDocument::AUDIENCE_ALL_USERS,
+                        'status' => KnowledgeDocument::STATUS_DRAFT,
+                        'vector_namespace' => KnowledgeDocument::VECTOR_NAMESPACE,
+                        'metadata' => [
+                            'origin' => 'admin_upload',
+                        ],
+                        'notes' => isset($attributes['notes']) ? (string) $attributes['notes'] : null,
+                    ]);
+                } catch (\Throwable $e) {
+                    Storage::delete($filePath);
+
+                    throw $e;
+                }
+            });
+        } catch (ValidationException $e) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+                userId: (int) $admin->id,
+                metadata: [
+                    'document_extension' => $extension,
+                    'mime_type' => $mimeType,
+                    'file_size_bytes' => $size,
+                    'reason' => 'validation_failed',
+                    'origin' => 'admin',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'validation_failed',
+            );
+
+            throw $e;
+        } catch (\Throwable $e) {
+            $usageEvents->failed(
+                feature: AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+                userId: (int) $admin->id,
+                metadata: [
+                    'document_extension' => $extension,
+                    'mime_type' => $mimeType,
+                    'file_size_bytes' => $size,
+                    'reason' => 'storage_failed',
+                    'origin' => 'admin',
+                ],
+                requestId: $requestId,
+                latencyMs: $usageEvents->latencyMsSince($startedAt),
+                errorCode: 'storage_failed',
+            );
+
+            throw $e;
+        }
+
+        $this->dispatchProcessing($document);
+
+        $usageEvents->completed(
+            feature: AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+            userId: (int) $admin->id,
+            metadata: [
+                'document_id' => (int) $document->id,
+                'document_extension' => $extension,
+                'mime_type' => $mimeType,
+                'file_size_bytes' => $size,
+                'origin' => 'admin',
+                'outcome' => 'uploaded',
+            ],
+            requestId: $requestId,
+            latencyMs: $usageEvents->latencyMsSince($startedAt),
+            subject: $document,
+        );
+
+        return $document;
+    }
+
+    public function dispatchProcessing(KnowledgeDocument $document): void
+    {
+        $document->update([
+            'status' => KnowledgeDocument::STATUS_PROCESSING,
+            'failed_at' => null,
+            'error_code' => null,
+            'error_message' => null,
+        ]);
+
+        ProcessKnowledgeDocument::dispatch($document);
+    }
+
+    public function activate(KnowledgeDocument $document, User $admin): KnowledgeDocument
+    {
+        $document->update([
+            'status' => KnowledgeDocument::STATUS_ACTIVE,
+            'archived_at' => null,
+        ]);
+
+        app(AIUsageEventService::class)->completed(
+            feature: AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+            userId: (int) $admin->id,
+            metadata: [
+                'document_id' => (int) $document->id,
+                'origin' => 'admin',
+                'outcome' => 'activated',
+            ],
+            subject: $document,
+        );
+
+        return $document->refresh();
+    }
+
+    public function archive(KnowledgeDocument $document, User $admin): KnowledgeDocument
+    {
+        $document->update([
+            'status' => KnowledgeDocument::STATUS_ARCHIVED,
+            'archived_at' => now(),
+        ]);
+
+        app(AIUsageEventService::class)->completed(
+            feature: AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+            userId: (int) $admin->id,
+            metadata: [
+                'document_id' => (int) $document->id,
+                'origin' => 'admin',
+                'outcome' => 'archived',
+            ],
+            subject: $document,
+        );
+
+        return $document->refresh();
+    }
+
+    public function reprocess(KnowledgeDocument $document, User $admin): KnowledgeDocument
+    {
+        $this->dispatchProcessing($document);
+
+        app(AIUsageEventService::class)->completed(
+            feature: AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+            userId: (int) $admin->id,
+            metadata: [
+                'document_id' => (int) $document->id,
+                'origin' => 'admin',
+                'outcome' => 'reprocess_dispatched',
+            ],
+            subject: $document,
+        );
+
+        return $document->refresh();
+    }
+
+    public function delete(KnowledgeDocument $document, User $admin): bool
+    {
+        $documentId = (int) $document->id;
+
+        $this->cleanupVectors($document);
+        $this->deleteStoredFile($document);
+
+        $deleted = $document->delete();
+
+        app(AIUsageEventService::class)->completed(
+            feature: AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+            userId: (int) $admin->id,
+            metadata: [
+                'document_id' => $documentId,
+                'origin' => 'admin',
+                'outcome' => 'deleted',
+            ],
+        );
+
+        return (bool) $deleted;
+    }
+
+    public function recordProcessingSuccess(KnowledgeDocument $document, ?string $provider, ?int $chunkCount, ?int $successfulChunks, ?int $failedChunks): void
+    {
+        $document->update([
+            'status' => KnowledgeDocument::STATUS_ACTIVE,
+            'processed_at' => now(),
+            'failed_at' => null,
+            'error_code' => null,
+            'error_message' => null,
+        ]);
+
+        KnowledgeChunk::updateOrCreate(
+            ['knowledge_document_id' => $document->id],
+            [
+                'chunk_count' => max(0, (int) $chunkCount),
+                'successful_chunks' => max(0, (int) $successfulChunks),
+                'failed_chunks' => max(0, (int) $failedChunks),
+                'embedding_provider' => $provider,
+                'last_synced_at' => now(),
+            ]
+        );
+    }
+
+    public function recordProcessingFailure(KnowledgeDocument $document, string $errorCode, ?string $errorMessage = null): void
+    {
+        $document->update([
+            'status' => KnowledgeDocument::STATUS_ERROR,
+            'failed_at' => now(),
+            'error_code' => substr($errorCode, 0, 64),
+            'error_message' => $errorMessage !== null ? substr($errorMessage, 0, 1000) : null,
+        ]);
+    }
+
+    private function cleanupVectors(KnowledgeDocument $document): void
+    {
+        $base = rtrim((string) config('services.ai_document_service.url', config('services.ai_service.url', 'http://127.0.0.1:8001')), '/');
+        $token = config('services.ai_document_service.token', config('services.ai_service.token'));
+        $url = $base.'/api/knowledge/'.urlencode($document->original_name).'?'.http_build_query([
+            'document_id' => (string) $document->id,
+            'cleanup_legacy' => 'true',
+        ]);
+
+        try {
+            $response = Http::withHeaders(['Authorization' => 'Bearer '.$token])->delete($url);
+
+            if (! $response->successful() && $response->status() !== 404) {
+                logger()->warning('Knowledge vector deletion failed, proceeding anyway', [
+                    'document_id' => $document->id,
+                    'status' => $response->status(),
+                    'body' => $response->body(),
+                ]);
+            }
+        } catch (\Throwable $e) {
+            logger()->warning('Knowledge vector deletion HTTP error, proceeding anyway', [
+                'document_id' => $document->id,
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function deleteStoredFile(KnowledgeDocument $document): void
+    {
+        if ($document->file_path && Storage::disk('local')->exists($document->file_path)) {
+            Storage::disk('local')->delete($document->file_path);
+        }
+    }
+
+    private function resolveTitle(?string $rawTitle, string $originalName): string
+    {
+        $title = trim((string) $rawTitle);
+
+        if ($title === '') {
+            $title = pathinfo($originalName, PATHINFO_FILENAME) ?: $originalName;
+        }
+
+        return mb_substr($title, 0, 191);
+    }
+
+    private function resolveSourceId(mixed $sourceId, User $admin): ?int
+    {
+        if ($sourceId === null || $sourceId === '') {
+            return null;
+        }
+
+        if (is_numeric($sourceId)) {
+            $source = KnowledgeSource::query()->find((int) $sourceId);
+
+            return $source?->id;
+        }
+
+        if (is_string($sourceId)) {
+            $source = KnowledgeSource::query()
+                ->firstOrCreate(
+                    ['slug' => KnowledgeSource::generateUniqueSlug($sourceId)],
+                    ['name' => $sourceId, 'created_by_id' => $admin->id]
+                );
+
+            return $source->id;
+        }
+
+        return null;
+    }
+}

--- a/laravel/database/migrations/2026_05_18_120000_create_knowledge_tables.php
+++ b/laravel/database/migrations/2026_05_18_120000_create_knowledge_tables.php
@@ -1,0 +1,85 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('knowledge_sources', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('created_by_id')
+                ->nullable()
+                ->constrained('users')
+                ->nullOnDelete();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('knowledge_documents', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('knowledge_source_id')
+                ->nullable()
+                ->constrained('knowledge_sources')
+                ->nullOnDelete();
+            $table->foreignId('uploaded_by_id')
+                ->nullable()
+                ->constrained('users')
+                ->nullOnDelete();
+            $table->string('title');
+            $table->string('original_name');
+            $table->string('filename');
+            $table->string('file_path');
+            $table->string('mime_type', 191)->nullable();
+            $table->unsignedBigInteger('file_size_bytes')->nullable();
+            $table->string('checksum_sha256', 64)->nullable();
+            $table->string('scope', 32)->default('global_internal');
+            $table->string('audience', 32)->default('all_users');
+            $table->string('status', 32)->default('draft');
+            $table->string('vector_namespace', 64)->default('knowledge');
+            $table->json('metadata')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamp('processed_at')->nullable();
+            $table->timestamp('archived_at')->nullable();
+            $table->timestamp('failed_at')->nullable();
+            $table->string('error_code', 64)->nullable();
+            $table->text('error_message')->nullable();
+            $table->timestamps();
+
+            $table->index('status', 'knowledge_documents_status_index');
+            $table->index('scope', 'knowledge_documents_scope_index');
+            $table->index('audience', 'knowledge_documents_audience_index');
+            $table->index('knowledge_source_id', 'knowledge_documents_source_index');
+            $table->index('uploaded_by_id', 'knowledge_documents_uploader_index');
+            $table->index('created_at', 'knowledge_documents_created_at_index');
+        });
+
+        Schema::create('knowledge_chunks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('knowledge_document_id')
+                ->constrained('knowledge_documents')
+                ->cascadeOnDelete();
+            $table->unsignedInteger('chunk_count')->default(0);
+            $table->unsignedInteger('successful_chunks')->default(0);
+            $table->unsignedInteger('failed_chunks')->default(0);
+            $table->string('embedding_provider', 191)->nullable();
+            $table->json('summary')->nullable();
+            $table->timestamp('last_synced_at')->nullable();
+            $table->timestamps();
+
+            $table->unique('knowledge_document_id', 'knowledge_chunks_document_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('knowledge_chunks');
+        Schema::dropIfExists('knowledge_documents');
+        Schema::dropIfExists('knowledge_sources');
+    }
+};

--- a/laravel/resources/views/components/admin/sidebar.blade.php
+++ b/laravel/resources/views/components/admin/sidebar.blade.php
@@ -36,6 +36,13 @@
             'icon' => 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z',
             'visible' => true,
         ],
+        [
+            'label' => 'Knowledge',
+            'description' => 'Knowledge base internal',
+            'route' => 'admin.knowledge',
+            'icon' => 'M12 6.253v13M12 6.253A6 6 0 1118 4M12 6.253A6 6 0 006 4m12 0v13M6 4v13m0 0a6 6 0 016 2.747M6 17a6 6 0 0112 0',
+            'visible' => true,
+        ],
     ];
 
     if ($user && method_exists($user, 'isSuperAdmin') && $user->isSuperAdmin()) {

--- a/laravel/resources/views/livewire/admin/admin-knowledge.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-knowledge.blade.php
@@ -1,0 +1,230 @@
+<div>
+    <div class="mb-6">
+        <div class="flex flex-wrap items-end justify-between gap-3">
+            <div class="max-w-2xl">
+                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Knowledge</p>
+                <h2 class="admin-page-title mt-1">Knowledge Base Internal</h2>
+                <p class="mt-2 text-sm leading-relaxed text-stone-500 dark:text-gray-400">
+                    Kelola dokumen knowledge internal global. Dokumen di-upload admin akan diproses menjadi vector dengan metadata <code class="font-mono text-[11px]">scope=global_internal</code> dan <code class="font-mono text-[11px]">audience=all_users</code>. Halaman ini hanya menampilkan metadata file, bukan isinya.
+                </p>
+            </div>
+            <x-admin.badge tone="primary">Admin only</x-admin.badge>
+        </div>
+    </div>
+
+    @if (session('knowledge_status'))
+        <div class="mb-4 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800 dark:border-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200">
+            {{ session('knowledge_status') }}
+        </div>
+    @endif
+
+    @php
+        $totalDocs = array_sum($statusCounts);
+        $activeCount = $statusCounts['active'] ?? 0;
+        $processingCount = ($statusCounts['draft'] ?? 0) + ($statusCounts['processing'] ?? 0);
+        $errorCount = $statusCounts['error'] ?? 0;
+        $archivedCount = $statusCounts['archived'] ?? 0;
+    @endphp
+
+    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <x-admin.kpi-card label="Total Knowledge" :value="number_format($totalDocs)" tone="primary" />
+        <x-admin.kpi-card label="Active" :value="number_format($activeCount)" tone="success" />
+        <x-admin.kpi-card label="Draft / Processing" :value="number_format($processingCount)" tone="warning" />
+        <x-admin.kpi-card label="Error" :value="number_format($errorCount)" tone="danger" />
+    </div>
+
+    <div class="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <x-admin.kpi-card label="Archived" :value="number_format($archivedCount)" tone="default" description="Dokumen yang dinonaktifkan." />
+    </div>
+
+    <div class="mt-6 grid gap-4 lg:grid-cols-3">
+        <div class="lg:col-span-2">
+            <x-admin.section title="Filter">
+                <x-slot name="actions">
+                    <button type="button"
+                            wire:click="resetFilters"
+                            class="text-[11px] font-semibold uppercase tracking-wider text-stone-500 transition hover:text-ista-primary dark:text-gray-400 dark:hover:text-amber-300">
+                        Reset
+                    </button>
+                </x-slot>
+                <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    <label class="admin-filter">
+                        <span class="admin-filter__label">Cari judul / nama file</span>
+                        <input type="search"
+                               wire:model.live.debounce.300ms="search"
+                               placeholder="Contoh: SOP HR"
+                               class="admin-filter__control" />
+                    </label>
+
+                    <label class="admin-filter">
+                        <span class="admin-filter__label">Status</span>
+                        <select wire:model.live="status" class="admin-filter__control">
+                            <option value="">Semua</option>
+                            @foreach ($statusOptions as $key => $label)
+                                <option value="{{ $key }}">{{ $label }}</option>
+                            @endforeach
+                        </select>
+                    </label>
+
+                    <label class="admin-filter">
+                        <span class="admin-filter__label">Source</span>
+                        <select wire:model.live="sourceFilter" class="admin-filter__control">
+                            <option value="">Semua</option>
+                            @foreach ($sources as $source)
+                                <option value="{{ $source->id }}">{{ $source->name }}</option>
+                            @endforeach
+                        </select>
+                    </label>
+                </div>
+            </x-admin.section>
+        </div>
+
+        <x-admin.section title="Upload Dokumen Knowledge" description="Format yang diterima: {{ implode(', ', $allowedExtensions) }}.">
+            <form wire:submit.prevent="upload" class="space-y-3">
+                <label class="admin-filter">
+                    <span class="admin-filter__label">Judul (opsional)</span>
+                    <input type="text"
+                           wire:model.defer="title"
+                           placeholder="Contoh: SOP Penerimaan Tamu"
+                           class="admin-filter__control" />
+                    @error('title') <span class="text-xs text-rose-500">{{ $message }}</span> @enderror
+                </label>
+
+                <label class="admin-filter">
+                    <span class="admin-filter__label">Source (existing)</span>
+                    <select wire:model.defer="sourceId" class="admin-filter__control">
+                        <option value="">— Pilih source —</option>
+                        @foreach ($sources as $source)
+                            <option value="{{ $source->id }}">{{ $source->name }}</option>
+                        @endforeach
+                    </select>
+                    @error('sourceId') <span class="text-xs text-rose-500">{{ $message }}</span> @enderror
+                </label>
+
+                <label class="admin-filter">
+                    <span class="admin-filter__label">Atau buat source baru</span>
+                    <input type="text"
+                           wire:model.defer="newSourceName"
+                           placeholder="Contoh: Aturan ISTANA"
+                           class="admin-filter__control" />
+                    @error('newSourceName') <span class="text-xs text-rose-500">{{ $message }}</span> @enderror
+                </label>
+
+                <label class="admin-filter">
+                    <span class="admin-filter__label">Catatan internal (opsional)</span>
+                    <textarea wire:model.defer="notes"
+                              rows="2"
+                              placeholder="Konteks tambahan untuk admin lain"
+                              class="admin-filter__control"></textarea>
+                    @error('notes') <span class="text-xs text-rose-500">{{ $message }}</span> @enderror
+                </label>
+
+                <label class="admin-filter">
+                    <span class="admin-filter__label">File knowledge</span>
+                    <input type="file"
+                           wire:model="file"
+                           accept=".pdf,.docx,.xlsx,.csv"
+                           class="admin-filter__control" />
+                    @error('file') <span class="text-xs text-rose-500">{{ $message }}</span> @enderror
+                </label>
+
+                <div wire:loading wire:target="file" class="text-xs text-stone-500 dark:text-gray-400">Meng-upload file…</div>
+
+                <button type="submit"
+                        class="inline-flex h-10 w-full items-center justify-center rounded-lg bg-ista-primary px-4 text-xs font-semibold uppercase tracking-wider text-amber-200 transition hover:bg-ista-primary/90 disabled:opacity-50"
+                        wire:loading.attr="disabled"
+                        wire:target="upload,file">
+                    <span wire:loading.remove wire:target="upload">Upload Knowledge</span>
+                    <span wire:loading wire:target="upload">Memproses…</span>
+                </button>
+            </form>
+        </x-admin.section>
+    </div>
+
+    <div class="mt-6">
+        <x-admin.section
+            title="Daftar Knowledge Internal"
+            description="Maksimum 100 baris. Status menunjukkan apakah knowledge aktif atau di-archive.">
+            @if ($documents->isEmpty())
+                <x-admin.empty-state title="Belum ada knowledge" description="Belum ada dokumen knowledge yang cocok dengan filter saat ini." />
+            @else
+                <x-admin.table :columns="[
+                    ['key' => 'title', 'label' => 'Judul / File'],
+                    ['key' => 'source', 'label' => 'Source'],
+                    ['key' => 'mime', 'label' => 'Tipe'],
+                    ['key' => 'size', 'label' => 'Ukuran', 'align' => 'right'],
+                    ['key' => 'status', 'label' => 'Status'],
+                    ['key' => 'time', 'label' => 'Dibuat', 'align' => 'right'],
+                    ['key' => 'actions', 'label' => 'Aksi', 'align' => 'right'],
+                ]">
+                    @foreach ($documents as $doc)
+                        @php
+                            $tone = match ($doc->status) {
+                                'active' => 'success',
+                                'draft', 'processing' => 'warning',
+                                'error' => 'danger',
+                                'archived' => 'neutral',
+                                default => 'neutral',
+                            };
+                        @endphp
+                        <tr>
+                            <td class="admin-table__td">
+                                <div class="flex flex-col">
+                                    <span class="text-sm font-semibold text-stone-700 dark:text-gray-200">{{ \Illuminate\Support\Str::limit((string) $doc->title, 60, '…') }}</span>
+                                    <span class="text-[11px] text-stone-400 dark:text-gray-500">{{ \Illuminate\Support\Str::limit((string) $doc->original_name, 60, '…') }}</span>
+                                </div>
+                            </td>
+                            <td class="admin-table__td">
+                                <span class="text-xs text-stone-600 dark:text-gray-300">{{ $doc->source?->name ?? '—' }}</span>
+                            </td>
+                            <td class="admin-table__td">
+                                <span class="font-mono text-[10.5px] uppercase tracking-wider text-stone-500 dark:text-gray-400">{{ $doc->mime_type ?? 'unknown' }}</span>
+                            </td>
+                            <td class="admin-table__td" data-align="right">
+                                <span class="font-mono text-xs text-stone-500 dark:text-gray-400">{{ $doc->formatted_size }}</span>
+                            </td>
+                            <td class="admin-table__td">
+                                <x-admin.badge :tone="$tone">{{ ucfirst($doc->status) }}</x-admin.badge>
+                                @if ($doc->error_code)
+                                    <p class="mt-1 text-[10.5px] text-rose-500 dark:text-rose-300">{{ $doc->error_code }}</p>
+                                @endif
+                            </td>
+                            <td class="admin-table__td" data-align="right">
+                                <span class="text-xs text-stone-500 dark:text-gray-400" title="{{ $doc->created_at?->toDateTimeString() }}">{{ $doc->created_at?->diffForHumans() }}</span>
+                            </td>
+                            <td class="admin-table__td" data-align="right">
+                                <div class="flex flex-wrap items-center justify-end gap-2">
+                                    @if ($doc->status !== 'active')
+                                        <button type="button"
+                                                wire:click="activate({{ $doc->id }})"
+                                                class="text-[11px] font-semibold uppercase tracking-wider text-emerald-600 transition hover:text-emerald-500 dark:text-emerald-300">
+                                            Activate
+                                        </button>
+                                    @endif
+                                    @if ($doc->status !== 'archived')
+                                        <button type="button"
+                                                wire:click="archive({{ $doc->id }})"
+                                                class="text-[11px] font-semibold uppercase tracking-wider text-amber-600 transition hover:text-amber-500 dark:text-amber-300">
+                                            Archive
+                                        </button>
+                                    @endif
+                                    <button type="button"
+                                            wire:click="reprocess({{ $doc->id }})"
+                                            class="text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:text-ista-primary dark:text-gray-300 dark:hover:text-amber-300">
+                                        Reprocess
+                                    </button>
+                                    <button type="button"
+                                            wire:click="delete({{ $doc->id }})"
+                                            wire:confirm="Yakin hapus knowledge ini? Vector akan dihapus juga."
+                                            class="text-[11px] font-semibold uppercase tracking-wider text-rose-600 transition hover:text-rose-500 dark:text-rose-300">
+                                        Delete
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                    @endforeach
+                </x-admin.table>
+            @endif
+        </x-admin.section>
+    </div>
+</div>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\OnlyOfficeCallbackController;
 use App\Livewire\Admin\AdminDashboard;
 use App\Livewire\Admin\AdminDocuments;
 use App\Livewire\Admin\AdminErrors;
+use App\Livewire\Admin\AdminKnowledge;
 use App\Livewire\Admin\AdminUsage;
 use App\Livewire\Admin\AdminUsers;
 use App\Livewire\Chat\ChatIndex;
@@ -115,6 +116,7 @@ Route::middleware(['auth', 'verified', 'admin'])
         Route::get('/usage', AdminUsage::class)->name('usage');
         Route::get('/errors', AdminErrors::class)->name('errors');
         Route::get('/documents', AdminDocuments::class)->name('documents');
+        Route::get('/knowledge', AdminKnowledge::class)->name('knowledge');
     });
 
 Route::middleware(['auth', 'verified', 'super_admin'])

--- a/laravel/tests/Feature/Admin/AdminKnowledgeManagementTest.php
+++ b/laravel/tests/Feature/Admin/AdminKnowledgeManagementTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Jobs\ProcessKnowledgeDocument;
+use App\Models\AIUsageEvent;
+use App\Models\KnowledgeDocument;
+use App\Models\KnowledgeSource;
+use App\Models\User;
+use App\Services\Knowledge\KnowledgeLifecycleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AdminKnowledgeManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_knowledge_page_renders_for_admin(): void
+    {
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+
+        $response = $this->actingAs($admin)->get('/admin/knowledge');
+
+        $response->assertOk();
+        $response->assertSee('Knowledge Base Internal', false);
+        $response->assertSee('global_internal', false);
+    }
+
+    public function test_regular_user_cannot_access_knowledge_page(): void
+    {
+        $user = User::factory()->create(['role' => User::ROLE_USER]);
+
+        $this->actingAs($user)->get('/admin/knowledge')->assertStatus(403);
+    }
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $this->get('/admin/knowledge')->assertRedirect(route('login'));
+    }
+
+    public function test_admin_can_upload_knowledge_document(): void
+    {
+        Storage::fake('local');
+        Queue::fake();
+
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $file = UploadedFile::fake()->create('sop.pdf', 12, 'application/pdf');
+
+        $this->actingAs($admin);
+
+        Livewire::test(\App\Livewire\Admin\AdminKnowledge::class)
+            ->set('title', 'SOP Penerimaan Tamu')
+            ->set('newSourceName', 'SOP Internal')
+            ->set('file', $file)
+            ->call('upload')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('knowledge_sources', [
+            'name' => 'SOP Internal',
+            'created_by_id' => $admin->id,
+        ]);
+
+        $this->assertDatabaseHas('knowledge_documents', [
+            'title' => 'SOP Penerimaan Tamu',
+            'original_name' => 'sop.pdf',
+            'mime_type' => 'application/pdf',
+            'scope' => KnowledgeDocument::SCOPE_GLOBAL_INTERNAL,
+            'audience' => KnowledgeDocument::AUDIENCE_ALL_USERS,
+            'status' => KnowledgeDocument::STATUS_PROCESSING,
+        ]);
+
+        Queue::assertPushed(ProcessKnowledgeDocument::class);
+
+        $this->assertDatabaseHas('ai_usage_events', [
+            'feature' => AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+            'status' => AIUsageEvent::STATUS_SUCCESS,
+            'user_id' => $admin->id,
+        ]);
+    }
+
+    public function test_upload_rejects_invalid_mime_type(): void
+    {
+        Storage::fake('local');
+        Queue::fake();
+
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $file = UploadedFile::fake()->create('malware.exe', 5, 'application/x-msdownload');
+
+        $this->actingAs($admin);
+
+        Livewire::test(\App\Livewire\Admin\AdminKnowledge::class)
+            ->set('file', $file)
+            ->call('upload')
+            ->assertHasErrors(['file']);
+
+        $this->assertDatabaseCount('knowledge_documents', 0);
+        Queue::assertNothingPushed();
+    }
+
+    public function test_admin_can_archive_and_activate_knowledge(): void
+    {
+        Queue::fake();
+
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $document = $this->makeKnowledgeDocument(['status' => KnowledgeDocument::STATUS_ACTIVE]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(\App\Livewire\Admin\AdminKnowledge::class)
+            ->call('archive', $document->id);
+
+        $this->assertSame(KnowledgeDocument::STATUS_ARCHIVED, $document->fresh()->status);
+
+        Livewire::test(\App\Livewire\Admin\AdminKnowledge::class)
+            ->call('activate', $document->id);
+
+        $this->assertSame(KnowledgeDocument::STATUS_ACTIVE, $document->fresh()->status);
+
+        $this->assertGreaterThanOrEqual(2, AIUsageEvent::query()
+            ->where('feature', AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN)
+            ->count());
+    }
+
+    public function test_admin_can_reprocess_knowledge_document(): void
+    {
+        Queue::fake();
+
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $document = $this->makeKnowledgeDocument(['status' => KnowledgeDocument::STATUS_ERROR]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(\App\Livewire\Admin\AdminKnowledge::class)
+            ->call('reprocess', $document->id);
+
+        Queue::assertPushed(ProcessKnowledgeDocument::class);
+        $this->assertSame(KnowledgeDocument::STATUS_PROCESSING, $document->fresh()->status);
+    }
+
+    public function test_admin_can_delete_knowledge_document_and_cleanup_vectors(): void
+    {
+        Storage::fake('local');
+        Queue::fake();
+        Http::fake([
+            '*/api/knowledge/*' => Http::response([], 200),
+        ]);
+
+        config()->set('services.ai_document_service.url', 'http://python-ai:8001');
+        config()->set('services.ai_document_service.token', 'internal-token');
+
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $document = $this->makeKnowledgeDocument([
+            'status' => KnowledgeDocument::STATUS_ACTIVE,
+            'file_path' => 'knowledge/1/sop.pdf',
+        ]);
+        Storage::disk('local')->put($document->file_path, 'dummy');
+
+        $this->actingAs($admin);
+
+        Livewire::test(\App\Livewire\Admin\AdminKnowledge::class)
+            ->call('delete', $document->id);
+
+        $this->assertDatabaseMissing('knowledge_documents', ['id' => $document->id]);
+        $this->assertFalse(Storage::disk('local')->exists('knowledge/1/sop.pdf'));
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/api/knowledge/sop.pdf')
+                && $request->method() === 'DELETE'
+                && str_contains($request->url(), 'cleanup_legacy=true');
+        });
+    }
+
+    public function test_filter_by_status_returns_only_matching_rows(): void
+    {
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+
+        $this->makeKnowledgeDocument([
+            'title' => 'SOP Active Doc',
+            'original_name' => 'active.pdf',
+            'status' => KnowledgeDocument::STATUS_ACTIVE,
+        ]);
+        $this->makeKnowledgeDocument([
+            'title' => 'SOP Archived Doc',
+            'original_name' => 'archived.pdf',
+            'status' => KnowledgeDocument::STATUS_ARCHIVED,
+        ]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(\App\Livewire\Admin\AdminKnowledge::class)
+            ->set('status', KnowledgeDocument::STATUS_ACTIVE)
+            ->assertSee('SOP Active Doc')
+            ->assertDontSee('SOP Archived Doc');
+    }
+
+    private function makeKnowledgeDocument(array $overrides = []): KnowledgeDocument
+    {
+        $source = KnowledgeSource::create([
+            'name' => $overrides['source_name'] ?? 'SOP Internal',
+            'slug' => 'sop-internal-'.uniqid(),
+        ]);
+
+        return KnowledgeDocument::create(array_merge([
+            'knowledge_source_id' => $source->id,
+            'uploaded_by_id' => null,
+            'title' => 'Default Knowledge Title',
+            'original_name' => 'sop.pdf',
+            'filename' => 'sop.pdf',
+            'file_path' => 'knowledge/1/sop.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 1024,
+            'scope' => KnowledgeDocument::SCOPE_GLOBAL_INTERNAL,
+            'audience' => KnowledgeDocument::AUDIENCE_ALL_USERS,
+            'status' => KnowledgeDocument::STATUS_DRAFT,
+            'vector_namespace' => KnowledgeDocument::VECTOR_NAMESPACE,
+        ], $overrides));
+    }
+}

--- a/laravel/tests/Feature/Jobs/ProcessKnowledgeDocumentTest.php
+++ b/laravel/tests/Feature/Jobs/ProcessKnowledgeDocumentTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\ProcessKnowledgeDocument;
+use App\Models\AIUsageEvent;
+use App\Models\KnowledgeChunk;
+use App\Models\KnowledgeDocument;
+use App\Models\KnowledgeSource;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ProcessKnowledgeDocumentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_job_marks_document_active_on_success_and_records_chunks(): void
+    {
+        Storage::fake('local');
+        Http::fake([
+            '*/api/knowledge/process' => Http::response([
+                'status' => 'success',
+                'embedding_provider' => 'fake-provider',
+                'chunk_count' => 12,
+                'successful_chunks' => 12,
+                'failed_chunks' => 0,
+            ], 200),
+        ]);
+
+        config()->set('services.ai_document_service.url', 'http://python-ai:8001');
+        config()->set('services.ai_document_service.token', 'internal-token');
+
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $document = $this->makeDocument($admin, KnowledgeDocument::STATUS_PROCESSING);
+        Storage::disk('local')->put($document->file_path, 'dummy content');
+
+        ProcessKnowledgeDocument::dispatchSync($document);
+
+        $document->refresh();
+        $this->assertSame(KnowledgeDocument::STATUS_ACTIVE, $document->status);
+        $this->assertNotNull($document->processed_at);
+
+        $chunk = KnowledgeChunk::where('knowledge_document_id', $document->id)->first();
+        $this->assertNotNull($chunk);
+        $this->assertSame(12, $chunk->chunk_count);
+        $this->assertSame('fake-provider', $chunk->embedding_provider);
+
+        Http::assertSent(function ($request) use ($document) {
+            return str_contains($request->url(), '/api/knowledge/process')
+                && $request->method() === 'POST'
+                && $request->hasHeader('Authorization', 'Bearer internal-token')
+                && $request->isMultipart()
+                && collect($request->data())->contains(fn ($field) => $field['name'] === 'document_id' && $field['contents'] === (string) $document->id)
+                && collect($request->data())->contains(fn ($field) => $field['name'] === 'scope' && $field['contents'] === KnowledgeDocument::SCOPE_GLOBAL_INTERNAL)
+                && collect($request->data())->contains(fn ($field) => $field['name'] === 'audience' && $field['contents'] === KnowledgeDocument::AUDIENCE_ALL_USERS);
+        });
+
+        $this->assertDatabaseHas('ai_usage_events', [
+            'feature' => AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+            'status' => AIUsageEvent::STATUS_SUCCESS,
+            'subject_id' => $document->id,
+        ]);
+    }
+
+    public function test_job_marks_document_error_when_microservice_fails(): void
+    {
+        Storage::fake('local');
+        Http::fake([
+            '*/api/knowledge/process' => Http::response('boom', 500),
+        ]);
+
+        config()->set('services.ai_document_service.url', 'http://python-ai:8001');
+        config()->set('services.ai_document_service.token', 'internal-token');
+
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $document = $this->makeDocument($admin, KnowledgeDocument::STATUS_PROCESSING);
+        Storage::disk('local')->put($document->file_path, 'dummy content');
+
+        try {
+            ProcessKnowledgeDocument::dispatchSync($document);
+        } catch (\Throwable) {
+            // re-thrown for retry; ignore in test.
+        }
+
+        $document->refresh();
+        $this->assertSame(KnowledgeDocument::STATUS_ERROR, $document->status);
+        $this->assertContains($document->error_code, ['microservice_error', 'job_failed']);
+        $this->assertNotNull($document->failed_at);
+
+        $this->assertDatabaseHas('ai_usage_events', [
+            'feature' => AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN,
+            'status' => AIUsageEvent::STATUS_ERROR,
+            'subject_id' => $document->id,
+        ]);
+    }
+
+    public function test_job_marks_document_error_when_file_missing(): void
+    {
+        Storage::fake('local');
+        Http::fake();
+
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $document = $this->makeDocument($admin, KnowledgeDocument::STATUS_PROCESSING);
+        // intentionally do not write the file to storage
+
+        ProcessKnowledgeDocument::dispatchSync($document);
+
+        $document->refresh();
+        $this->assertSame(KnowledgeDocument::STATUS_ERROR, $document->status);
+        $this->assertSame('file_not_found', $document->error_code);
+
+        Http::assertNothingSent();
+    }
+
+    private function makeDocument(User $admin, string $status): KnowledgeDocument
+    {
+        $source = KnowledgeSource::create([
+            'name' => 'SOP Internal',
+            'slug' => 'sop-internal-'.uniqid(),
+            'created_by_id' => $admin->id,
+        ]);
+
+        return KnowledgeDocument::create([
+            'knowledge_source_id' => $source->id,
+            'uploaded_by_id' => $admin->id,
+            'title' => 'SOP Tamu',
+            'original_name' => 'sop.pdf',
+            'filename' => 'sop.pdf',
+            'file_path' => 'knowledge/'.$source->id.'/sop.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 1024,
+            'scope' => KnowledgeDocument::SCOPE_GLOBAL_INTERNAL,
+            'audience' => KnowledgeDocument::AUDIENCE_ALL_USERS,
+            'status' => $status,
+            'vector_namespace' => KnowledgeDocument::VECTOR_NAMESPACE,
+        ]);
+    }
+}

--- a/python-ai/app/documents_api.py
+++ b/python-ai/app/documents_api.py
@@ -4,13 +4,14 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, Response
 
 from app.api_shared import HealthResponse, build_health_payload, build_ready_payload
-from app.routers import documents, memos
+from app.routers import documents, knowledge, memos
 
 # Load .env from the project root (python-ai/.env)
 load_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env"))
 
 app = FastAPI(title="ISTA AI Document Microservice", version="1.2.0")
 app.include_router(documents.router)
+app.include_router(knowledge.router)
 app.include_router(memos.router)
 
 

--- a/python-ai/app/routers/knowledge.py
+++ b/python-ai/app/routers/knowledge.py
@@ -1,0 +1,180 @@
+"""Knowledge base ingest API router.
+
+This module exposes endpoints used by the Laravel admin to ingest internal
+knowledge documents into Chroma. The ingest pipeline is shared with the
+per-user document ingest, but every chunk is tagged with metadata that
+clearly differentiates it from personal documents:
+
+  - ``scope`` = ``global_internal``
+  - ``audience`` = ``all_users``
+  - ``status`` = ``active``
+  - ``user_id`` = the synthetic ``__knowledge__`` namespace, which guarantees
+    that personal-document filters (``user_id == real_user_id``) cannot match
+    knowledge vectors.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
+
+from app.api_shared import verify_token
+from app.routers.documents import (
+    ALLOWED_EXTENSIONS,
+    MAX_UPLOAD_BYTES,
+    _require_safe_filename,
+    _require_supported_extension,
+    _stream_upload_with_limit,
+)
+from app.services import rag_ingest
+
+router = APIRouter(prefix="/api/knowledge", tags=["Knowledge"])
+
+
+KNOWLEDGE_USER_ID = "__knowledge__"
+DEFAULT_SCOPE = "global_internal"
+DEFAULT_AUDIENCE = "all_users"
+DEFAULT_STATUS = "active"
+
+
+def _process_knowledge_document(
+    file_path: str,
+    filename: str,
+    document_id: str,
+    *,
+    scope: str = DEFAULT_SCOPE,
+    audience: str = DEFAULT_AUDIENCE,
+    status: str = DEFAULT_STATUS,
+    knowledge_source_id: str | None = None,
+    title: str | None = None,
+):
+    """Ingest a knowledge document via the shared rag pipeline.
+
+    The chunks emitted by ``rag_ingest.process_document`` get extra metadata
+    for the knowledge namespace appended through ``rag_ingest.metadata_overrides``.
+    """
+
+    overrides = {
+        "scope": scope,
+        "audience": audience,
+        "knowledge_status": status,
+    }
+    if knowledge_source_id:
+        overrides["knowledge_source_id"] = knowledge_source_id
+    if title:
+        overrides["knowledge_title"] = title[:191]
+
+    previous = getattr(rag_ingest, "_knowledge_metadata_overrides", None)
+    rag_ingest._knowledge_metadata_overrides = overrides
+    try:
+        return rag_ingest.process_document(
+            file_path=file_path,
+            filename=filename,
+            user_id=KNOWLEDGE_USER_ID,
+            document_id=document_id,
+        )
+    finally:
+        rag_ingest._knowledge_metadata_overrides = previous
+
+
+def _delete_knowledge_vectors(
+    filename: str,
+    document_id: str,
+    cleanup_legacy: bool = False,
+):
+    return rag_ingest.delete_document_vectors(
+        filename,
+        user_id=KNOWLEDGE_USER_ID,
+        document_id=document_id if document_id else None,
+        cleanup_legacy=cleanup_legacy,
+    )
+
+
+@router.post("/process", dependencies=[Depends(verify_token)])
+def upload_knowledge(
+    file: UploadFile = File(...),
+    document_id: str = Form(...),
+    knowledge_source_id: str = Form(""),
+    scope: str = Form(DEFAULT_SCOPE),
+    audience: str = Form(DEFAULT_AUDIENCE),
+    title: str = Form(""),
+):
+    """Ingest a knowledge document and tag it with knowledge metadata."""
+
+    if not document_id:
+        raise HTTPException(status_code=400, detail="document_id is required for knowledge ingest.")
+
+    safe_filename = _require_safe_filename(file.filename)
+    _require_supported_extension(safe_filename)
+
+    temp_dir = "temp_files"
+    os.makedirs(temp_dir, exist_ok=True)
+
+    file_id = str(uuid.uuid4())
+    temp_file_path = os.path.join(temp_dir, f"knowledge_{file_id}_{safe_filename}")
+
+    try:
+        _stream_upload_with_limit(file, temp_file_path)
+
+        success, message = _process_knowledge_document(
+            temp_file_path,
+            safe_filename,
+            document_id=document_id,
+            scope=scope or DEFAULT_SCOPE,
+            audience=audience or DEFAULT_AUDIENCE,
+            knowledge_source_id=knowledge_source_id or None,
+            title=title or None,
+        )
+
+        if success:
+            return {
+                "status": "success",
+                "message": message,
+                "filename": safe_filename,
+                "scope": scope or DEFAULT_SCOPE,
+                "audience": audience or DEFAULT_AUDIENCE,
+                "document_id": document_id,
+            }
+
+        raise HTTPException(status_code=500, detail=message)
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover — defensive guard
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    finally:
+        if os.path.exists(temp_file_path):
+            os.remove(temp_file_path)
+
+
+@router.delete("/{filename}", dependencies=[Depends(verify_token)])
+async def delete_knowledge(
+    filename: str,
+    document_id: str = Query(""),
+    cleanup_legacy: bool = Query(False),
+):
+    if not document_id:
+        raise HTTPException(status_code=400, detail="document_id is required to delete knowledge vectors.")
+
+    success, message = _delete_knowledge_vectors(
+        filename,
+        document_id=document_id,
+        cleanup_legacy=cleanup_legacy,
+    )
+
+    if success:
+        return {"status": "success", "message": message}
+
+    raise HTTPException(status_code=500, detail=message)
+
+
+__all__ = [
+    "router",
+    "KNOWLEDGE_USER_ID",
+    "DEFAULT_SCOPE",
+    "DEFAULT_AUDIENCE",
+    "DEFAULT_STATUS",
+    "_process_knowledge_document",
+    "_delete_knowledge_vectors",
+]

--- a/python-ai/app/services/rag_ingest.py
+++ b/python-ai/app/services/rag_ingest.py
@@ -24,6 +24,25 @@ from app.services.lightweight_text_splitter import LightweightRecursiveTextSplit
 logger = logging.getLogger(__name__)
 
 
+# ── Optional metadata overrides ──────────────────────────────────────────────
+# Callers (e.g. the knowledge ingest router) can set
+# ``rag_ingest._knowledge_metadata_overrides`` to a dict that will be merged
+# into every chunk's metadata. This is intentionally a module-level attribute
+# so the wrapper is process-local and resets after each ingest run.
+_knowledge_metadata_overrides: dict | None = None
+
+
+def _apply_metadata_overrides(chunk_metadata: dict) -> None:
+    overrides = _knowledge_metadata_overrides
+    if not overrides:
+        return
+
+    for key, value in overrides.items():
+        if value is None:
+            continue
+        chunk_metadata[key] = value
+
+
 def _delete_chroma_ids_with_retry(
     delete_callable,
     ids: list[str],
@@ -172,6 +191,7 @@ def process_document(
                 }
                 if document_id:
                     parent_meta["document_id"] = str(document_id)
+                _apply_metadata_overrides(parent_meta)
                 pdr_parent_docs.append((parent_id, parent.page_content, parent_meta))
 
                 children = child_splitter.split_documents([parent])
@@ -230,6 +250,7 @@ def process_document(
             chunk.metadata["chunk_index"] = idx
             if document_id:
                 chunk.metadata["document_id"] = str(document_id)
+            _apply_metadata_overrides(chunk.metadata)
             if idx == 0:
                 logger.info("🔍 INGEST: Storing chunk metadata - filename='%s', user_id='%s'", filename, str(user_id))
 

--- a/python-ai/tests/test_knowledge_router.py
+++ b/python-ai/tests/test_knowledge_router.py
@@ -1,0 +1,166 @@
+import io
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _build_client(monkeypatch):
+    """Return a FastAPI TestClient with knowledge router mounted and auth bypassed."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    # Bypass token check for tests.
+    monkeypatch.setattr("app.api_shared.get_internal_service_token", lambda: "test-token")
+
+    app = FastAPI()
+    from app.routers import knowledge
+
+    app.include_router(knowledge.router)
+    return TestClient(app)
+
+
+def test_knowledge_process_calls_rag_with_global_internal_metadata(monkeypatch):
+    from app.routers import knowledge as knowledge_module
+    from app.services import rag_ingest
+
+    captured = {}
+
+    def fake_process_document(file_path, filename, user_id, document_id):
+        captured["file_path"] = file_path
+        captured["filename"] = filename
+        captured["user_id"] = user_id
+        captured["document_id"] = document_id
+        captured["overrides"] = dict(rag_ingest._knowledge_metadata_overrides or {})
+        return True, "Knowledge ingested"
+
+    monkeypatch.setattr(rag_ingest, "process_document", fake_process_document)
+
+    client = _build_client(monkeypatch)
+
+    response = client.post(
+        "/api/knowledge/process",
+        headers={"Authorization": "Bearer test-token"},
+        files={"file": ("sop.pdf", io.BytesIO(b"%PDF-1.4 dummy"), "application/pdf")},
+        data={
+            "document_id": "42",
+            "knowledge_source_id": "7",
+            "scope": "global_internal",
+            "audience": "all_users",
+            "title": "SOP Penerimaan Tamu",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "success"
+    assert body["scope"] == "global_internal"
+    assert body["audience"] == "all_users"
+    assert body["document_id"] == "42"
+
+    assert captured["filename"] == "sop.pdf"
+    assert captured["user_id"] == knowledge_module.KNOWLEDGE_USER_ID
+    assert captured["document_id"] == "42"
+    assert captured["overrides"] == {
+        "scope": "global_internal",
+        "audience": "all_users",
+        "knowledge_status": "active",
+        "knowledge_source_id": "7",
+        "knowledge_title": "SOP Penerimaan Tamu",
+    }
+
+    # Ensure the override sentinel is reset after the call so subsequent ingests
+    # do not accidentally inherit knowledge metadata.
+    assert getattr(rag_ingest, "_knowledge_metadata_overrides") is None
+
+
+def test_knowledge_delete_uses_knowledge_user_id(monkeypatch):
+    from app.routers import knowledge as knowledge_module
+    from app.services import rag_ingest
+
+    captured = {}
+
+    def fake_delete(filename, user_id=None, document_id=None, cleanup_legacy=False):
+        captured["filename"] = filename
+        captured["user_id"] = user_id
+        captured["document_id"] = document_id
+        captured["cleanup_legacy"] = cleanup_legacy
+        return True, "deleted"
+
+    monkeypatch.setattr(rag_ingest, "delete_document_vectors", fake_delete)
+
+    client = _build_client(monkeypatch)
+
+    response = client.delete(
+        "/api/knowledge/sop.pdf?document_id=42&cleanup_legacy=true",
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+    assert response.status_code == 200
+    assert captured["filename"] == "sop.pdf"
+    assert captured["user_id"] == knowledge_module.KNOWLEDGE_USER_ID
+    assert captured["document_id"] == "42"
+    assert captured["cleanup_legacy"] is True
+
+
+def test_knowledge_process_requires_document_id(monkeypatch):
+    from app.services import rag_ingest
+
+    monkeypatch.setattr(rag_ingest, "process_document", lambda *a, **kw: (True, "ok"))
+
+    client = _build_client(monkeypatch)
+
+    # Sending without document_id at all → FastAPI rejects with 422 (validation).
+    response_missing = client.post(
+        "/api/knowledge/process",
+        headers={"Authorization": "Bearer test-token"},
+        files={"file": ("sop.pdf", io.BytesIO(b"dummy"), "application/pdf")},
+    )
+    assert response_missing.status_code == 422
+
+    # Sending an empty document_id → router rejects with 400 from custom guard.
+    response_empty = client.post(
+        "/api/knowledge/process",
+        headers={"Authorization": "Bearer test-token"},
+        files={"file": ("sop.pdf", io.BytesIO(b"dummy"), "application/pdf")},
+        data={"document_id": ""},
+    )
+    assert response_empty.status_code in (400, 422)
+
+
+def test_knowledge_process_rejects_unsupported_extension(monkeypatch):
+    from app.services import rag_ingest
+
+    monkeypatch.setattr(rag_ingest, "process_document", lambda *a, **kw: (True, "ok"))
+
+    client = _build_client(monkeypatch)
+
+    response = client.post(
+        "/api/knowledge/process",
+        headers={"Authorization": "Bearer test-token"},
+        files={"file": ("malware.exe", io.BytesIO(b"binary"), "application/x-msdownload")},
+        data={"document_id": "42"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_metadata_overrides_apply_to_chunks(monkeypatch):
+    """End-to-end check that _apply_metadata_overrides injects knowledge keys."""
+    from app.services import rag_ingest
+
+    chunk_meta = {"filename": "sop.pdf", "user_id": "__knowledge__"}
+
+    rag_ingest._knowledge_metadata_overrides = {
+        "scope": "global_internal",
+        "audience": "all_users",
+        "knowledge_status": "active",
+    }
+    try:
+        rag_ingest._apply_metadata_overrides(chunk_meta)
+    finally:
+        rag_ingest._knowledge_metadata_overrides = None
+
+    assert chunk_meta["scope"] == "global_internal"
+    assert chunk_meta["audience"] == "all_users"
+    assert chunk_meta["knowledge_status"] == "active"


### PR DESCRIPTION
Closes #211 (Child 5 dari parent #209).

## Ringkasan
Modul Knowledge Base Internal yang dikelola admin, dengan state machine `draft → processing → active / error → archived`, terpisah dari dokumen pribadi user. Vector hasil ingest ditandai eksplisit dengan `scope=global_internal`, `audience=all_users`, dan disimpan pada synthetic `user_id=__knowledge__` agar tidak tercampur dengan retrieval dokumen pribadi.

## Yang berubah

### Database & model
- Migration baru `2026_05_18_120000_create_knowledge_tables.php`: `knowledge_sources`, `knowledge_documents`, `knowledge_chunks`.
- Model: `KnowledgeSource`, `KnowledgeDocument`, `KnowledgeChunk` dengan konstanta status & scope.

### Service & job
- `App\Services\Knowledge\KnowledgeLifecycleService`: upload, activate, archive, reprocess, delete (cleanup vector + file storage).
- `App\Jobs\ProcessKnowledgeDocument`: panggil Python `/api/knowledge/process`, update status & error_code.

### UI admin
- Livewire `App\Livewire\Admin\AdminKnowledge` + view `/admin/knowledge` (list, filter, upload, archive/activate/reprocess/delete).
- Sidebar admin menu **Knowledge** dengan deskripsi.
- Konstanta filter `AIUsageEvent::FEATURE_KNOWLEDGE_ADMIN` masuk ke `AdminUsage` dropdown.

### Python AI
- Router baru `python-ai/app/routers/knowledge.py` (`POST /api/knowledge/process`, `DELETE /api/knowledge/{filename}`).
- Hook `_knowledge_metadata_overrides` di `rag_ingest.py` agar metadata knowledge dapat diinjeksi ke setiap chunk dan parent PDR.
- Registrasi router di `documents_api.py`.

### Event tracking
- Tambah konstanta `FEATURE_KNOWLEDGE_ADMIN` dan emit event `started/completed/failed` saat upload, activate, archive, reprocess, delete, dan job processing.

## Test
### Laravel
- `tests/Feature/Admin/AdminKnowledgeManagementTest.php` — 9 case: akses admin/user/guest, upload sukses, mime invalid, archive→activate, reprocess (queue), delete + cleanup vector, filter status.
- `tests/Feature/Jobs/ProcessKnowledgeDocumentTest.php` — 3 case: success → active + chunks tercatat, microservice error, file hilang.
- Hasil: \`php artisan test\` ⇒ **467 passed (2001 assertions)**.

### Python
- `tests/test_knowledge_router.py` — 5 case: metadata override `global_internal`, delete pakai user_id `__knowledge__`, validasi `document_id`, validasi extension, sentinel reset setelah ingest.
- Hasil: \`pytest\` ⇒ **354 passed**.

## Risiko & follow-up
- **Retrieval ke chat masih di luar scope** (Child 6 #...): vector knowledge sudah di Chroma tetapi belum dipakai oleh chat. Filter user di rag_retrieval saat ini menggunakan `user_id=real_user_id` sehingga vector knowledge tidak akan match — aman secara default sampai retrieval Child 6 diimplementasikan.
- **AI Configuration & ISTURA Excel**: tidak disentuh, sesuai scope issue.
- Plan: `issue/issue-211-admin-knowledge-base-internal-plan-2026-05-18.md`.