### PR TITLE
feat(admin): admin access security hardening (#245)

### DIFF
--- a/issue/issue-228-admin-access-security-hardening-2026-05-18.md
+++ b/issue/issue-228-admin-access-security-hardening-2026-05-18.md
@@ -1,0 +1,215 @@
+# Admin Access Security Hardening sebelum Merge Knowledge Base
+
+Parent: https://github.com/Hasbi1605/ISTA-AI/issues/209
+GitHub Issue: https://github.com/Hasbi1605/ISTA-AI/issues/245
+Blocks: https://github.com/Hasbi1605/ISTA-AI/issues/211
+
+## Latar Belakang
+Fitur admin dashboard foundation, usage tracking, design shell, dan monitoring MVP sudah berjalan sampai tahap PR/merge/deploy awal. Child #211 Admin Knowledge Base Internal sudah dikerjakan dalam PR tetapi belum merge. Sebelum #211 masuk ke production, akses admin perlu di-hardening karena Knowledge Base Internal memungkinkan admin mengunggah, mengaktifkan, mengarsipkan, dan memproses dokumen internal yang nantinya bisa digunakan seluruh user.
+
+Hardening ini dibuat sebagai issue baru agar tidak mengubah scope issue yang sudah selesai/terlanjur dikerjakan. Issue ini menjadi blocker sebelum merge #211 dan sebelum melanjutkan fitur yang lebih sensitif seperti Knowledge Internal Retrieval, AI Configuration, dan ISTURA.
+
+## Tujuan
+- Menyediakan jalur login admin khusus yang lebih aman.
+- Memastikan `/admin` hanya dapat diakses admin/super_admin aktif.
+- Menyediakan satu akun `admin` dan satu akun `super_admin` awal melalui command/seeder berbasis environment.
+- Membuat `super_admin` dapat membuat, mengedit, mengaktifkan/menonaktifkan, dan reset akun admin.
+- Mencegah admin biasa mengatur akun admin, termasuk akunnya sendiri.
+- Menambahkan audit log untuk login admin dan perubahan akun admin.
+- Menjaga desain halaman admin tetap konsisten dengan ISTA AI.
+
+## Ruang Lingkup
+- Route `/admin/login`, `POST /admin/login`, dan `POST /admin/logout`.
+- Login admin hardened tanpa pendaftaran, lupa password, guest chat, social login, atau CTA publik.
+- Migration additive untuk status keamanan akun admin.
+- Seeder/command bootstrap akun admin dan super_admin dari `.env`.
+- Account management untuk `super_admin`.
+- Audit log perubahan akun admin.
+- Middleware active-admin check.
+- Test akses, login, account management, audit, dan desain dasar.
+
+## Di Luar Scope
+- Mengubah ulang fitur monitoring dashboard yang sudah merge/deploy.
+- Mengubah logic Knowledge Base Internal #211 selain menambahkan guard akses bila perlu.
+- SSO/2FA.
+- Public self-service reset password untuk admin.
+- AI Configuration.
+- Retrieval knowledge internal.
+
+## Design Consistency Guardrails
+- Gunakan Laravel + Livewire + Tailwind sesuai stack existing.
+- `/admin/login` harus memakai identitas visual ISTA AI: logo, warna, typography, dark mode, radius, dan button style yang konsisten.
+- Halaman admin login harus minimal dan formal: email, password, tombol masuk, pesan error generik.
+- Jangan tampilkan link register, lupa password, guest chat, dashboard publik, atau CTA fitur.
+- Account management harus memakai admin shell/design system yang sudah dibuat di #216.
+- Gunakan table, filter, status badge, action button, modal/confirmation pattern yang konsisten dengan admin dashboard.
+- Tidak ada nested cards.
+- Responsive mobile dan dark mode wajib dicek.
+- Copywriting harus ringkas, formal, dan sesuai konteks instansi.
+
+## Rekomendasi Keamanan
+- `/admin` unauthenticated redirect ke `/admin/login`, bukan login publik jika memungkinkan.
+- Login admin hanya berhasil untuk role `admin` atau `super_admin` dengan `is_active=true`.
+- User biasa yang mencoba login lewat `/admin/login` mendapat error generik.
+- Error login tidak membocorkan apakah email ada, role salah, password salah, atau akun nonaktif.
+- Rate limit admin login lebih ketat daripada login publik.
+- Regenerate session setelah login berhasil.
+- Akun awal dibuat dari `.env`, bukan hardcoded.
+- Temporary password awal harus memaksa `force_password_change=true`.
+- Admin nonaktif tidak dapat mengakses route admin meskipun masih punya session.
+- Audit log tidak menyimpan password atau secret.
+
+## Data Model
+
+Kolom additive pada `users`:
+
+```text
+is_active boolean default true index
+disabled_at timestamp nullable
+disabled_by nullable foreign key users
+disabled_reason string nullable
+force_password_change boolean default false
+last_admin_login_at timestamp nullable
+last_admin_login_ip string nullable
+```
+
+Jika kolom `role`, `last_seen_at`, atau `last_active_feature` sudah dibuat pada issue sebelumnya, jangan dibuat ulang.
+
+Tabel audit:
+
+```text
+admin_account_audits
+id
+actor_id nullable
+target_user_id nullable
+action string index
+ip_address nullable
+user_agent nullable
+before_snapshot json nullable
+after_snapshot json nullable
+metadata json nullable
+created_at
+updated_at
+```
+
+Action audit:
+
+```text
+admin_login_success
+admin_login_failed
+admin_created
+admin_updated
+admin_activated
+admin_deactivated
+admin_password_reset
+admin_role_changed
+```
+
+Env bootstrap:
+
+```text
+INITIAL_ADMIN_EMAIL=admin@example.go.id
+INITIAL_ADMIN_PASSWORD=temporary-secret
+INITIAL_SUPER_ADMIN_EMAIL=superadmin@example.go.id
+INITIAL_SUPER_ADMIN_PASSWORD=temporary-secret
+```
+
+Jika env credential tidak tersedia, command/seeder harus gagal dengan pesan jelas dan tidak membuat password default.
+
+## Admin Account Management
+
+Route yang disarankan:
+
+```text
+GET /admin/accounts
+GET /admin/accounts/create
+POST /admin/accounts
+GET /admin/accounts/{user}/edit
+PUT /admin/accounts/{user}
+POST /admin/accounts/{user}/activate
+POST /admin/accounts/{user}/deactivate
+POST /admin/accounts/{user}/reset-password
+```
+
+Aturan:
+- Hanya `super_admin` aktif yang dapat mengakses account management.
+- Super admin dapat membuat akun `admin` dan `super_admin`.
+- Super admin dapat mengedit nama, email, role, status aktif, dan `force_password_change`.
+- Super admin dapat reset password admin menjadi temporary password.
+- Admin biasa tidak bisa membuka account management.
+- Admin biasa tidak bisa mengubah akunnya sendiri dari dashboard admin.
+- Cegah deactivate super_admin terakhir.
+- Cegah self-deactivate jika membuat tidak ada super_admin aktif.
+- Hard delete tidak direkomendasikan untuk MVP; gunakan deactivate agar audit tetap utuh.
+
+## Area / File Terkait
+- `laravel/routes/web.php`
+- `laravel/app/Models/User.php`
+- `laravel/app/Models/AdminAccountAudit.php`
+- `laravel/app/Http/Middleware/*`
+- `laravel/app/Http/Controllers/Auth/*`
+- `laravel/app/Http/Controllers/Admin/*`
+- `laravel/app/Livewire/Admin/*`
+- `laravel/resources/views/admin/*`
+- `laravel/resources/views/livewire/admin/*`
+- `laravel/resources/css/app.css`
+- `laravel/database/migrations/*`
+- `laravel/database/seeders/*`
+- `laravel/app/Console/Commands/*`
+- `laravel/tests/Feature/*`
+
+## Risiko
+- Admin login yang masih memakai halaman publik bisa membawa link self-service yang tidak diinginkan.
+- Account management yang terlalu bebas bisa menonaktifkan semua super_admin.
+- Pesan error login terlalu spesifik bisa membantu enumerasi akun.
+- UI baru bisa terasa berbeda dari admin dashboard jika tidak memakai shell/komponen #216.
+- Hardening yang terlalu besar bisa mengganggu #211; perubahan harus difokuskan pada akses dan akun.
+
+## Langkah Implementasi
+1. Audit kondisi admin auth yang sudah ada dari #214/#210.
+2. Tambah migration kolom keamanan akun admin jika belum ada.
+3. Buat `AdminAccountAudit`.
+4. Buat command/seeder bootstrap akun `admin` dan `super_admin` dari env.
+5. Buat `/admin/login` khusus admin dengan desain konsisten.
+6. Tambah login handler admin dengan rate limit, generic error, session regenerate, role check, active check, dan audit.
+7. Tambah middleware active-admin check untuk route `/admin/*`.
+8. Buat halaman account management untuk `super_admin` memakai admin shell.
+9. Tambah guard agar super_admin terakhir tidak bisa dinonaktifkan.
+10. Tambah audit pada create/update/activate/deactivate/reset password.
+11. Pastikan `/admin/knowledge` pada PR #211 memakai guard admin aktif.
+12. Tambah test akses, login, account management, audit, dan smoke render desain.
+
+## Rencana Test
+```bash
+cd laravel && php artisan test --filter='Admin|AdminAccess|AdminAccount|Knowledge'
+```
+
+Minimal test:
+- Guest membuka `/admin` diarahkan ke `/admin/login`.
+- `/admin/login` tidak menampilkan register, forgot password, guest chat, atau CTA publik.
+- User biasa tidak bisa login lewat `/admin/login`.
+- Admin aktif bisa login dan membuka `/admin`.
+- Admin nonaktif tidak bisa login.
+- Super admin aktif bisa membuka `/admin/accounts`.
+- Admin biasa tidak bisa membuka `/admin/accounts`.
+- Super admin bisa create/edit/activate/deactivate/reset password admin.
+- Admin biasa tidak bisa mengatur akunnya sendiri.
+- Sistem menolak deactivate super_admin terakhir.
+- Audit tercatat untuk login berhasil/gagal dan perubahan akun admin.
+- `/admin/knowledge` tetap terlindungi.
+
+Verifikasi manual:
+- Tampilan `/admin/login` konsisten dengan ISTA AI.
+- Account management memakai admin shell yang sama.
+- Dark mode dan mobile tidak overlap.
+
+## Kriteria Selesai
+- GitHub issue ini merge sebelum #211.
+- `/admin/login` hardened tersedia.
+- Akun awal admin dan super_admin dapat dibuat aman dari env.
+- `super_admin` dapat mengelola akun admin.
+- Admin biasa tidak bisa mengatur akun admin atau akunnya sendiri.
+- Admin nonaktif tidak dapat mengakses admin area.
+- Audit admin account tersedia.
+- Desain admin login dan account management konsisten dengan sistem existing.
+- Test relevan lulus.

--- a/laravel/.env.example
+++ b/laravel/.env.example
@@ -107,4 +107,13 @@ GOOGLE_DRIVE_OAUTH_REDIRECT_URI=
 GOOGLE_DRIVE_OAUTH_SETUP_KEY=
 GOOGLE_DRIVE_OAUTH_ADMIN_EMAILS=
 
+# Admin bootstrap accounts (used by `php artisan admin:bootstrap-accounts`).
+# Both pairs MUST be set before running the bootstrap command. Use long,
+# unique temporary passwords; admins will be forced to change them on first
+# login (force_password_change=true).
+INITIAL_ADMIN_EMAIL=
+INITIAL_ADMIN_PASSWORD=
+INITIAL_SUPER_ADMIN_EMAIL=
+INITIAL_SUPER_ADMIN_PASSWORD=
+
 VITE_APP_NAME="${APP_NAME}"

--- a/laravel/app/Console/Commands/BootstrapAdminAccounts.php
+++ b/laravel/app/Console/Commands/BootstrapAdminAccounts.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\AdminAccountAudit;
+use App\Models\User;
+use App\Services\Admin\AdminAccountAuditService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+class BootstrapAdminAccounts extends Command
+{
+    protected $signature = 'admin:bootstrap-accounts
+        {--force-reset-password : Reset the temporary password for existing bootstrap accounts}';
+
+    protected $description = 'Bootstrap initial admin & super admin accounts from environment variables.';
+
+    public function handle(AdminAccountAuditService $audit): int
+    {
+        $config = [
+            [
+                'role' => User::ROLE_SUPER_ADMIN,
+                'email' => env('INITIAL_SUPER_ADMIN_EMAIL'),
+                'password' => env('INITIAL_SUPER_ADMIN_PASSWORD'),
+                'label' => 'super admin',
+                'name' => 'Super Admin ISTA',
+            ],
+            [
+                'role' => User::ROLE_ADMIN,
+                'email' => env('INITIAL_ADMIN_EMAIL'),
+                'password' => env('INITIAL_ADMIN_PASSWORD'),
+                'label' => 'admin',
+                'name' => 'Admin ISTA',
+            ],
+        ];
+
+        $missing = [];
+        foreach ($config as $entry) {
+            if (empty($entry['email']) || empty($entry['password'])) {
+                $missing[] = $entry['label'];
+            }
+        }
+
+        if (! empty($missing)) {
+            $this->error('Tidak dapat melakukan bootstrap. Env credential tidak lengkap untuk: '
+                .implode(', ', $missing).'.');
+            $this->line('Set INITIAL_ADMIN_EMAIL, INITIAL_ADMIN_PASSWORD, INITIAL_SUPER_ADMIN_EMAIL, dan INITIAL_SUPER_ADMIN_PASSWORD pada .env.');
+
+            return self::FAILURE;
+        }
+
+        foreach ($config as $entry) {
+            $email = strtolower(trim((string) $entry['email']));
+            $password = (string) $entry['password'];
+            $label = $entry['label'];
+            $role = $entry['role'];
+
+            if (strlen($password) < 8) {
+                $this->error(sprintf('Password awal untuk %s minimal 8 karakter.', $label));
+
+                return self::FAILURE;
+            }
+
+            DB::transaction(function () use ($email, $password, $role, $label, $entry, $audit) {
+                $user = User::query()->where('email', $email)->first();
+
+                if (! $user) {
+                    $user = User::create([
+                        'name' => $entry['name'],
+                        'email' => $email,
+                        'password' => Hash::make($password),
+                        'email_verified_at' => now(),
+                        'role' => $role,
+                        'is_active' => true,
+                        'force_password_change' => true,
+                    ]);
+
+                    $audit->record(
+                        AdminAccountAudit::ACTION_CREATED,
+                        actor: null,
+                        target: $user,
+                        after: $audit->snapshot($user),
+                        metadata: ['source' => 'bootstrap'],
+                    );
+
+                    $this->info(sprintf('Akun %s dibuat: %s.', $label, $email));
+
+                    return;
+                }
+
+                $before = $audit->snapshot($user);
+                $changed = false;
+
+                if ($user->role !== $role) {
+                    $user->role = $role;
+                    $changed = true;
+                }
+
+                if (! (bool) $user->is_active) {
+                    $user->is_active = true;
+                    $user->disabled_at = null;
+                    $user->disabled_by = null;
+                    $user->disabled_reason = null;
+                    $changed = true;
+                }
+
+                if ($this->option('force-reset-password')) {
+                    $user->password = Hash::make($password);
+                    $user->force_password_change = true;
+                    $changed = true;
+                }
+
+                if ($changed) {
+                    $user->save();
+
+                    $audit->record(
+                        AdminAccountAudit::ACTION_UPDATED,
+                        actor: null,
+                        target: $user,
+                        before: $before,
+                        after: $audit->snapshot($user),
+                        metadata: ['source' => 'bootstrap'],
+                    );
+
+                    $this->info(sprintf('Akun %s diperbarui: %s.', $label, $email));
+                } else {
+                    $this->line(sprintf('Akun %s sudah konsisten: %s.', $label, $email));
+                }
+            });
+        }
+
+        $this->newLine();
+        $this->info('Bootstrap akun admin selesai. Pastikan password awal segera diganti setelah login.');
+
+        return self::SUCCESS;
+    }
+}

--- a/laravel/app/Http/Controllers/Admin/AdminLoginController.php
+++ b/laravel/app/Http/Controllers/Admin/AdminLoginController.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\AdminAccountAudit;
+use App\Models\User;
+use App\Services\Admin\AdminAccountAuditService;
+use Illuminate\Auth\Events\Lockout;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use Illuminate\View\View;
+
+class AdminLoginController extends Controller
+{
+    /**
+     * Generic message returned for any login failure to avoid account enumeration.
+     */
+    private const GENERIC_FAILURE_MESSAGE = 'Email atau password salah, atau akun tidak dapat mengakses admin.';
+
+    public function __construct(private readonly AdminAccountAuditService $audit)
+    {
+    }
+
+    public function showLoginForm(Request $request): View|RedirectResponse
+    {
+        if ($request->user() && $request->user()->canAccessAdmin()) {
+            return redirect()->intended(route('admin.dashboard'));
+        }
+
+        return view('admin.auth.login');
+    }
+
+    public function login(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'email' => ['required', 'string', 'email', 'max:255'],
+            'password' => ['required', 'string'],
+        ]);
+
+        $this->ensureIsNotRateLimited($request, $validated['email']);
+
+        $email = strtolower(trim($validated['email']));
+        $user = User::query()->where('email', $email)->first();
+
+        $reason = null;
+
+        if (! $user || ! Hash::check($validated['password'], (string) $user->password)) {
+            $reason = 'invalid_credentials';
+        } elseif (! $user->isAdminFamily()) {
+            $reason = 'not_admin';
+        } elseif (! $user->isActive()) {
+            $reason = 'account_disabled';
+        } elseif (is_null($user->email_verified_at)) {
+            $reason = 'unverified';
+        }
+
+        if ($reason !== null) {
+            RateLimiter::hit($this->throttleKey($request, $email));
+
+            $this->audit->record(
+                AdminAccountAudit::ACTION_LOGIN_FAILED,
+                actor: null,
+                target: $user,
+                metadata: [
+                    'reason' => $reason,
+                    'email_attempt_hash' => hash('sha256', $email),
+                ],
+                request: $request,
+            );
+
+            throw ValidationException::withMessages([
+                'email' => self::GENERIC_FAILURE_MESSAGE,
+            ]);
+        }
+
+        Auth::login($user, false);
+        $request->session()->regenerate();
+
+        $user->forceFill([
+            'last_admin_login_at' => now(),
+            'last_admin_login_ip' => $request->ip(),
+        ])->save();
+
+        RateLimiter::clear($this->throttleKey($request, $email));
+
+        $this->audit->record(
+            AdminAccountAudit::ACTION_LOGIN_SUCCESS,
+            actor: $user,
+            target: $user,
+            metadata: ['role' => $user->role],
+            request: $request,
+        );
+
+        return redirect()->intended(route('admin.dashboard'));
+    }
+
+    public function logout(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        if ($user) {
+            $this->audit->record(
+                AdminAccountAudit::ACTION_LOGOUT,
+                actor: $user,
+                target: $user,
+                request: $request,
+            );
+        }
+
+        return redirect()->route('admin.login');
+    }
+
+    private function ensureIsNotRateLimited(Request $request, string $email): void
+    {
+        $key = $this->throttleKey($request, $email);
+
+        if (! RateLimiter::tooManyAttempts($key, 5)) {
+            return;
+        }
+
+        event(new Lockout($request));
+
+        $seconds = RateLimiter::availableIn($key);
+
+        throw ValidationException::withMessages([
+            'email' => trans('auth.throttle', [
+                'seconds' => $seconds,
+                'minutes' => max(1, (int) ceil($seconds / 60)),
+            ]),
+        ]);
+    }
+
+    private function throttleKey(Request $request, string $email): string
+    {
+        return 'admin-login|'.Str::transliterate(Str::lower($email)).'|'.$request->ip();
+    }
+}

--- a/laravel/app/Http/Controllers/Admin/AdminPasswordChangeController.php
+++ b/laravel/app/Http/Controllers/Admin/AdminPasswordChangeController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\AdminAccountAudit;
+use App\Services\Admin\AdminAccountAuditService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
+use Illuminate\View\View;
+
+class AdminPasswordChangeController extends Controller
+{
+    public function __construct(private readonly AdminAccountAuditService $audit)
+    {
+    }
+
+    public function show(Request $request): View|RedirectResponse
+    {
+        $user = $request->user();
+
+        if (! $user || ! $user->isAdminFamily()) {
+            return redirect()->route('admin.login');
+        }
+
+        return view('admin.auth.password-change');
+    }
+
+    public function update(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        if (! $user || ! $user->isAdminFamily()) {
+            return redirect()->route('admin.login');
+        }
+
+        $validated = $request->validate([
+            'current_password' => ['required', 'string'],
+            'password' => ['required', 'string', 'confirmed', Password::defaults()],
+        ]);
+
+        if (! Hash::check($validated['current_password'], (string) $user->password)) {
+            throw ValidationException::withMessages([
+                'current_password' => __('auth.password'),
+            ]);
+        }
+
+        if (Hash::check($validated['password'], (string) $user->password)) {
+            throw ValidationException::withMessages([
+                'password' => 'Password baru tidak boleh sama dengan password sebelumnya.',
+            ]);
+        }
+
+        $user->forceFill([
+            'password' => Hash::make($validated['password']),
+            'force_password_change' => false,
+        ])->save();
+
+        $this->audit->record(
+            AdminAccountAudit::ACTION_PASSWORD_RESET,
+            actor: $user,
+            target: $user,
+            metadata: ['by' => 'self_force_change'],
+            request: $request,
+        );
+
+        return redirect()->intended(route('admin.dashboard'))
+            ->with('status', 'Password berhasil diperbarui.');
+    }
+}

--- a/laravel/app/Http/Middleware/EnsureAdminPasswordChanged.php
+++ b/laravel/app/Http/Middleware/EnsureAdminPasswordChanged.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureAdminPasswordChanged
+{
+    /**
+     * Force admin/super_admin with force_password_change=true to update password
+     * before they can use any admin route.
+     *
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user || ! method_exists($user, 'isAdminFamily') || ! $user->isAdminFamily()) {
+            return $next($request);
+        }
+
+        if (! ($user->force_password_change ?? false)) {
+            return $next($request);
+        }
+
+        // Already on the force-change route or submitting the form? Allow.
+        if ($request->routeIs('admin.password.change')
+            || $request->routeIs('admin.password.update')
+            || $request->routeIs('admin.logout')) {
+            return $next($request);
+        }
+
+        return redirect()->route('admin.password.change');
+    }
+}

--- a/laravel/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/laravel/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -4,12 +4,13 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 class EnsureUserIsAdmin
 {
     /**
-     * Allow only authenticated admin or super admin users.
+     * Allow only authenticated, active admin or super admin users.
      *
      * @param  Closure(Request): Response  $next
      */
@@ -18,11 +19,26 @@ class EnsureUserIsAdmin
         $user = $request->user();
 
         if (! $user) {
-            return redirect()->guest(route('login'));
+            return redirect()->guest(route('admin.login'));
         }
 
-        if (! method_exists($user, 'canAccessAdmin') || ! $user->canAccessAdmin()) {
-            abort(403, 'Halaman ini hanya untuk admin.');
+        if (! method_exists($user, 'isAdminFamily') || ! $user->isAdminFamily()) {
+            // Authenticated but not admin role - log out and send to admin login
+            Auth::logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            return redirect()->route('admin.login')
+                ->withErrors(['email' => 'Akun tidak memiliki akses ke admin.']);
+        }
+
+        if (method_exists($user, 'isActive') && ! $user->isActive()) {
+            Auth::logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            return redirect()->route('admin.login')
+                ->withErrors(['email' => 'Akun admin sedang dinonaktifkan.']);
         }
 
         return $next($request);

--- a/laravel/app/Http/Middleware/EnsureUserIsSuperAdmin.php
+++ b/laravel/app/Http/Middleware/EnsureUserIsSuperAdmin.php
@@ -4,12 +4,13 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 class EnsureUserIsSuperAdmin
 {
     /**
-     * Allow only authenticated super admin users.
+     * Allow only authenticated active super admin users.
      *
      * @param  Closure(Request): Response  $next
      */
@@ -18,11 +19,30 @@ class EnsureUserIsSuperAdmin
         $user = $request->user();
 
         if (! $user) {
-            return redirect()->guest(route('login'));
+            return redirect()->guest(route('admin.login'));
+        }
+
+        if (! method_exists($user, 'isAdminFamily') || ! $user->isAdminFamily()) {
+            // Regular users that somehow reach this route should be sent to admin login.
+            Auth::logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            return redirect()->route('admin.login')
+                ->withErrors(['email' => 'Akun tidak memiliki akses ke admin.']);
         }
 
         if (! method_exists($user, 'isSuperAdmin') || ! $user->isSuperAdmin()) {
             abort(403, 'Halaman ini hanya untuk super admin.');
+        }
+
+        if (method_exists($user, 'isActive') && ! $user->isActive()) {
+            Auth::logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            return redirect()->route('admin.login')
+                ->withErrors(['email' => 'Akun admin sedang dinonaktifkan.']);
         }
 
         return $next($request);

--- a/laravel/app/Livewire/Admin/AdminAccounts.php
+++ b/laravel/app/Livewire/Admin/AdminAccounts.php
@@ -141,10 +141,7 @@ class AdminAccounts extends Component
 
     public function startEdit(int $userId): void
     {
-        $user = User::query()->findOrFail($userId);
-        if (! $user->isAdminFamily()) {
-            abort(404);
-        }
+        $user = $this->resolveAdminTarget($userId);
 
         $this->editingUserId = $user->id;
         $this->editName = $user->name;
@@ -177,7 +174,7 @@ class AdminAccounts extends Component
             'editRole' => 'role',
         ]);
 
-        $target = User::query()->findOrFail($this->editingUserId);
+        $target = $this->resolveAdminTarget($this->editingUserId);
 
         try {
             $service->update(
@@ -203,7 +200,7 @@ class AdminAccounts extends Component
 
     public function activate(int $userId, AdminAccountManagementService $service): void
     {
-        $target = User::query()->findOrFail($userId);
+        $target = $this->resolveAdminTarget($userId);
 
         $service->activate(auth()->user(), $target, request());
 
@@ -212,6 +209,9 @@ class AdminAccounts extends Component
 
     public function startDeactivate(int $userId): void
     {
+        // Verify target is admin-family before opening modal.
+        $this->resolveAdminTarget($userId);
+
         $this->deactivatingUserId = $userId;
         $this->deactivateReason = '';
         $this->resetErrorBag();
@@ -229,7 +229,7 @@ class AdminAccounts extends Component
             return;
         }
 
-        $target = User::query()->findOrFail($this->deactivatingUserId);
+        $target = $this->resolveAdminTarget($this->deactivatingUserId);
 
         try {
             $service->deactivate(
@@ -251,11 +251,7 @@ class AdminAccounts extends Component
 
     public function startResetPassword(int $userId, AdminAccountManagementService $service): void
     {
-        $target = User::query()->findOrFail($userId);
-
-        if (! $target->isAdminFamily()) {
-            abort(404);
-        }
+        $target = $this->resolveAdminTarget($userId);
 
         $temporary = $service->generateTemporaryPassword();
         $service->resetPassword(auth()->user(), $target, $temporary, request());
@@ -329,5 +325,21 @@ class AdminAccounts extends Component
                 $this->addError($target, $message);
             }
         }
+    }
+
+    /**
+     * Resolve the requested user as an admin-family target.
+     * Returns 404 if the user does not exist or is a regular user, so that
+     * Livewire requests cannot be manipulated to operate on non-admin users.
+     */
+    private function resolveAdminTarget(int $userId): User
+    {
+        $user = User::query()->find($userId);
+
+        if (! $user || ! $user->isAdminFamily()) {
+            abort(404, 'Akun target bukan akun admin.');
+        }
+
+        return $user;
     }
 }

--- a/laravel/app/Livewire/Admin/AdminAccounts.php
+++ b/laravel/app/Livewire/Admin/AdminAccounts.php
@@ -1,0 +1,333 @@
+<?php
+
+namespace App\Livewire\Admin;
+
+use App\Models\User;
+use App\Services\Admin\AdminAccountManagementService;
+use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+#[Layout('layouts.admin', ['title' => 'Account Management', 'heading' => 'Account Management'])]
+class AdminAccounts extends Component
+{
+    use WithPagination;
+
+    public string $search = '';
+
+    public string $roleFilter = 'all';
+
+    public string $statusFilter = 'all';
+
+    // Create form
+    public bool $showCreateModal = false;
+
+    public string $newName = '';
+
+    public string $newEmail = '';
+
+    public string $newPassword = '';
+
+    public string $newRole = User::ROLE_ADMIN;
+
+    public bool $newForcePasswordChange = true;
+
+    // Edit form
+    public ?int $editingUserId = null;
+
+    public string $editName = '';
+
+    public string $editEmail = '';
+
+    public string $editRole = User::ROLE_ADMIN;
+
+    public bool $editForcePasswordChange = false;
+
+    // Reset password
+    public ?int $resettingUserId = null;
+
+    public ?string $generatedTemporaryPassword = null;
+
+    // Confirm deactivate
+    public ?int $deactivatingUserId = null;
+
+    public string $deactivateReason = '';
+
+    public ?string $flashMessage = null;
+
+    public ?string $flashError = null;
+
+    public function mount(): void
+    {
+        if (! auth()->user() || ! auth()->user()->isSuperAdmin() || ! auth()->user()->isActive()) {
+            abort(403, 'Hanya super admin aktif yang dapat mengakses halaman ini.');
+        }
+    }
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingRoleFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingStatusFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function openCreateModal(): void
+    {
+        $this->reset(['newName', 'newEmail', 'newPassword']);
+        $this->newRole = User::ROLE_ADMIN;
+        $this->newForcePasswordChange = true;
+        $this->resetErrorBag();
+        $this->showCreateModal = true;
+    }
+
+    public function closeCreateModal(): void
+    {
+        $this->showCreateModal = false;
+        $this->resetErrorBag();
+    }
+
+    public function generateNewPassword(AdminAccountManagementService $service): void
+    {
+        $this->newPassword = $service->generateTemporaryPassword();
+    }
+
+    public function createAccount(AdminAccountManagementService $service): void
+    {
+        $validated = $this->validate([
+            'newName' => ['required', 'string', 'max:120'],
+            'newEmail' => ['required', 'email', 'max:255'],
+            'newPassword' => ['required', 'string', 'min:8', 'max:255'],
+            'newRole' => ['required', 'in:admin,super_admin'],
+            'newForcePasswordChange' => ['boolean'],
+        ], attributes: [
+            'newName' => 'nama',
+            'newEmail' => 'email',
+            'newPassword' => 'password',
+            'newRole' => 'role',
+        ]);
+
+        try {
+            $service->create(
+                actor: auth()->user(),
+                data: [
+                    'name' => $validated['newName'],
+                    'email' => $validated['newEmail'],
+                    'password' => $validated['newPassword'],
+                    'role' => $validated['newRole'],
+                    'force_password_change' => $this->newForcePasswordChange,
+                ],
+                request: request(),
+            );
+        } catch (ValidationException $e) {
+            $this->mapServiceErrors($e, prefix: 'new');
+
+            return;
+        }
+
+        $this->showCreateModal = false;
+        $this->reset(['newName', 'newEmail', 'newPassword']);
+        $this->flashMessage = 'Akun admin berhasil dibuat.';
+    }
+
+    public function startEdit(int $userId): void
+    {
+        $user = User::query()->findOrFail($userId);
+        if (! $user->isAdminFamily()) {
+            abort(404);
+        }
+
+        $this->editingUserId = $user->id;
+        $this->editName = $user->name;
+        $this->editEmail = $user->email;
+        $this->editRole = $user->role;
+        $this->editForcePasswordChange = (bool) $user->force_password_change;
+        $this->resetErrorBag();
+    }
+
+    public function cancelEdit(): void
+    {
+        $this->editingUserId = null;
+        $this->resetErrorBag();
+    }
+
+    public function saveEdit(AdminAccountManagementService $service): void
+    {
+        if ($this->editingUserId === null) {
+            return;
+        }
+
+        $validated = $this->validate([
+            'editName' => ['required', 'string', 'max:120'],
+            'editEmail' => ['required', 'email', 'max:255'],
+            'editRole' => ['required', 'in:admin,super_admin'],
+            'editForcePasswordChange' => ['boolean'],
+        ], attributes: [
+            'editName' => 'nama',
+            'editEmail' => 'email',
+            'editRole' => 'role',
+        ]);
+
+        $target = User::query()->findOrFail($this->editingUserId);
+
+        try {
+            $service->update(
+                actor: auth()->user(),
+                target: $target,
+                data: [
+                    'name' => $validated['editName'],
+                    'email' => $validated['editEmail'],
+                    'role' => $validated['editRole'],
+                    'force_password_change' => $this->editForcePasswordChange,
+                ],
+                request: request(),
+            );
+        } catch (ValidationException $e) {
+            $this->mapServiceErrors($e, prefix: 'edit');
+
+            return;
+        }
+
+        $this->editingUserId = null;
+        $this->flashMessage = 'Akun admin berhasil diperbarui.';
+    }
+
+    public function activate(int $userId, AdminAccountManagementService $service): void
+    {
+        $target = User::query()->findOrFail($userId);
+
+        $service->activate(auth()->user(), $target, request());
+
+        $this->flashMessage = sprintf('Akun "%s" diaktifkan.', $target->email);
+    }
+
+    public function startDeactivate(int $userId): void
+    {
+        $this->deactivatingUserId = $userId;
+        $this->deactivateReason = '';
+        $this->resetErrorBag();
+    }
+
+    public function cancelDeactivate(): void
+    {
+        $this->deactivatingUserId = null;
+        $this->deactivateReason = '';
+    }
+
+    public function confirmDeactivate(AdminAccountManagementService $service): void
+    {
+        if ($this->deactivatingUserId === null) {
+            return;
+        }
+
+        $target = User::query()->findOrFail($this->deactivatingUserId);
+
+        try {
+            $service->deactivate(
+                actor: auth()->user(),
+                target: $target,
+                reason: $this->deactivateReason ?: null,
+                request: request(),
+            );
+        } catch (ValidationException $e) {
+            $this->flashError = $e->validator->errors()->first();
+            $this->deactivatingUserId = null;
+
+            return;
+        }
+
+        $this->deactivatingUserId = null;
+        $this->flashMessage = sprintf('Akun "%s" dinonaktifkan.', $target->email);
+    }
+
+    public function startResetPassword(int $userId, AdminAccountManagementService $service): void
+    {
+        $target = User::query()->findOrFail($userId);
+
+        if (! $target->isAdminFamily()) {
+            abort(404);
+        }
+
+        $temporary = $service->generateTemporaryPassword();
+        $service->resetPassword(auth()->user(), $target, $temporary, request());
+
+        $this->resettingUserId = $target->id;
+        $this->generatedTemporaryPassword = $temporary;
+        $this->flashMessage = sprintf('Password sementara untuk "%s" berhasil dibuat.', $target->email);
+    }
+
+    public function dismissTemporaryPassword(): void
+    {
+        $this->resettingUserId = null;
+        $this->generatedTemporaryPassword = null;
+    }
+
+    public function clearFlash(): void
+    {
+        $this->flashMessage = null;
+        $this->flashError = null;
+    }
+
+    public function render(AdminAccountManagementService $service)
+    {
+        $query = $service->adminAccountsQuery();
+
+        if ($this->search !== '') {
+            $term = '%'.trim($this->search).'%';
+            $query->where(function ($q) use ($term) {
+                $q->where('email', 'like', $term)
+                    ->orWhere('name', 'like', $term);
+            });
+        }
+
+        if ($this->roleFilter !== 'all' && in_array($this->roleFilter, [User::ROLE_ADMIN, User::ROLE_SUPER_ADMIN], true)) {
+            $query->where('role', $this->roleFilter);
+        }
+
+        if ($this->statusFilter === 'active') {
+            $query->where('is_active', true);
+        } elseif ($this->statusFilter === 'inactive') {
+            $query->where('is_active', false);
+        }
+
+        $accounts = $query->paginate(15);
+
+        return view('livewire.admin.admin-accounts', [
+            'accounts' => $accounts,
+            'totalActiveSuperAdmins' => $service->activeSuperAdminsCount(),
+        ]);
+    }
+
+    /**
+     * Map errors thrown by the service into the appropriate prefixed property names.
+     */
+    private function mapServiceErrors(ValidationException $exception, string $prefix): void
+    {
+        $errors = $exception->validator->errors();
+
+        $map = [
+            'name' => $prefix.'Name',
+            'email' => $prefix.'Email',
+            'password' => $prefix.'Password',
+            'role' => $prefix.'Role',
+            'is_active' => $prefix.'Active',
+            'force_password_change' => $prefix.'ForcePasswordChange',
+        ];
+
+        foreach ($errors->messages() as $field => $messages) {
+            $target = $map[$field] ?? $field;
+            foreach ((array) $messages as $message) {
+                $this->addError($target, $message);
+            }
+        }
+    }
+}

--- a/laravel/app/Models/AdminAccountAudit.php
+++ b/laravel/app/Models/AdminAccountAudit.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AdminAccountAudit extends Model
+{
+    use HasFactory;
+
+    public const ACTION_LOGIN_SUCCESS = 'admin_login_success';
+
+    public const ACTION_LOGIN_FAILED = 'admin_login_failed';
+
+    public const ACTION_LOGOUT = 'admin_logout';
+
+    public const ACTION_CREATED = 'admin_created';
+
+    public const ACTION_UPDATED = 'admin_updated';
+
+    public const ACTION_ACTIVATED = 'admin_activated';
+
+    public const ACTION_DEACTIVATED = 'admin_deactivated';
+
+    public const ACTION_PASSWORD_RESET = 'admin_password_reset';
+
+    public const ACTION_ROLE_CHANGED = 'admin_role_changed';
+
+    protected $fillable = [
+        'actor_id',
+        'target_user_id',
+        'action',
+        'ip_address',
+        'user_agent',
+        'before_snapshot',
+        'after_snapshot',
+        'metadata',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'before_snapshot' => 'array',
+            'after_snapshot' => 'array',
+            'metadata' => 'array',
+        ];
+    }
+
+    public function actor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'actor_id');
+    }
+
+    public function targetUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'target_user_id');
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -42,6 +42,13 @@ class User extends Authenticatable implements MustVerifyEmail
         'role',
         'last_seen_at',
         'last_active_feature',
+        'is_active',
+        'disabled_at',
+        'disabled_by',
+        'disabled_reason',
+        'force_password_change',
+        'last_admin_login_at',
+        'last_admin_login_ip',
     ];
 
     /**
@@ -60,6 +67,10 @@ class User extends Authenticatable implements MustVerifyEmail
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'last_seen_at' => 'datetime',
+            'is_active' => 'boolean',
+            'disabled_at' => 'datetime',
+            'force_password_change' => 'boolean',
+            'last_admin_login_at' => 'datetime',
         ];
     }
 
@@ -84,7 +95,39 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function canAccessAdmin(): bool
     {
+        return ($this->isAdmin() || $this->isSuperAdmin()) && $this->isActive();
+    }
+
+    /**
+     * Determine whether the user account is considered active.
+     */
+    public function isActive(): bool
+    {
+        return (bool) ($this->is_active ?? true);
+    }
+
+    /**
+     * Determine whether the user is part of the admin family (admin or super admin).
+     */
+    public function isAdminFamily(): bool
+    {
         return $this->isAdmin() || $this->isSuperAdmin();
+    }
+
+    /**
+     * Audit log entries where this user is the actor.
+     */
+    public function adminAuditActions()
+    {
+        return $this->hasMany(AdminAccountAudit::class, 'actor_id');
+    }
+
+    /**
+     * Audit log entries where this user is the target.
+     */
+    public function adminAuditTargets()
+    {
+        return $this->hasMany(AdminAccountAudit::class, 'target_user_id');
     }
 
     /**

--- a/laravel/app/Services/Admin/AdminAccountAuditService.php
+++ b/laravel/app/Services/Admin/AdminAccountAuditService.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Services\Admin;
+
+use App\Models\AdminAccountAudit;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class AdminAccountAuditService
+{
+    /**
+     * Record an admin audit log entry. Never persists secrets such as passwords.
+     */
+    public function record(
+        string $action,
+        ?User $actor = null,
+        ?User $target = null,
+        ?array $before = null,
+        ?array $after = null,
+        ?array $metadata = null,
+        ?Request $request = null,
+    ): ?AdminAccountAudit {
+        $request ??= request();
+
+        try {
+            return AdminAccountAudit::create([
+                'actor_id' => $actor?->getKey(),
+                'target_user_id' => $target?->getKey(),
+                'action' => $action,
+                'ip_address' => $request?->ip(),
+                'user_agent' => substr((string) ($request?->userAgent() ?? ''), 0, 512) ?: null,
+                'before_snapshot' => $before ? $this->sanitize($before) : null,
+                'after_snapshot' => $after ? $this->sanitize($after) : null,
+                'metadata' => $metadata ? $this->sanitize($metadata) : null,
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('Failed to write admin account audit', [
+                'action' => $action,
+                'message' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Strip sensitive keys from snapshots/metadata.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function sanitize(array $payload): array
+    {
+        $sensitive = ['password', 'remember_token', 'verification_code', 'token'];
+
+        return collect($payload)
+            ->reject(fn ($value, $key) => in_array(strtolower((string) $key), $sensitive, true))
+            ->all();
+    }
+
+    /**
+     * Build a snapshot of an admin user with audit-safe fields.
+     *
+     * @return array<string, mixed>
+     */
+    public function snapshot(User $user): array
+    {
+        return [
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'role' => $user->role,
+            'is_active' => (bool) $user->is_active,
+            'force_password_change' => (bool) $user->force_password_change,
+        ];
+    }
+}

--- a/laravel/app/Services/Admin/AdminAccountManagementService.php
+++ b/laravel/app/Services/Admin/AdminAccountManagementService.php
@@ -81,6 +81,7 @@ class AdminAccountManagementService
     public function update(User $actor, User $target, array $data, ?Request $request = null): User
     {
         $this->guardActorIsSuperAdmin($actor);
+        $this->guardTargetIsAdminFamily($target);
 
         return DB::transaction(function () use ($actor, $target, $data, $request) {
             $before = $this->audit->snapshot($target);
@@ -158,6 +159,7 @@ class AdminAccountManagementService
     public function activate(User $actor, User $target, ?Request $request = null): User
     {
         $this->guardActorIsSuperAdmin($actor);
+        $this->guardTargetIsAdminFamily($target);
 
         if ($target->is_active) {
             return $target;
@@ -190,6 +192,7 @@ class AdminAccountManagementService
     public function deactivate(User $actor, User $target, ?string $reason = null, ?Request $request = null): User
     {
         $this->guardActorIsSuperAdmin($actor);
+        $this->guardTargetIsAdminFamily($target);
 
         if ($target->isAdminFamily() && $target->id === $actor->id) {
             throw ValidationException::withMessages([
@@ -233,6 +236,7 @@ class AdminAccountManagementService
     public function resetPassword(User $actor, User $target, string $temporaryPassword, ?Request $request = null): User
     {
         $this->guardActorIsSuperAdmin($actor);
+        $this->guardTargetIsAdminFamily($target);
 
         if (strlen($temporaryPassword) < 8) {
             throw ValidationException::withMessages([
@@ -293,6 +297,21 @@ class AdminAccountManagementService
                 'role' => $actor->role,
             ]);
             abort(403, 'Hanya super admin aktif yang dapat mengelola akun admin.');
+        }
+    }
+
+    /**
+     * Refuse operations whose target is not part of the admin family.
+     * Account management routes must never alter regular users.
+     */
+    private function guardTargetIsAdminFamily(User $target): void
+    {
+        if (! $target->isAdminFamily()) {
+            Log::warning('Account management attempted on non-admin target', [
+                'target_id' => $target->id,
+                'role' => $target->role,
+            ]);
+            abort(404, 'Akun target bukan akun admin.');
         }
     }
 

--- a/laravel/app/Services/Admin/AdminAccountManagementService.php
+++ b/laravel/app/Services/Admin/AdminAccountManagementService.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace App\Services\Admin;
+
+use App\Models\AdminAccountAudit;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class AdminAccountManagementService
+{
+    public function __construct(private readonly AdminAccountAuditService $audit)
+    {
+    }
+
+    /**
+     * Create a new admin or super admin account.
+     */
+    public function create(User $actor, array $data, ?Request $request = null): User
+    {
+        $this->guardActorIsSuperAdmin($actor);
+
+        $role = $this->normalizeRole($data['role'] ?? null);
+        $email = strtolower(trim((string) ($data['email'] ?? '')));
+        $name = trim((string) ($data['name'] ?? ''));
+        $password = (string) ($data['password'] ?? '');
+
+        if ($email === '' || $name === '' || $password === '') {
+            throw ValidationException::withMessages([
+                'name' => 'Nama wajib diisi.',
+                'email' => 'Email wajib diisi.',
+                'password' => 'Password wajib diisi.',
+            ]);
+        }
+
+        if (strlen($password) < 8) {
+            throw ValidationException::withMessages([
+                'password' => 'Password minimal 8 karakter.',
+            ]);
+        }
+
+        if (User::query()->where('email', $email)->exists()) {
+            throw ValidationException::withMessages([
+                'email' => 'Email sudah digunakan.',
+            ]);
+        }
+
+        return DB::transaction(function () use ($actor, $name, $email, $password, $role, $data, $request) {
+            $user = User::create([
+                'name' => $name,
+                'email' => $email,
+                'password' => Hash::make($password),
+                'email_verified_at' => now(),
+                'role' => $role,
+                'is_active' => true,
+                'force_password_change' => (bool) ($data['force_password_change'] ?? true),
+            ]);
+
+            $this->audit->record(
+                AdminAccountAudit::ACTION_CREATED,
+                actor: $actor,
+                target: $user,
+                after: $this->audit->snapshot($user),
+                metadata: ['role' => $role],
+                request: $request,
+            );
+
+            return $user;
+        });
+    }
+
+    /**
+     * Update an admin account name, email, role, force_password_change, and active status.
+     */
+    public function update(User $actor, User $target, array $data, ?Request $request = null): User
+    {
+        $this->guardActorIsSuperAdmin($actor);
+
+        return DB::transaction(function () use ($actor, $target, $data, $request) {
+            $before = $this->audit->snapshot($target);
+            $target->refresh();
+
+            $newName = isset($data['name']) ? trim((string) $data['name']) : $target->name;
+            $newEmail = isset($data['email']) ? strtolower(trim((string) $data['email'])) : $target->email;
+            $newRole = isset($data['role']) ? $this->normalizeRole($data['role']) : $target->role;
+            $forcePwd = array_key_exists('force_password_change', $data)
+                ? (bool) $data['force_password_change']
+                : (bool) $target->force_password_change;
+
+            if ($newName === '') {
+                throw ValidationException::withMessages([
+                    'name' => 'Nama wajib diisi.',
+                ]);
+            }
+
+            if (! filter_var($newEmail, FILTER_VALIDATE_EMAIL)) {
+                throw ValidationException::withMessages([
+                    'email' => 'Email tidak valid.',
+                ]);
+            }
+
+            if ($newEmail !== $target->email
+                && User::query()->where('email', $newEmail)->where('id', '!=', $target->id)->exists()) {
+                throw ValidationException::withMessages([
+                    'email' => 'Email sudah digunakan akun lain.',
+                ]);
+            }
+
+            // If we are changing role from super_admin to admin, ensure another active super admin exists.
+            if ($target->role === User::ROLE_SUPER_ADMIN && $newRole !== User::ROLE_SUPER_ADMIN) {
+                $this->guardLastSuperAdmin($target);
+            }
+
+            $roleChanged = $newRole !== $target->role;
+
+            $target->forceFill([
+                'name' => $newName,
+                'email' => $newEmail,
+                'role' => $newRole,
+                'force_password_change' => $forcePwd,
+            ])->save();
+
+            $after = $this->audit->snapshot($target);
+
+            $this->audit->record(
+                AdminAccountAudit::ACTION_UPDATED,
+                actor: $actor,
+                target: $target,
+                before: $before,
+                after: $after,
+                request: $request,
+            );
+
+            if ($roleChanged) {
+                $this->audit->record(
+                    AdminAccountAudit::ACTION_ROLE_CHANGED,
+                    actor: $actor,
+                    target: $target,
+                    before: ['role' => $before['role']],
+                    after: ['role' => $after['role']],
+                    request: $request,
+                );
+            }
+
+            return $target;
+        });
+    }
+
+    /**
+     * Activate an admin account.
+     */
+    public function activate(User $actor, User $target, ?Request $request = null): User
+    {
+        $this->guardActorIsSuperAdmin($actor);
+
+        if ($target->is_active) {
+            return $target;
+        }
+
+        $before = $this->audit->snapshot($target);
+
+        $target->forceFill([
+            'is_active' => true,
+            'disabled_at' => null,
+            'disabled_by' => null,
+            'disabled_reason' => null,
+        ])->save();
+
+        $this->audit->record(
+            AdminAccountAudit::ACTION_ACTIVATED,
+            actor: $actor,
+            target: $target,
+            before: $before,
+            after: $this->audit->snapshot($target),
+            request: $request,
+        );
+
+        return $target;
+    }
+
+    /**
+     * Deactivate an admin account, blocking access.
+     */
+    public function deactivate(User $actor, User $target, ?string $reason = null, ?Request $request = null): User
+    {
+        $this->guardActorIsSuperAdmin($actor);
+
+        if ($target->isAdminFamily() && $target->id === $actor->id) {
+            throw ValidationException::withMessages([
+                'is_active' => 'Tidak dapat menonaktifkan akun sendiri.',
+            ]);
+        }
+
+        if ($target->isSuperAdmin() && $target->is_active) {
+            $this->guardLastSuperAdmin($target);
+        }
+
+        if (! $target->is_active) {
+            return $target;
+        }
+
+        $before = $this->audit->snapshot($target);
+
+        $target->forceFill([
+            'is_active' => false,
+            'disabled_at' => now(),
+            'disabled_by' => $actor->id,
+            'disabled_reason' => $reason ? Str::limit((string) $reason, 250, '') : null,
+        ])->save();
+
+        $this->audit->record(
+            AdminAccountAudit::ACTION_DEACTIVATED,
+            actor: $actor,
+            target: $target,
+            before: $before,
+            after: $this->audit->snapshot($target),
+            metadata: ['reason' => $reason],
+            request: $request,
+        );
+
+        return $target;
+    }
+
+    /**
+     * Reset password to a temporary value, marks force_password_change=true.
+     */
+    public function resetPassword(User $actor, User $target, string $temporaryPassword, ?Request $request = null): User
+    {
+        $this->guardActorIsSuperAdmin($actor);
+
+        if (strlen($temporaryPassword) < 8) {
+            throw ValidationException::withMessages([
+                'password' => 'Password sementara minimal 8 karakter.',
+            ]);
+        }
+
+        $target->forceFill([
+            'password' => Hash::make($temporaryPassword),
+            'force_password_change' => true,
+        ])->save();
+
+        $this->audit->record(
+            AdminAccountAudit::ACTION_PASSWORD_RESET,
+            actor: $actor,
+            target: $target,
+            metadata: ['by' => $actor->email],
+            request: $request,
+        );
+
+        return $target;
+    }
+
+    public function adminAccountsQuery(): Builder
+    {
+        return User::query()
+            ->whereIn('role', [User::ROLE_ADMIN, User::ROLE_SUPER_ADMIN])
+            ->orderByDesc('id');
+    }
+
+    public function activeSuperAdminsCount(?int $excludeUserId = null): int
+    {
+        $query = User::query()
+            ->where('role', User::ROLE_SUPER_ADMIN)
+            ->where('is_active', true);
+
+        if ($excludeUserId !== null) {
+            $query->where('id', '!=', $excludeUserId);
+        }
+
+        return $query->count();
+    }
+
+    private function guardLastSuperAdmin(User $target): void
+    {
+        if ($this->activeSuperAdminsCount($target->id) === 0) {
+            throw ValidationException::withMessages([
+                'role' => 'Tidak dapat menonaktifkan atau menurunkan super admin terakhir.',
+            ]);
+        }
+    }
+
+    private function guardActorIsSuperAdmin(User $actor): void
+    {
+        if (! $actor->isSuperAdmin() || ! $actor->isActive()) {
+            Log::warning('Non super admin attempted admin account management', [
+                'actor_id' => $actor->id,
+                'role' => $actor->role,
+            ]);
+            abort(403, 'Hanya super admin aktif yang dapat mengelola akun admin.');
+        }
+    }
+
+    private function normalizeRole(?string $role): string
+    {
+        $role = $role ?? User::ROLE_ADMIN;
+
+        if (! in_array($role, [User::ROLE_ADMIN, User::ROLE_SUPER_ADMIN], true)) {
+            throw ValidationException::withMessages([
+                'role' => 'Role tidak valid.',
+            ]);
+        }
+
+        return $role;
+    }
+
+    /**
+     * Generate a cryptographically secure temporary password.
+     */
+    public function generateTemporaryPassword(int $length = 14): string
+    {
+        $alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789';
+        $max = strlen($alphabet) - 1;
+        $password = '';
+
+        for ($i = 0; $i < $length; $i++) {
+            $password .= $alphabet[random_int(0, $max)];
+        }
+
+        return $password;
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\AddSecurityHeaders;
+use App\Http\Middleware\EnsureAdminPasswordChanged;
 use App\Http\Middleware\EnsureUserIsAdmin;
 use App\Http\Middleware\EnsureUserIsSuperAdmin;
 use App\Http\Middleware\UpdateUserPresence;
@@ -32,6 +33,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'admin' => EnsureUserIsAdmin::class,
             'super_admin' => EnsureUserIsSuperAdmin::class,
+            'admin.password_changed' => EnsureAdminPasswordChanged::class,
             'presence' => UpdateUserPresence::class,
         ]);
 

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -35,6 +35,14 @@ return Application::configure(basePath: dirname(__DIR__))
             'presence' => UpdateUserPresence::class,
         ]);
 
+        $middleware->redirectGuestsTo(function (Request $request) {
+            if ($request->is('admin') || $request->is('admin/*')) {
+                return route('admin.login');
+            }
+
+            return route('login');
+        });
+
         $middleware->appendToGroup('web', UpdateUserPresence::class);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/laravel/database/migrations/2026_05_18_120000_add_admin_security_columns_to_users_table.php
+++ b/laravel/database/migrations/2026_05_18_120000_add_admin_security_columns_to_users_table.php
@@ -1,0 +1,85 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (! Schema::hasColumn('users', 'is_active')) {
+                $table->boolean('is_active')->default(true)->after('role');
+                $table->index('is_active');
+            }
+
+            if (! Schema::hasColumn('users', 'disabled_at')) {
+                $table->timestamp('disabled_at')->nullable()->after('is_active');
+            }
+
+            if (! Schema::hasColumn('users', 'disabled_by')) {
+                $table->unsignedBigInteger('disabled_by')->nullable()->after('disabled_at');
+                $table->foreign('disabled_by')
+                    ->references('id')
+                    ->on('users')
+                    ->nullOnDelete();
+            }
+
+            if (! Schema::hasColumn('users', 'disabled_reason')) {
+                $table->string('disabled_reason')->nullable()->after('disabled_by');
+            }
+
+            if (! Schema::hasColumn('users', 'force_password_change')) {
+                $table->boolean('force_password_change')->default(false)->after('disabled_reason');
+            }
+
+            if (! Schema::hasColumn('users', 'last_admin_login_at')) {
+                $table->timestamp('last_admin_login_at')->nullable()->after('force_password_change');
+            }
+
+            if (! Schema::hasColumn('users', 'last_admin_login_ip')) {
+                $table->string('last_admin_login_ip', 45)->nullable()->after('last_admin_login_at');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'last_admin_login_ip')) {
+                $table->dropColumn('last_admin_login_ip');
+            }
+
+            if (Schema::hasColumn('users', 'last_admin_login_at')) {
+                $table->dropColumn('last_admin_login_at');
+            }
+
+            if (Schema::hasColumn('users', 'force_password_change')) {
+                $table->dropColumn('force_password_change');
+            }
+
+            if (Schema::hasColumn('users', 'disabled_reason')) {
+                $table->dropColumn('disabled_reason');
+            }
+
+            if (Schema::hasColumn('users', 'disabled_by')) {
+                try {
+                    $table->dropForeign(['disabled_by']);
+                } catch (\Throwable $e) {
+                    // ignore if foreign key does not exist
+                }
+                $table->dropColumn('disabled_by');
+            }
+
+            if (Schema::hasColumn('users', 'disabled_at')) {
+                $table->dropColumn('disabled_at');
+            }
+
+            if (Schema::hasColumn('users', 'is_active')) {
+                $table->dropIndex(['is_active']);
+                $table->dropColumn('is_active');
+            }
+        });
+    }
+};

--- a/laravel/database/migrations/2026_05_18_120100_create_admin_account_audits_table.php
+++ b/laravel/database/migrations/2026_05_18_120100_create_admin_account_audits_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('admin_account_audits', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('actor_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('target_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('action', 64)->index();
+            $table->string('ip_address', 45)->nullable();
+            $table->string('user_agent', 512)->nullable();
+            $table->json('before_snapshot')->nullable();
+            $table->json('after_snapshot')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index('created_at');
+            $table->index(['target_user_id', 'action']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('admin_account_audits');
+    }
+};

--- a/laravel/resources/views/admin/auth/login.blade.php
+++ b/laravel/resources/views/admin/auth/login.blade.php
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}"
+      x-data="{ darkMode: localStorage.getItem('theme') === 'dark' }"
+      x-init="$watch('darkMode', value => { localStorage.setItem('theme', value ? 'dark' : 'light'); document.documentElement.classList.toggle('dark', value); })"
+      :class="{ 'dark': darkMode }">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <meta name="robots" content="noindex,nofollow">
+
+    <title>Admin Login · ISTA AI</title>
+
+    <link rel="icon" type="image/png" href="{{ asset('images/ista/logo.png') }}">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+    <script>
+        if (localStorage.theme === 'dark') {
+            document.documentElement.classList.add('dark');
+        } else {
+            document.documentElement.classList.remove('dark');
+        }
+    </script>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="ista-shell ista-display-sans min-h-screen bg-[#fafaf9] text-stone-800 transition-colors duration-300 dark:bg-gray-950 dark:text-gray-100">
+    <div class="relative flex min-h-screen w-full items-center justify-center overflow-hidden px-4 py-10">
+        <div aria-hidden="true" class="pointer-events-none absolute inset-0 -z-10">
+            <div class="absolute -top-40 -left-40 h-[26rem] w-[26rem] rounded-full bg-ista-primary/[0.08] blur-3xl dark:bg-ista-primary/10"></div>
+            <div class="absolute -bottom-40 -right-32 h-[28rem] w-[28rem] rounded-full bg-ista-gold/[0.08] blur-3xl dark:bg-amber-500/10"></div>
+        </div>
+
+        <div class="absolute right-4 top-4 sm:right-6 sm:top-6">
+            <button type="button"
+                    @click="darkMode = !darkMode"
+                    class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-stone-200 bg-white text-stone-500 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-ista-primary/40 dark:hover:text-amber-300"
+                    aria-label="Toggle dark mode">
+                <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />
+                </svg>
+                <svg x-show="darkMode === true" style="display: none;" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z" />
+                </svg>
+            </button>
+        </div>
+
+        <main class="relative w-full max-w-md">
+            <div class="mb-6 flex flex-col items-center text-center">
+                <a href="{{ route('admin.login') }}" class="flex items-center gap-3">
+                    <img src="{{ asset('images/ista/logo.png') }}" alt="ISTA AI" class="h-10 w-10 object-contain">
+                    <span class="ista-brand-title text-2xl text-ista-primary not-italic dark:text-amber-200">
+                        ISTA <span class="font-light italic text-ista-gold dark:text-amber-300">AI</span>
+                    </span>
+                </a>
+                <p class="mt-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-400 dark:text-gray-500">Admin Console</p>
+                <h1 class="mt-2 text-2xl font-semibold text-stone-900 dark:text-gray-50">Login Admin</h1>
+                <p class="mt-2 max-w-sm text-sm leading-relaxed text-stone-500 dark:text-gray-400">
+                    Akses terbatas untuk administrator yang berwenang. Aktivitas login dicatat untuk keperluan audit.
+                </p>
+            </div>
+
+            <section class="rounded-2xl border border-stone-200 bg-white/95 p-6 shadow-sm backdrop-blur dark:border-gray-800 dark:bg-gray-900/80 sm:p-8">
+                @if ($errors->any())
+                    <div role="alert" class="mb-5 rounded-lg border border-rose-200 bg-rose-50/80 p-3 text-sm text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-200">
+                        {{ $errors->first() }}
+                    </div>
+                @endif
+
+                @if (session('status'))
+                    <div class="mb-5 rounded-lg border border-emerald-200 bg-emerald-50/80 p-3 text-sm text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-200">
+                        {{ session('status') }}
+                    </div>
+                @endif
+
+                <form method="POST" action="{{ route('admin.login.attempt') }}" class="space-y-4" novalidate>
+                    @csrf
+
+                    <div>
+                        <label for="admin-email" class="block text-[11px] font-semibold uppercase tracking-[0.16em] text-stone-500 dark:text-gray-400">Email</label>
+                        <input id="admin-email"
+                               type="email"
+                               name="email"
+                               value="{{ old('email') }}"
+                               autocomplete="username"
+                               required
+                               class="mt-2 w-full rounded-lg border border-stone-300 bg-white px-3 py-2.5 text-sm font-medium text-stone-800 shadow-[inset_0_1px_0_rgba(28,25,23,0.03)] transition placeholder:text-stone-400 focus:border-ista-primary focus:outline-none focus:ring-2 focus:ring-ista-primary/15 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500"
+                               placeholder="admin@instansi.go.id">
+                    </div>
+
+                    <div>
+                        <label for="admin-password" class="block text-[11px] font-semibold uppercase tracking-[0.16em] text-stone-500 dark:text-gray-400">Password</label>
+                        <input id="admin-password"
+                               type="password"
+                               name="password"
+                               autocomplete="current-password"
+                               required
+                               class="mt-2 w-full rounded-lg border border-stone-300 bg-white px-3 py-2.5 text-sm font-medium text-stone-800 shadow-[inset_0_1px_0_rgba(28,25,23,0.03)] transition placeholder:text-stone-400 focus:border-ista-primary focus:outline-none focus:ring-2 focus:ring-ista-primary/15 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500"
+                               placeholder="••••••••">
+                    </div>
+
+                    <button type="submit"
+                            class="inline-flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-ista-primary px-4 text-sm font-semibold uppercase tracking-wider text-amber-300 shadow-sm transition hover:bg-stone-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/40 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M11 16l-4-4m0 0l4-4m-4 4h12m-4 8h2a2 2 0 002-2V6a2 2 0 00-2-2h-2"/>
+                        </svg>
+                        Masuk ke Admin
+                    </button>
+                </form>
+
+                <p class="mt-5 text-center text-[11px] uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">
+                    Halaman terbatas. Bukan untuk pendaftaran publik.
+                </p>
+            </section>
+
+            <p class="mt-6 text-center text-[11px] text-stone-400 dark:text-gray-500">
+                © {{ date('Y') }} ISTA AI · Akses admin diawasi dan dicatat.
+            </p>
+        </main>
+    </div>
+</body>
+</html>

--- a/laravel/resources/views/admin/auth/password-change.blade.php
+++ b/laravel/resources/views/admin/auth/password-change.blade.php
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}"
+      x-data="{ darkMode: localStorage.getItem('theme') === 'dark' }"
+      x-init="$watch('darkMode', value => { localStorage.setItem('theme', value ? 'dark' : 'light'); document.documentElement.classList.toggle('dark', value); })"
+      :class="{ 'dark': darkMode }">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <meta name="robots" content="noindex,nofollow">
+
+    <title>Ganti Password Admin · ISTA AI</title>
+
+    <link rel="icon" type="image/png" href="{{ asset('images/ista/logo.png') }}">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+    <script>
+        if (localStorage.theme === 'dark') {
+            document.documentElement.classList.add('dark');
+        } else {
+            document.documentElement.classList.remove('dark');
+        }
+    </script>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="ista-shell ista-display-sans min-h-screen bg-[#fafaf9] text-stone-800 transition-colors duration-300 dark:bg-gray-950 dark:text-gray-100">
+    <div class="relative flex min-h-screen w-full items-center justify-center overflow-hidden px-4 py-10">
+        <div aria-hidden="true" class="pointer-events-none absolute inset-0 -z-10">
+            <div class="absolute -top-40 -left-40 h-[26rem] w-[26rem] rounded-full bg-ista-primary/[0.08] blur-3xl dark:bg-ista-primary/10"></div>
+            <div class="absolute -bottom-40 -right-32 h-[28rem] w-[28rem] rounded-full bg-ista-gold/[0.08] blur-3xl dark:bg-amber-500/10"></div>
+        </div>
+
+        <main class="relative w-full max-w-md">
+            <div class="mb-6 flex flex-col items-center text-center">
+                <a href="{{ route('admin.dashboard') }}" class="flex items-center gap-3">
+                    <img src="{{ asset('images/ista/logo.png') }}" alt="ISTA AI" class="h-10 w-10 object-contain">
+                    <span class="ista-brand-title text-2xl text-ista-primary not-italic dark:text-amber-200">
+                        ISTA <span class="font-light italic text-ista-gold dark:text-amber-300">AI</span>
+                    </span>
+                </a>
+                <p class="mt-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-400 dark:text-gray-500">Admin Console</p>
+                <h1 class="mt-2 text-2xl font-semibold text-stone-900 dark:text-gray-50">Wajib Ganti Password</h1>
+                <p class="mt-2 max-w-sm text-sm leading-relaxed text-stone-500 dark:text-gray-400">
+                    Akun ini menggunakan password sementara. Buat password baru sebelum melanjutkan ke admin dashboard.
+                </p>
+            </div>
+
+            <section class="rounded-2xl border border-stone-200 bg-white/95 p-6 shadow-sm backdrop-blur dark:border-gray-800 dark:bg-gray-900/80 sm:p-8">
+                @if ($errors->any())
+                    <div role="alert" class="mb-5 rounded-lg border border-rose-200 bg-rose-50/80 p-3 text-sm text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-200">
+                        <ul class="list-disc pl-5 space-y-1">
+                            @foreach ($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
+                <form method="POST" action="{{ route('admin.password.update') }}" class="space-y-4" novalidate>
+                    @csrf
+
+                    <div>
+                        <label for="current_password" class="block text-[11px] font-semibold uppercase tracking-[0.16em] text-stone-500 dark:text-gray-400">Password Saat Ini</label>
+                        <input id="current_password"
+                               type="password"
+                               name="current_password"
+                               autocomplete="current-password"
+                               required
+                               class="mt-2 w-full rounded-lg border border-stone-300 bg-white px-3 py-2.5 text-sm font-medium text-stone-800 shadow-[inset_0_1px_0_rgba(28,25,23,0.03)] transition placeholder:text-stone-400 focus:border-ista-primary focus:outline-none focus:ring-2 focus:ring-ista-primary/15 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500"
+                               placeholder="Password sementara">
+                    </div>
+
+                    <div>
+                        <label for="password" class="block text-[11px] font-semibold uppercase tracking-[0.16em] text-stone-500 dark:text-gray-400">Password Baru</label>
+                        <input id="password"
+                               type="password"
+                               name="password"
+                               autocomplete="new-password"
+                               required
+                               class="mt-2 w-full rounded-lg border border-stone-300 bg-white px-3 py-2.5 text-sm font-medium text-stone-800 shadow-[inset_0_1px_0_rgba(28,25,23,0.03)] transition placeholder:text-stone-400 focus:border-ista-primary focus:outline-none focus:ring-2 focus:ring-ista-primary/15 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500"
+                               placeholder="Minimal 8 karakter">
+                    </div>
+
+                    <div>
+                        <label for="password_confirmation" class="block text-[11px] font-semibold uppercase tracking-[0.16em] text-stone-500 dark:text-gray-400">Konfirmasi Password Baru</label>
+                        <input id="password_confirmation"
+                               type="password"
+                               name="password_confirmation"
+                               autocomplete="new-password"
+                               required
+                               class="mt-2 w-full rounded-lg border border-stone-300 bg-white px-3 py-2.5 text-sm font-medium text-stone-800 shadow-[inset_0_1px_0_rgba(28,25,23,0.03)] transition placeholder:text-stone-400 focus:border-ista-primary focus:outline-none focus:ring-2 focus:ring-ista-primary/15 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500"
+                               placeholder="Ulangi password baru">
+                    </div>
+
+                    <button type="submit"
+                            class="inline-flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-ista-primary px-4 text-sm font-semibold uppercase tracking-wider text-amber-300 shadow-sm transition hover:bg-stone-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/40 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900">
+                        Simpan Password Baru
+                    </button>
+                </form>
+
+                <form method="POST" action="{{ route('admin.logout') }}" class="mt-4 text-center">
+                    @csrf
+                    <button type="submit" class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 transition hover:text-rose-600 dark:text-gray-500 dark:hover:text-rose-300">
+                        Keluar
+                    </button>
+                </form>
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/laravel/resources/views/components/admin/sidebar.blade.php
+++ b/laravel/resources/views/components/admin/sidebar.blade.php
@@ -40,6 +40,14 @@
 
     if ($user && method_exists($user, 'isSuperAdmin') && $user->isSuperAdmin()) {
         $items[] = [
+            'label' => 'Account Management',
+            'description' => 'Kelola akun admin',
+            'route' => 'admin.accounts',
+            'icon' => 'M12 11c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v3h16v-3c0-2.66-5.33-4-8-4z',
+            'visible' => true,
+        ];
+
+        $items[] = [
             'label' => 'AI Configuration',
             'description' => 'Hanya super admin',
             'route' => 'admin.ai-config',

--- a/laravel/resources/views/components/layouts/admin.blade.php
+++ b/laravel/resources/views/components/layouts/admin.blade.php
@@ -83,6 +83,17 @@
                         </svg>
                         Kembali ke Chat
                     </a>
+                    <form method="POST" action="{{ route('admin.logout') }}" class="inline-flex">
+                        @csrf
+                        <button type="submit"
+                                class="inline-flex h-10 items-center gap-2 rounded-lg border border-stone-200 bg-white px-3 text-xs font-semibold uppercase tracking-wider text-stone-600 transition hover:border-rose-400/40 hover:text-rose-600 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-rose-400/40 dark:hover:text-rose-300"
+                                aria-label="Keluar dari admin">
+                            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
+                            </svg>
+                            <span class="hidden sm:inline">Logout</span>
+                        </button>
+                    </form>
                     <livewire:dashboard-nav-profile />
                 </div>
             </header>

--- a/laravel/resources/views/layouts/admin.blade.php
+++ b/laravel/resources/views/layouts/admin.blade.php
@@ -83,6 +83,17 @@
                         </svg>
                         Kembali ke Chat
                     </a>
+                    <form method="POST" action="{{ route('admin.logout') }}" class="inline-flex">
+                        @csrf
+                        <button type="submit"
+                                class="inline-flex h-10 items-center gap-2 rounded-lg border border-stone-200 bg-white px-3 text-xs font-semibold uppercase tracking-wider text-stone-600 transition hover:border-rose-400/40 hover:text-rose-600 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-rose-400/40 dark:hover:text-rose-300"
+                                aria-label="Keluar dari admin">
+                            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
+                            </svg>
+                            <span class="hidden sm:inline">Logout</span>
+                        </button>
+                    </form>
                     <livewire:dashboard-nav-profile />
                 </div>
             </header>

--- a/laravel/resources/views/livewire/admin/admin-accounts.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-accounts.blade.php
@@ -1,0 +1,316 @@
+<div>
+    <div class="mb-6">
+        <div class="flex flex-wrap items-end justify-between gap-3">
+            <div class="max-w-2xl">
+                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Super Admin</p>
+                <h2 class="admin-page-title mt-1">Account Management</h2>
+                <p class="mt-2 text-sm leading-relaxed text-stone-500 dark:text-gray-400">
+                    Kelola akun admin dan super admin. Buat akun baru, ubah role, aktifkan atau nonaktifkan akses, dan reset password sementara.
+                </p>
+            </div>
+            <div class="flex flex-wrap items-center gap-2">
+                <x-admin.badge tone="gold">
+                    <span class="h-1.5 w-1.5 rounded-full bg-amber-500"></span>
+                    Akses terbatas
+                </x-admin.badge>
+                <x-admin.badge tone="primary">
+                    Total Super Admin Aktif: {{ $totalActiveSuperAdmins }}
+                </x-admin.badge>
+                <button type="button"
+                        wire:click="openCreateModal"
+                        class="inline-flex h-9 items-center gap-2 rounded-lg bg-ista-primary px-3 text-xs font-semibold uppercase tracking-wider text-amber-300 transition hover:bg-stone-800">
+                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 4v16m8-8H4"/>
+                    </svg>
+                    Tambah Akun
+                </button>
+            </div>
+        </div>
+    </div>
+
+    @if ($flashMessage)
+        <div class="mb-4 rounded-lg border border-emerald-200 bg-emerald-50/80 p-3 text-sm text-emerald-800 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-200">
+            <div class="flex items-start justify-between gap-3">
+                <span>{{ $flashMessage }}</span>
+                <button type="button" wire:click="clearFlash" class="text-emerald-700/80 hover:text-emerald-900 dark:text-emerald-200/80 dark:hover:text-emerald-100">
+                    <span class="sr-only">Tutup</span>
+                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M6 18L18 6M6 6l12 12"/></svg>
+                </button>
+            </div>
+        </div>
+    @endif
+
+    @if ($flashError)
+        <div class="mb-4 rounded-lg border border-rose-200 bg-rose-50/80 p-3 text-sm text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-200">
+            <div class="flex items-start justify-between gap-3">
+                <span>{{ $flashError }}</span>
+                <button type="button" wire:click="clearFlash" class="text-rose-600 hover:text-rose-800 dark:text-rose-200/80 dark:hover:text-rose-100">
+                    <span class="sr-only">Tutup</span>
+                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M6 18L18 6M6 6l12 12"/></svg>
+                </button>
+            </div>
+        </div>
+    @endif
+
+    @if ($generatedTemporaryPassword)
+        <div class="mb-4 rounded-lg border border-amber-200 bg-amber-50/80 p-4 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-200">
+            <div class="flex items-start justify-between gap-3">
+                <div class="min-w-0">
+                    <p class="font-semibold">Password sementara berhasil dibuat</p>
+                    <p class="mt-1 text-xs">Salin password berikut sekarang. Sistem tidak akan menampilkannya kembali.</p>
+                    <code class="mt-2 inline-block rounded bg-white/80 px-3 py-1.5 font-mono text-sm tracking-widest text-stone-900 dark:bg-gray-900 dark:text-amber-200">
+                        {{ $generatedTemporaryPassword }}
+                    </code>
+                </div>
+                <button type="button" wire:click="dismissTemporaryPassword" class="text-amber-800/80 hover:text-amber-900 dark:text-amber-200/80 dark:hover:text-amber-100">
+                    <span class="sr-only">Tutup</span>
+                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M6 18L18 6M6 6l12 12"/></svg>
+                </button>
+            </div>
+        </div>
+    @endif
+
+    <x-admin.section
+        title="Daftar Akun Admin"
+        description="Akun admin dan super admin yang terdaftar dalam sistem.">
+        <x-slot name="actions">
+            <div class="flex flex-wrap items-center gap-2">
+                <label class="admin-filter">
+                    <span class="admin-filter__label">Cari</span>
+                    <input type="text"
+                           wire:model.live.debounce.300ms="search"
+                           placeholder="Nama atau email"
+                           class="admin-filter__control">
+                </label>
+                <label class="admin-filter">
+                    <span class="admin-filter__label">Role</span>
+                    <select wire:model.live="roleFilter" class="admin-filter__control">
+                        <option value="all">Semua</option>
+                        <option value="admin">Admin</option>
+                        <option value="super_admin">Super Admin</option>
+                    </select>
+                </label>
+                <label class="admin-filter">
+                    <span class="admin-filter__label">Status</span>
+                    <select wire:model.live="statusFilter" class="admin-filter__control">
+                        <option value="all">Semua</option>
+                        <option value="active">Aktif</option>
+                        <option value="inactive">Nonaktif</option>
+                    </select>
+                </label>
+            </div>
+        </x-slot>
+
+        <x-admin.table :columns="[
+            ['key' => 'name', 'label' => 'Akun'],
+            ['key' => 'role', 'label' => 'Role'],
+            ['key' => 'status', 'label' => 'Status'],
+            ['key' => 'last_login', 'label' => 'Login Terakhir', 'align' => 'right'],
+            ['key' => 'actions', 'label' => 'Aksi', 'align' => 'right'],
+        ]">
+            @forelse ($accounts as $account)
+                <tr>
+                    <td class="admin-table__td">
+                        <div class="flex flex-col">
+                            <span class="text-sm font-semibold text-stone-700 dark:text-gray-200">{{ $account->name }}</span>
+                            <span class="text-[11px] text-stone-400 dark:text-gray-500">{{ $account->email }}</span>
+                            @if ($account->force_password_change)
+                                <span class="mt-1 inline-flex w-fit items-center gap-1 rounded-md bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+                                    Wajib ganti password
+                                </span>
+                            @endif
+                        </div>
+                    </td>
+                    <td class="admin-table__td">
+                        <x-admin.badge :tone="$account->role === 'super_admin' ? 'gold' : 'primary'">
+                            {{ $account->role === 'super_admin' ? 'Super Admin' : 'Admin' }}
+                        </x-admin.badge>
+                    </td>
+                    <td class="admin-table__td">
+                        @if ($account->is_active)
+                            <x-admin.badge tone="success">Aktif</x-admin.badge>
+                        @else
+                            <x-admin.badge tone="danger">Nonaktif</x-admin.badge>
+                        @endif
+                    </td>
+                    <td class="admin-table__td" data-align="right">
+                        <span class="text-xs text-stone-500 dark:text-gray-400" title="{{ $account->last_admin_login_at?->toDateTimeString() ?? '—' }}">
+                            {{ $account->last_admin_login_at?->diffForHumans() ?? '—' }}
+                        </span>
+                    </td>
+                    <td class="admin-table__td" data-align="right">
+                        <div class="flex flex-wrap items-center justify-end gap-1.5">
+                            <button type="button"
+                                    wire:click="startEdit({{ $account->id }})"
+                                    class="inline-flex h-8 items-center gap-1 rounded-md border border-stone-200 bg-white px-2 text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-ista-primary/40 dark:hover:text-amber-300">
+                                Edit
+                            </button>
+
+                            @if ($account->is_active)
+                                <button type="button"
+                                        wire:click="startDeactivate({{ $account->id }})"
+                                        class="inline-flex h-8 items-center gap-1 rounded-md border border-rose-200 bg-rose-50 px-2 text-[11px] font-semibold uppercase tracking-wider text-rose-700 transition hover:bg-rose-100 dark:border-rose-900/40 dark:bg-rose-950/40 dark:text-rose-200">
+                                    Nonaktifkan
+                                </button>
+                            @else
+                                <button type="button"
+                                        wire:click="activate({{ $account->id }})"
+                                        class="inline-flex h-8 items-center gap-1 rounded-md border border-emerald-200 bg-emerald-50 px-2 text-[11px] font-semibold uppercase tracking-wider text-emerald-700 transition hover:bg-emerald-100 dark:border-emerald-900/40 dark:bg-emerald-950/40 dark:text-emerald-200">
+                                    Aktifkan
+                                </button>
+                            @endif
+
+                            <button type="button"
+                                    wire:click="startResetPassword({{ $account->id }})"
+                                    wire:confirm="Reset password admin {{ $account->email }}? Password lama tidak dapat dipakai lagi."
+                                    class="inline-flex h-8 items-center gap-1 rounded-md border border-stone-200 bg-white px-2 text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-ista-primary/40 dark:hover:text-amber-300">
+                                Reset Password
+                            </button>
+                        </div>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="5" class="admin-table__empty">
+                        <x-admin.empty-state
+                            title="Belum ada akun admin"
+                            description="Tambahkan akun admin atau super admin baru untuk mulai mengelola sistem." />
+                    </td>
+                </tr>
+            @endforelse
+        </x-admin.table>
+
+        @if ($accounts->hasPages())
+            <div class="mt-4">
+                {{ $accounts->links() }}
+            </div>
+        @endif
+    </x-admin.section>
+
+    {{-- Edit drawer --}}
+    @if ($editingUserId)
+        @php
+            $editingUser = \App\Models\User::query()->find($editingUserId);
+        @endphp
+        <div class="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/40 p-4 backdrop-blur-sm dark:bg-black/60" role="dialog" aria-modal="true">
+            <div class="w-full max-w-md rounded-2xl border border-stone-200 bg-white p-6 shadow-xl dark:border-gray-800 dark:bg-gray-900">
+                <h3 class="text-base font-semibold text-stone-900 dark:text-gray-100">Edit Akun Admin</h3>
+                <p class="mt-1 text-xs text-stone-500 dark:text-gray-400">{{ $editingUser?->email }}</p>
+
+                <div class="mt-4 space-y-3">
+                    <div>
+                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Nama</label>
+                        <input type="text" wire:model.defer="editName" class="mt-1 admin-filter__control w-full">
+                        @error('editName') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
+                    </div>
+                    <div>
+                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Email</label>
+                        <input type="email" wire:model.defer="editEmail" class="mt-1 admin-filter__control w-full">
+                        @error('editEmail') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
+                    </div>
+                    <div>
+                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Role</label>
+                        <select wire:model.defer="editRole" class="mt-1 admin-filter__control w-full">
+                            <option value="admin">Admin</option>
+                            <option value="super_admin">Super Admin</option>
+                        </select>
+                        @error('editRole') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
+                    </div>
+                    <label class="flex items-center gap-2 text-xs text-stone-600 dark:text-gray-300">
+                        <input type="checkbox" wire:model.defer="editForcePasswordChange" class="h-4 w-4 rounded border-stone-300 text-ista-primary focus:ring-ista-primary/20 dark:border-gray-700">
+                        Wajib ganti password saat login berikutnya
+                    </label>
+                </div>
+
+                <div class="mt-5 flex items-center justify-end gap-2">
+                    <button type="button" wire:click="cancelEdit" class="inline-flex h-9 items-center gap-1 rounded-md border border-stone-200 bg-white px-3 text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+                        Batal
+                    </button>
+                    <button type="button" wire:click="saveEdit" class="inline-flex h-9 items-center gap-1 rounded-md bg-ista-primary px-3 text-[11px] font-semibold uppercase tracking-wider text-amber-300 transition hover:bg-stone-800">
+                        Simpan Perubahan
+                    </button>
+                </div>
+            </div>
+        </div>
+    @endif
+
+    {{-- Deactivate confirmation --}}
+    @if ($deactivatingUserId)
+        <div class="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/40 p-4 backdrop-blur-sm dark:bg-black/60" role="dialog" aria-modal="true">
+            <div class="w-full max-w-md rounded-2xl border border-stone-200 bg-white p-6 shadow-xl dark:border-gray-800 dark:bg-gray-900">
+                <h3 class="text-base font-semibold text-stone-900 dark:text-gray-100">Konfirmasi Nonaktifkan Akun</h3>
+                <p class="mt-1 text-xs leading-relaxed text-stone-500 dark:text-gray-400">
+                    Akun yang dinonaktifkan tidak dapat login ke admin meskipun masih memiliki sesi aktif.
+                </p>
+
+                <div class="mt-3">
+                    <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Alasan (opsional)</label>
+                    <textarea wire:model.defer="deactivateReason" rows="2" class="mt-1 admin-filter__control w-full" placeholder="Misal: rotasi tugas, mutasi"></textarea>
+                </div>
+
+                <div class="mt-5 flex items-center justify-end gap-2">
+                    <button type="button" wire:click="cancelDeactivate" class="inline-flex h-9 items-center gap-1 rounded-md border border-stone-200 bg-white px-3 text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+                        Batal
+                    </button>
+                    <button type="button" wire:click="confirmDeactivate" class="inline-flex h-9 items-center gap-1 rounded-md bg-rose-600 px-3 text-[11px] font-semibold uppercase tracking-wider text-white transition hover:bg-rose-700">
+                        Nonaktifkan
+                    </button>
+                </div>
+            </div>
+        </div>
+    @endif
+
+    {{-- Create modal --}}
+    @if ($showCreateModal)
+        <div class="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/40 p-4 backdrop-blur-sm dark:bg-black/60" role="dialog" aria-modal="true">
+            <div class="w-full max-w-md rounded-2xl border border-stone-200 bg-white p-6 shadow-xl dark:border-gray-800 dark:bg-gray-900">
+                <h3 class="text-base font-semibold text-stone-900 dark:text-gray-100">Tambah Akun Admin</h3>
+                <p class="mt-1 text-xs text-stone-500 dark:text-gray-400">Buat akun admin atau super admin baru. Akun otomatis diverifikasi.</p>
+
+                <div class="mt-4 space-y-3">
+                    <div>
+                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Nama</label>
+                        <input type="text" wire:model.defer="newName" class="mt-1 admin-filter__control w-full">
+                        @error('newName') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
+                    </div>
+                    <div>
+                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Email</label>
+                        <input type="email" wire:model.defer="newEmail" class="mt-1 admin-filter__control w-full" placeholder="email@instansi.go.id">
+                        @error('newEmail') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
+                    </div>
+                    <div>
+                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Password Sementara</label>
+                        <div class="mt-1 flex gap-2">
+                            <input type="text" wire:model.defer="newPassword" class="admin-filter__control w-full font-mono">
+                            <button type="button" wire:click="generateNewPassword" class="inline-flex h-10 items-center rounded-md border border-stone-200 bg-white px-3 text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+                                Generate
+                            </button>
+                        </div>
+                        @error('newPassword') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
+                    </div>
+                    <div>
+                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Role</label>
+                        <select wire:model.defer="newRole" class="mt-1 admin-filter__control w-full">
+                            <option value="admin">Admin</option>
+                            <option value="super_admin">Super Admin</option>
+                        </select>
+                        @error('newRole') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
+                    </div>
+                    <label class="flex items-center gap-2 text-xs text-stone-600 dark:text-gray-300">
+                        <input type="checkbox" wire:model.defer="newForcePasswordChange" class="h-4 w-4 rounded border-stone-300 text-ista-primary focus:ring-ista-primary/20 dark:border-gray-700">
+                        Wajibkan ganti password setelah login pertama
+                    </label>
+                </div>
+
+                <div class="mt-5 flex items-center justify-end gap-2">
+                    <button type="button" wire:click="closeCreateModal" class="inline-flex h-9 items-center gap-1 rounded-md border border-stone-200 bg-white px-3 text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+                        Batal
+                    </button>
+                    <button type="button" wire:click="createAccount" class="inline-flex h-9 items-center gap-1 rounded-md bg-ista-primary px-3 text-[11px] font-semibold uppercase tracking-wider text-amber-300 transition hover:bg-stone-800">
+                        Buat Akun
+                    </button>
+                </div>
+            </div>
+        </div>
+    @endif
+</div>

--- a/laravel/resources/views/livewire/profile/update-password-form.blade.php
+++ b/laravel/resources/views/livewire/profile/update-password-form.blade.php
@@ -30,6 +30,7 @@ new class extends Component
 
         Auth::user()->update([
             'password' => Hash::make($validated['password']),
+            'force_password_change' => false,
         ]);
 
         $this->reset('current_password', 'password', 'password_confirmation');

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -121,7 +121,15 @@ Route::middleware(['web'])
         });
 
         Route::middleware('auth')->group(function () {
+            // Logout must remain accessible for any authenticated user (including inactive
+            // admins whose session is still valid) so they can clear their session.
             Route::post('/logout', [AdminLoginController::class, 'logout'])->name('logout');
+        });
+
+        // Force password change endpoints require the same active-admin guard as the
+        // rest of /admin/*. We deliberately omit `admin.password_changed` here to avoid
+        // a redirect loop while the flag is still true.
+        Route::middleware(['auth', 'verified', 'admin'])->group(function () {
             Route::get('/password/change', [AdminPasswordChangeController::class, 'show'])->name('password.change');
             Route::post('/password/change', [AdminPasswordChangeController::class, 'update'])
                 ->middleware('throttle:10,1')

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Admin\AdminLoginController;
+use App\Http\Controllers\Admin\AdminPasswordChangeController;
 use App\Http\Controllers\Chat\ChatStreamController;
 use App\Http\Controllers\CloudStorage\GoogleDriveOAuthController;
 use App\Http\Controllers\Documents\DocumentExportController;
@@ -121,10 +122,14 @@ Route::middleware(['web'])
 
         Route::middleware('auth')->group(function () {
             Route::post('/logout', [AdminLoginController::class, 'logout'])->name('logout');
+            Route::get('/password/change', [AdminPasswordChangeController::class, 'show'])->name('password.change');
+            Route::post('/password/change', [AdminPasswordChangeController::class, 'update'])
+                ->middleware('throttle:10,1')
+                ->name('password.update');
         });
     });
 
-Route::middleware(['auth', 'verified', 'admin'])
+Route::middleware(['auth', 'verified', 'admin', 'admin.password_changed'])
     ->prefix('admin')
     ->name('admin.')
     ->group(function () {
@@ -135,7 +140,7 @@ Route::middleware(['auth', 'verified', 'admin'])
         Route::get('/documents', AdminDocuments::class)->name('documents');
     });
 
-Route::middleware(['auth', 'verified', 'super_admin'])
+Route::middleware(['auth', 'verified', 'super_admin', 'admin.password_changed'])
     ->prefix('admin')
     ->name('admin.')
     ->group(function () {

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,11 +1,13 @@
 <?php
 
+use App\Http\Controllers\Admin\AdminLoginController;
 use App\Http\Controllers\Chat\ChatStreamController;
 use App\Http\Controllers\CloudStorage\GoogleDriveOAuthController;
 use App\Http\Controllers\Documents\DocumentExportController;
 use App\Http\Controllers\Documents\DocumentPreviewController;
 use App\Http\Controllers\Memos\MemoFileController;
 use App\Http\Controllers\OnlyOfficeCallbackController;
+use App\Livewire\Admin\AdminAccounts;
 use App\Livewire\Admin\AdminDashboard;
 use App\Livewire\Admin\AdminDocuments;
 use App\Livewire\Admin\AdminErrors;
@@ -106,6 +108,22 @@ Route::middleware(['auth', 'verified'])
         Route::get('/callback', [GoogleDriveOAuthController::class, 'callback'])->name('callback');
     });
 
+Route::middleware(['web'])
+    ->prefix('admin')
+    ->name('admin.')
+    ->group(function () {
+        Route::middleware('guest')->group(function () {
+            Route::get('/login', [AdminLoginController::class, 'showLoginForm'])->name('login');
+            Route::post('/login', [AdminLoginController::class, 'login'])
+                ->middleware('throttle:10,1')
+                ->name('login.attempt');
+        });
+
+        Route::middleware('auth')->group(function () {
+            Route::post('/logout', [AdminLoginController::class, 'logout'])->name('logout');
+        });
+    });
+
 Route::middleware(['auth', 'verified', 'admin'])
     ->prefix('admin')
     ->name('admin.')
@@ -122,6 +140,7 @@ Route::middleware(['auth', 'verified', 'super_admin'])
     ->name('admin.')
     ->group(function () {
         Route::view('/ai-config', 'admin.ai-config')->name('ai-config');
+        Route::get('/accounts', AdminAccounts::class)->name('accounts');
     });
 
 require __DIR__.'/auth.php';

--- a/laravel/tests/Feature/Admin/AdminAccessTest.php
+++ b/laravel/tests/Feature/Admin/AdminAccessTest.php
@@ -10,14 +10,14 @@ class AdminAccessTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_guest_is_redirected_to_login_for_admin_dashboard(): void
+    public function test_guest_is_redirected_to_admin_login_for_admin_dashboard(): void
     {
         $response = $this->get('/admin');
 
-        $response->assertRedirect(route('login'));
+        $response->assertRedirect(route('admin.login'));
     }
 
-    public function test_regular_user_is_forbidden_from_admin_dashboard(): void
+    public function test_regular_user_is_redirected_to_admin_login_when_accessing_admin(): void
     {
         $user = User::factory()->create([
             'role' => User::ROLE_USER,
@@ -25,7 +25,7 @@ class AdminAccessTest extends TestCase
 
         $response = $this->actingAs($user)->get('/admin');
 
-        $response->assertStatus(403);
+        $response->assertRedirect(route('admin.login'));
     }
 
     public function test_admin_can_access_admin_dashboard(): void

--- a/laravel/tests/Feature/Admin/AdminAccountManagementTest.php
+++ b/laravel/tests/Feature/Admin/AdminAccountManagementTest.php
@@ -273,4 +273,139 @@ class AdminAccountManagementTest extends TestCase
         $this->assertArrayNotHasKey('password', (array) ($audit->before_snapshot ?? []));
         $this->assertArrayNotHasKey('password', (array) ($audit->metadata ?? []));
     }
+
+    public function test_service_refuses_update_on_non_admin_target(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $regular = User::factory()->create(['role' => User::ROLE_USER]);
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+
+        $service->update($superAdmin, $regular, [
+            'name' => 'Hacked',
+            'email' => $regular->email,
+            'role' => User::ROLE_ADMIN,
+        ]);
+    }
+
+    public function test_service_refuses_activate_on_non_admin_target(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $regular = User::factory()->create([
+            'role' => User::ROLE_USER,
+            'is_active' => false,
+        ]);
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+
+        $service->activate($superAdmin, $regular);
+    }
+
+    public function test_service_refuses_deactivate_on_non_admin_target(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $regular = User::factory()->create([
+            'role' => User::ROLE_USER,
+            'is_active' => true,
+        ]);
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+
+        $service->deactivate($superAdmin, $regular);
+    }
+
+    public function test_service_refuses_reset_password_on_non_admin_target(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $regular = User::factory()->create(['role' => User::ROLE_USER]);
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+
+        $service->resetPassword($superAdmin, $regular, 'temp-pass-1234');
+    }
+
+    public function test_livewire_refuses_to_edit_non_admin_target_id(): void
+    {
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $regular = User::factory()->create(['role' => User::ROLE_USER]);
+
+        \Livewire\Livewire::actingAs($superAdmin)
+            ->test(\App\Livewire\Admin\AdminAccounts::class)
+            ->call('startEdit', $regular->id)
+            ->assertStatus(404);
+    }
+
+    public function test_livewire_refuses_to_activate_non_admin_target_id(): void
+    {
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $regular = User::factory()->create([
+            'role' => User::ROLE_USER,
+            'is_active' => false,
+        ]);
+
+        \Livewire\Livewire::actingAs($superAdmin)
+            ->test(\App\Livewire\Admin\AdminAccounts::class)
+            ->call('activate', $regular->id)
+            ->assertStatus(404);
+
+        $regular->refresh();
+        $this->assertFalse((bool) $regular->is_active);
+    }
+
+    public function test_livewire_refuses_to_deactivate_non_admin_target_id(): void
+    {
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $regular = User::factory()->create([
+            'role' => User::ROLE_USER,
+            'is_active' => true,
+        ]);
+
+        \Livewire\Livewire::actingAs($superAdmin)
+            ->test(\App\Livewire\Admin\AdminAccounts::class)
+            ->call('startDeactivate', $regular->id)
+            ->assertStatus(404);
+    }
+
+    public function test_livewire_refuses_to_reset_password_non_admin_target_id(): void
+    {
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $regular = User::factory()->create(['role' => User::ROLE_USER]);
+        $originalPasswordHash = $regular->password;
+
+        \Livewire\Livewire::actingAs($superAdmin)
+            ->test(\App\Livewire\Admin\AdminAccounts::class)
+            ->call('startResetPassword', $regular->id)
+            ->assertStatus(404);
+
+        $regular->refresh();
+        $this->assertEquals($originalPasswordHash, $regular->password);
+    }
 }

--- a/laravel/tests/Feature/Admin/AdminAccountManagementTest.php
+++ b/laravel/tests/Feature/Admin/AdminAccountManagementTest.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\AdminAccountAudit;
+use App\Models\User;
+use App\Services\Admin\AdminAccountManagementService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class AdminAccountManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_super_admin_can_access_account_management_page(): void
+    {
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+
+        $response = $this->actingAs($superAdmin)->get('/admin/accounts');
+
+        $response->assertOk();
+        $response->assertSee('Account Management');
+        $response->assertSee('Daftar Akun Admin');
+    }
+
+    public function test_admin_cannot_access_account_management_page(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+        ]);
+
+        $response = $this->actingAs($admin)->get('/admin/accounts');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_regular_user_cannot_access_account_management_page(): void
+    {
+        $user = User::factory()->create(['role' => User::ROLE_USER]);
+
+        $response = $this->actingAs($user)->get('/admin/accounts');
+
+        $response->assertRedirect(route('admin.login'));
+    }
+
+    public function test_super_admin_can_create_admin_account(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+
+        $created = $service->create($superAdmin, [
+            'name' => 'Admin Baru',
+            'email' => 'admin-baru@instansi.go.id',
+            'password' => 'temporary-pass-1234',
+            'role' => User::ROLE_ADMIN,
+            'force_password_change' => true,
+        ]);
+
+        $this->assertEquals(User::ROLE_ADMIN, $created->role);
+        $this->assertTrue((bool) $created->is_active);
+        $this->assertTrue((bool) $created->force_password_change);
+        $this->assertDatabaseHas('admin_account_audits', [
+            'actor_id' => $superAdmin->id,
+            'target_user_id' => $created->id,
+            'action' => AdminAccountAudit::ACTION_CREATED,
+        ]);
+    }
+
+    public function test_super_admin_cannot_create_with_duplicate_email(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $existing = User::factory()->create(['email' => 'duplicate@instansi.go.id']);
+
+        $this->expectException(ValidationException::class);
+
+        $service->create($superAdmin, [
+            'name' => 'Admin Baru',
+            'email' => $existing->email,
+            'password' => 'temporary-pass-1234',
+            'role' => User::ROLE_ADMIN,
+        ]);
+    }
+
+    public function test_super_admin_can_update_admin_role(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $target = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+        ]);
+
+        $service->update($superAdmin, $target, [
+            'name' => $target->name,
+            'email' => $target->email,
+            'role' => User::ROLE_SUPER_ADMIN,
+        ]);
+
+        $target->refresh();
+        $this->assertEquals(User::ROLE_SUPER_ADMIN, $target->role);
+        $this->assertDatabaseHas('admin_account_audits', [
+            'actor_id' => $superAdmin->id,
+            'target_user_id' => $target->id,
+            'action' => AdminAccountAudit::ACTION_ROLE_CHANGED,
+        ]);
+    }
+
+    public function test_super_admin_can_deactivate_other_admin(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $target = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+        ]);
+
+        $service->deactivate($superAdmin, $target, 'mutasi');
+
+        $target->refresh();
+        $this->assertFalse((bool) $target->is_active);
+        $this->assertNotNull($target->disabled_at);
+        $this->assertEquals($superAdmin->id, $target->disabled_by);
+        $this->assertDatabaseHas('admin_account_audits', [
+            'actor_id' => $superAdmin->id,
+            'target_user_id' => $target->id,
+            'action' => AdminAccountAudit::ACTION_DEACTIVATED,
+        ]);
+    }
+
+    public function test_super_admin_cannot_deactivate_self(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        // Add another super admin so the "last super admin" guard isn't the trigger
+        User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        $service->deactivate($superAdmin, $superAdmin);
+    }
+
+    public function test_cannot_deactivate_last_super_admin(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $solo = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        // Use a separate actor super admin to bypass self-deactivate guard.
+        $actor = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        // Now deactivate $actor first, leaving $solo as the only active super admin.
+        $service->deactivate($solo, $actor);
+
+        $this->assertEquals(1, $service->activeSuperAdminsCount());
+
+        $this->expectException(ValidationException::class);
+        // Attempt to deactivate the remaining super admin via another super admin actor: not possible (only one left).
+        // Use solo as actor to demonstrate the guard against deactivating the last one.
+        $service->deactivate($solo, $solo);
+    }
+
+    public function test_super_admin_can_reset_password_and_force_change(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $target = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'password' => Hash::make('old-password'),
+            'force_password_change' => false,
+        ]);
+
+        $service->resetPassword($superAdmin, $target, 'new-temp-1234');
+
+        $target->refresh();
+        $this->assertTrue(Hash::check('new-temp-1234', $target->password));
+        $this->assertTrue((bool) $target->force_password_change);
+        $this->assertDatabaseHas('admin_account_audits', [
+            'actor_id' => $superAdmin->id,
+            'target_user_id' => $target->id,
+            'action' => AdminAccountAudit::ACTION_PASSWORD_RESET,
+        ]);
+    }
+
+    public function test_admin_cannot_perform_account_management(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+        ]);
+        $target = User::factory()->create(['role' => User::ROLE_ADMIN]);
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+        $service->update($admin, $target, ['name' => 'X']);
+    }
+
+    public function test_super_admin_cannot_demote_last_super_admin(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $solo = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        $service->update($solo, $solo, [
+            'role' => User::ROLE_ADMIN,
+        ]);
+    }
+
+    public function test_audit_does_not_persist_password(): void
+    {
+        $service = app(AdminAccountManagementService::class);
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+
+        $created = $service->create($superAdmin, [
+            'name' => 'Admin Test',
+            'email' => 'audit-pass@instansi.go.id',
+            'password' => 'rahasia-banget-1234',
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        $audit = AdminAccountAudit::query()
+            ->where('target_user_id', $created->id)
+            ->where('action', AdminAccountAudit::ACTION_CREATED)
+            ->firstOrFail();
+
+        $serialized = json_encode([
+            'before' => $audit->before_snapshot,
+            'after' => $audit->after_snapshot,
+            'metadata' => $audit->metadata,
+        ]);
+
+        $this->assertStringNotContainsString('rahasia-banget-1234', (string) $serialized);
+        // Snapshot must not contain a hashed password under the literal "password" key
+        $this->assertArrayNotHasKey('password', (array) $audit->after_snapshot);
+        $this->assertArrayNotHasKey('password', (array) ($audit->before_snapshot ?? []));
+        $this->assertArrayNotHasKey('password', (array) ($audit->metadata ?? []));
+    }
+}

--- a/laravel/tests/Feature/Admin/AdminForcePasswordChangeTest.php
+++ b/laravel/tests/Feature/Admin/AdminForcePasswordChangeTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class AdminForcePasswordChangeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_with_force_password_change_is_redirected_from_dashboard(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'force_password_change' => true,
+        ]);
+
+        $this->actingAs($admin)
+            ->get('/admin')
+            ->assertRedirect(route('admin.password.change'));
+    }
+
+    public function test_admin_with_force_password_change_is_redirected_from_accounts(): void
+    {
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+            'force_password_change' => true,
+        ]);
+
+        $this->actingAs($superAdmin)
+            ->get('/admin/accounts')
+            ->assertRedirect(route('admin.password.change'));
+    }
+
+    public function test_admin_login_with_force_change_redirects_to_change_password(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'force_password_change' => true,
+            'password' => Hash::make('temporary-1234'),
+        ]);
+
+        // First login redirects intended to dashboard...
+        $this->post('/admin/login', [
+            'email' => $admin->email,
+            'password' => 'temporary-1234',
+        ])->assertRedirect(route('admin.dashboard'));
+
+        // ...but the dashboard itself bounces to the change-password page
+        $this->get('/admin')->assertRedirect(route('admin.password.change'));
+    }
+
+    public function test_admin_can_change_password_and_flag_is_cleared(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'force_password_change' => true,
+            'password' => Hash::make('old-temp-1234'),
+        ]);
+
+        $this->actingAs($admin)
+            ->from(route('admin.password.change'))
+            ->post('/admin/password/change', [
+                'current_password' => 'old-temp-1234',
+                'password' => 'BrandNew_PassW0rd!',
+                'password_confirmation' => 'BrandNew_PassW0rd!',
+            ])
+            ->assertRedirect(route('admin.dashboard'));
+
+        $admin->refresh();
+        $this->assertFalse((bool) $admin->force_password_change);
+        $this->assertTrue(Hash::check('BrandNew_PassW0rd!', $admin->password));
+
+        // After change, dashboard is accessible without redirect.
+        $this->actingAs($admin)
+            ->get('/admin')
+            ->assertOk();
+    }
+
+    public function test_change_password_rejects_wrong_current_password(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'force_password_change' => true,
+            'password' => Hash::make('correct-temp-1234'),
+        ]);
+
+        $this->actingAs($admin)
+            ->from(route('admin.password.change'))
+            ->post('/admin/password/change', [
+                'current_password' => 'wrong-current',
+                'password' => 'NewSecret_1234!',
+                'password_confirmation' => 'NewSecret_1234!',
+            ])
+            ->assertRedirect(route('admin.password.change'))
+            ->assertSessionHasErrors('current_password');
+
+        $admin->refresh();
+        $this->assertTrue((bool) $admin->force_password_change);
+        $this->assertTrue(Hash::check('correct-temp-1234', $admin->password));
+    }
+
+    public function test_change_password_rejects_same_password(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'force_password_change' => true,
+            'password' => Hash::make('same-pass-1234!'),
+        ]);
+
+        $this->actingAs($admin)
+            ->from(route('admin.password.change'))
+            ->post('/admin/password/change', [
+                'current_password' => 'same-pass-1234!',
+                'password' => 'same-pass-1234!',
+                'password_confirmation' => 'same-pass-1234!',
+            ])
+            ->assertRedirect(route('admin.password.change'))
+            ->assertSessionHasErrors('password');
+
+        $admin->refresh();
+        $this->assertTrue((bool) $admin->force_password_change);
+    }
+
+    public function test_profile_password_update_clears_force_change_flag(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'force_password_change' => true,
+            'password' => Hash::make('temp-1234'),
+        ]);
+
+        \Livewire\Livewire::actingAs($admin)
+            ->test('profile.update-password-form')
+            ->set('current_password', 'temp-1234')
+            ->set('password', 'NewSecret_1234!')
+            ->set('password_confirmation', 'NewSecret_1234!')
+            ->call('updatePassword');
+
+        $admin->refresh();
+        $this->assertFalse((bool) $admin->force_password_change);
+        $this->assertTrue(Hash::check('NewSecret_1234!', $admin->password));
+    }
+
+    public function test_admin_with_force_change_can_still_logout(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'force_password_change' => true,
+        ]);
+
+        $this->actingAs($admin)
+            ->post('/admin/logout')
+            ->assertRedirect(route('admin.login'));
+
+        $this->assertGuest();
+    }
+}

--- a/laravel/tests/Feature/Admin/AdminForcePasswordChangeTest.php
+++ b/laravel/tests/Feature/Admin/AdminForcePasswordChangeTest.php
@@ -166,4 +166,96 @@ class AdminForcePasswordChangeTest extends TestCase
 
         $this->assertGuest();
     }
+
+    public function test_inactive_admin_cannot_view_force_change_page(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => false,
+            'force_password_change' => true,
+            'password' => Hash::make('temp-1234'),
+        ]);
+
+        $this->actingAs($admin)
+            ->get('/admin/password/change')
+            ->assertRedirect(route('admin.login'));
+
+        // Session is invalidated by EnsureUserIsAdmin guard.
+        $this->assertGuest();
+    }
+
+    public function test_inactive_admin_cannot_submit_force_change_form(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => false,
+            'force_password_change' => true,
+            'password' => Hash::make('temp-1234'),
+        ]);
+
+        $this->actingAs($admin)
+            ->post('/admin/password/change', [
+                'current_password' => 'temp-1234',
+                'password' => 'BrandNew_PassW0rd!',
+                'password_confirmation' => 'BrandNew_PassW0rd!',
+            ])
+            ->assertRedirect(route('admin.login'));
+
+        $this->assertGuest();
+
+        $admin->refresh();
+        // Password and flag must remain unchanged.
+        $this->assertTrue(Hash::check('temp-1234', $admin->password));
+        $this->assertTrue((bool) $admin->force_password_change);
+    }
+
+    public function test_unverified_admin_cannot_view_force_change_page(): void
+    {
+        $admin = User::factory()->unverified()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'force_password_change' => true,
+            'password' => Hash::make('temp-1234'),
+        ]);
+
+        $this->actingAs($admin)
+            ->get('/admin/password/change')
+            ->assertRedirect(route('verification.notice'));
+    }
+
+    public function test_unverified_admin_cannot_submit_force_change_form(): void
+    {
+        $admin = User::factory()->unverified()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'force_password_change' => true,
+            'password' => Hash::make('temp-1234'),
+        ]);
+
+        $this->actingAs($admin)
+            ->post('/admin/password/change', [
+                'current_password' => 'temp-1234',
+                'password' => 'BrandNew_PassW0rd!',
+                'password_confirmation' => 'BrandNew_PassW0rd!',
+            ])
+            ->assertRedirect(route('verification.notice'));
+
+        $admin->refresh();
+        $this->assertTrue(Hash::check('temp-1234', $admin->password));
+        $this->assertTrue((bool) $admin->force_password_change);
+    }
+
+    public function test_regular_user_cannot_access_force_change_page_even_with_session(): void
+    {
+        $user = User::factory()->create([
+            'role' => User::ROLE_USER,
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($user)
+            ->get('/admin/password/change')
+            ->assertRedirect(route('admin.login'));
+
+        $this->assertGuest();
+    }
 }

--- a/laravel/tests/Feature/Admin/AdminLoginTest.php
+++ b/laravel/tests/Feature/Admin/AdminLoginTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\AdminAccountAudit;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class AdminLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_login_page_renders_without_public_links(): void
+    {
+        $response = $this->get('/admin/login');
+
+        $response->assertOk();
+        $response->assertSee('Login Admin');
+        $response->assertSee('Admin Console');
+        $response->assertDontSee('Daftar', false);
+        $response->assertDontSee('Lupa Password', false);
+        $response->assertDontSee('Guest Chat', false);
+        $response->assertDontSee(route('register'), false);
+        $response->assertDontSee(route('password.request'), false);
+        $response->assertDontSee(route('guest-chat'), false);
+    }
+
+    public function test_active_admin_can_login_via_admin_login(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'password' => Hash::make('correct-pass-1234'),
+        ]);
+
+        $response = $this->post('/admin/login', [
+            'email' => $admin->email,
+            'password' => 'correct-pass-1234',
+        ]);
+
+        $response->assertRedirect(route('admin.dashboard'));
+        $this->assertAuthenticatedAs($admin);
+        $this->assertDatabaseHas('admin_account_audits', [
+            'target_user_id' => $admin->id,
+            'action' => AdminAccountAudit::ACTION_LOGIN_SUCCESS,
+        ]);
+    }
+
+    public function test_inactive_admin_cannot_login(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => false,
+            'password' => Hash::make('correct-pass-1234'),
+        ]);
+
+        $response = $this->post('/admin/login', [
+            'email' => $admin->email,
+            'password' => 'correct-pass-1234',
+        ]);
+
+        $response->assertSessionHasErrors('email');
+        $this->assertGuest();
+        $this->assertDatabaseHas('admin_account_audits', [
+            'target_user_id' => $admin->id,
+            'action' => AdminAccountAudit::ACTION_LOGIN_FAILED,
+        ]);
+    }
+
+    public function test_regular_user_cannot_login_via_admin_login(): void
+    {
+        $user = User::factory()->create([
+            'role' => User::ROLE_USER,
+            'password' => Hash::make('correct-pass-1234'),
+        ]);
+
+        $response = $this->post('/admin/login', [
+            'email' => $user->email,
+            'password' => 'correct-pass-1234',
+        ]);
+
+        $response->assertSessionHasErrors('email');
+        $this->assertGuest();
+        $this->assertDatabaseHas('admin_account_audits', [
+            'target_user_id' => $user->id,
+            'action' => AdminAccountAudit::ACTION_LOGIN_FAILED,
+        ]);
+    }
+
+    public function test_login_with_wrong_password_is_audited_and_returns_generic_error(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'password' => Hash::make('correct-pass-1234'),
+        ]);
+
+        $response = $this->post('/admin/login', [
+            'email' => $admin->email,
+            'password' => 'wrong-pass',
+        ]);
+
+        $response->assertSessionHasErrors('email');
+        $errors = session('errors')->getBag('default')->first('email');
+        $this->assertStringContainsString('Email atau password salah', $errors);
+        $this->assertGuest();
+    }
+
+    public function test_login_with_unknown_email_does_not_disclose_existence(): void
+    {
+        $response = $this->post('/admin/login', [
+            'email' => 'no-such-user@example.com',
+            'password' => 'whatever-1234',
+        ]);
+
+        $response->assertSessionHasErrors('email');
+        $errors = session('errors')->getBag('default')->first('email');
+        $this->assertStringContainsString('Email atau password salah', $errors);
+        $this->assertDatabaseHas('admin_account_audits', [
+            'action' => AdminAccountAudit::ACTION_LOGIN_FAILED,
+        ]);
+    }
+
+    public function test_admin_logout_clears_session_and_audits(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($admin)
+            ->post('/admin/logout')
+            ->assertRedirect(route('admin.login'));
+
+        $this->assertGuest();
+        $this->assertDatabaseHas('admin_account_audits', [
+            'target_user_id' => $admin->id,
+            'action' => AdminAccountAudit::ACTION_LOGOUT,
+        ]);
+    }
+
+    public function test_admin_login_records_last_admin_login_metadata(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'password' => Hash::make('correct-pass-1234'),
+        ]);
+
+        $this->post('/admin/login', [
+            'email' => $admin->email,
+            'password' => 'correct-pass-1234',
+        ]);
+
+        $admin->refresh();
+        $this->assertNotNull($admin->last_admin_login_at);
+        $this->assertNotNull($admin->last_admin_login_ip);
+    }
+
+    public function test_inactive_admin_with_session_cannot_access_admin(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => false,
+        ]);
+
+        $response = $this->actingAs($admin)->get('/admin');
+
+        $response->assertRedirect(route('admin.login'));
+        $this->assertGuest();
+    }
+}

--- a/laravel/tests/Feature/Admin/AdminMonitoringDashboardTest.php
+++ b/laravel/tests/Feature/Admin/AdminMonitoringDashboardTest.php
@@ -214,18 +214,18 @@ class AdminMonitoringDashboardTest extends TestCase
     {
         $user = User::factory()->create(['role' => User::ROLE_USER]);
 
-        $this->actingAs($user)->get('/admin/users')->assertStatus(403);
-        $this->actingAs($user)->get('/admin/usage')->assertStatus(403);
-        $this->actingAs($user)->get('/admin/errors')->assertStatus(403);
-        $this->actingAs($user)->get('/admin/documents')->assertStatus(403);
+        $this->actingAs($user)->get('/admin/users')->assertRedirect(route('admin.login'));
+        $this->actingAs($user)->get('/admin/usage')->assertRedirect(route('admin.login'));
+        $this->actingAs($user)->get('/admin/errors')->assertRedirect(route('admin.login'));
+        $this->actingAs($user)->get('/admin/documents')->assertRedirect(route('admin.login'));
     }
 
-    public function test_guest_is_redirected_to_login_for_monitoring_pages(): void
+    public function test_guest_is_redirected_to_admin_login_for_monitoring_pages(): void
     {
-        $this->get('/admin/users')->assertRedirect(route('login'));
-        $this->get('/admin/usage')->assertRedirect(route('login'));
-        $this->get('/admin/errors')->assertRedirect(route('login'));
-        $this->get('/admin/documents')->assertRedirect(route('login'));
+        $this->get('/admin/users')->assertRedirect(route('admin.login'));
+        $this->get('/admin/usage')->assertRedirect(route('admin.login'));
+        $this->get('/admin/errors')->assertRedirect(route('admin.login'));
+        $this->get('/admin/documents')->assertRedirect(route('admin.login'));
     }
 
     public function test_admin_pages_do_not_leak_message_content(): void

--- a/laravel/tests/Feature/Admin/BootstrapAdminAccountsCommandTest.php
+++ b/laravel/tests/Feature/Admin/BootstrapAdminAccountsCommandTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\AdminAccountAudit;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class BootstrapAdminAccountsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_fails_when_env_credentials_missing(): void
+    {
+        config([
+            'app.env' => 'testing',
+        ]);
+
+        // Ensure env getters return null
+        putenv('INITIAL_ADMIN_EMAIL');
+        putenv('INITIAL_ADMIN_PASSWORD');
+        putenv('INITIAL_SUPER_ADMIN_EMAIL');
+        putenv('INITIAL_SUPER_ADMIN_PASSWORD');
+
+        $exitCode = Artisan::call('admin:bootstrap-accounts');
+        $this->assertEquals(1, $exitCode);
+    }
+
+    public function test_command_creates_admin_and_super_admin_from_env(): void
+    {
+        putenv('INITIAL_ADMIN_EMAIL=admin@example.go.id');
+        putenv('INITIAL_ADMIN_PASSWORD=temp-pass-1234');
+        putenv('INITIAL_SUPER_ADMIN_EMAIL=superadmin@example.go.id');
+        putenv('INITIAL_SUPER_ADMIN_PASSWORD=super-temp-1234');
+
+        $exitCode = Artisan::call('admin:bootstrap-accounts');
+        $this->assertEquals(0, $exitCode);
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'admin@example.go.id',
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+            'force_password_change' => true,
+        ]);
+        $this->assertDatabaseHas('users', [
+            'email' => 'superadmin@example.go.id',
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+            'force_password_change' => true,
+        ]);
+
+        $this->assertDatabaseHas('admin_account_audits', [
+            'action' => AdminAccountAudit::ACTION_CREATED,
+        ]);
+    }
+
+    public function test_command_is_idempotent_for_existing_users(): void
+    {
+        putenv('INITIAL_ADMIN_EMAIL=admin@example.go.id');
+        putenv('INITIAL_ADMIN_PASSWORD=temp-pass-1234');
+        putenv('INITIAL_SUPER_ADMIN_EMAIL=superadmin@example.go.id');
+        putenv('INITIAL_SUPER_ADMIN_PASSWORD=super-temp-1234');
+
+        Artisan::call('admin:bootstrap-accounts');
+        $countBefore = User::count();
+
+        Artisan::call('admin:bootstrap-accounts');
+        $this->assertEquals($countBefore, User::count());
+    }
+
+    public function test_command_force_reset_password_updates_password(): void
+    {
+        putenv('INITIAL_ADMIN_EMAIL=admin@example.go.id');
+        putenv('INITIAL_ADMIN_PASSWORD=initial-pass-1234');
+        putenv('INITIAL_SUPER_ADMIN_EMAIL=superadmin@example.go.id');
+        putenv('INITIAL_SUPER_ADMIN_PASSWORD=initial-super-1234');
+
+        Artisan::call('admin:bootstrap-accounts');
+
+        $admin = User::where('email', 'admin@example.go.id')->first();
+        $admin->forceFill(['password' => Hash::make('manually-changed')])->save();
+
+        // Re-run with force reset and a new password
+        putenv('INITIAL_ADMIN_PASSWORD=new-reset-pass-1234');
+        Artisan::call('admin:bootstrap-accounts', ['--force-reset-password' => true]);
+
+        $admin->refresh();
+        $this->assertTrue(Hash::check('new-reset-pass-1234', $admin->password));
+        $this->assertTrue((bool) $admin->force_password_change);
+    }
+}


### PR DESCRIPTION
Closes #245
Blocks: #211

## Ringkasan
Hardening akses admin sebelum merge Knowledge Base Internal:

- Jalur khusus /admin/login dengan rate limit lebih ketat, generic error untuk semua kegagalan, session regenerate, dan reject role non-admin/akun nonaktif.
- Middleware active-admin check dan redirect guest /admin/* ke /admin/login (bukan login publik).
- Migration additive kolom keamanan pada `users`: `is_active`, `disabled_at`, `disabled_by`, `disabled_reason`, `force_password_change`, `last_admin_login_at`, `last_admin_login_ip`.
- Tabel `admin_account_audits` + model `AdminAccountAudit` dan `AdminAccountAuditService` (sanitisasi password/secret).
- Command `admin:bootstrap-accounts` membuat akun awal admin & super_admin dari env (`INITIAL_*_EMAIL/PASSWORD`), force_password_change=true. Gagal jelas jika env tidak lengkap.
- Halaman `/admin/accounts` khusus super_admin: list/filter, create, edit (nama/email/role/force_password_change), activate/deactivate, reset password sementara, dengan guard self-deactivate dan last super admin.
- Audit lengkap: login_success, login_failed, logout, created, updated, activated, deactivated, password_reset, role_changed.
- Desain admin login dan account management memakai admin shell ISTA AI (logo, warna, dark mode, badge/table/section components).

## File Utama
- `laravel/app/Http/Controllers/Admin/AdminLoginController.php`
- `laravel/app/Livewire/Admin/AdminAccounts.php` + `resources/views/livewire/admin/admin-accounts.blade.php`
- `laravel/app/Services/Admin/{AdminAccountAuditService,AdminAccountManagementService}.php`
- `laravel/app/Models/{AdminAccountAudit,User}.php`
- `laravel/app/Http/Middleware/{EnsureUserIsAdmin,EnsureUserIsSuperAdmin}.php`
- `laravel/app/Console/Commands/BootstrapAdminAccounts.php`
- `laravel/database/migrations/2026_05_18_120000_*`, `2026_05_18_120100_*`
- `laravel/resources/views/admin/auth/login.blade.php`
- `laravel/routes/web.php`, `laravel/bootstrap/app.php`
- `laravel/.env.example`

## Test
```
cd laravel && php artisan test
```
Hasil: **489 passed (2068 assertions)**.

Test baru:
- `AdminLoginTest` — render login, success/fail (admin/inactive/regular/wrong/unknown), audit, last_admin_login_at/ip, session/admin redirect inactive admin.
- `AdminAccountManagementTest` — akses super admin/admin/regular, create/duplicate/update/role-change, deactivate self/last-super-admin, reset password, audit no-secret.
- `BootstrapAdminAccountsCommandTest` — gagal saat env hilang, create kedua akun, idempotent, --force-reset-password update password.
- Update test existing `AdminAccessTest` & `AdminMonitoringDashboardTest` agar redirect ke `/admin/login`.

## Risiko & Catatan
- Migration additive only; kolom `role/last_seen_at/last_active_feature` lama tidak diubah.
- Default `is_active=true`, sehingga user existing tidak terblokir.
- Guest publik di /admin/* sekarang diarahkan ke /admin/login.
- Sebelum deploy production: set `INITIAL_ADMIN_EMAIL/PASSWORD` & `INITIAL_SUPER_ADMIN_EMAIL/PASSWORD` di `.env` lalu jalankan `php artisan admin:bootstrap-accounts`. Password awal akan force-change pada login pertama.
- `/admin/knowledge` (PR #211) otomatis terlindungi karena memakai middleware admin yang sudah diperketat.