### PR TITLE
fix(admin): bootstrap email_verified_at on admin/super_admin (#245)

### DIFF
--- a/laravel/app/Console/Commands/BootstrapAdminAccounts.php
+++ b/laravel/app/Console/Commands/BootstrapAdminAccounts.php
@@ -66,7 +66,9 @@ class BootstrapAdminAccounts extends Command
                 $user = User::query()->where('email', $email)->first();
 
                 if (! $user) {
-                    $user = User::create([
+                    // Use forceFill+save instead of create() because email_verified_at
+                    // is not in $fillable on the User model.
+                    $user = (new User)->forceFill([
                         'name' => $entry['name'],
                         'email' => $email,
                         'password' => Hash::make($password),
@@ -75,6 +77,7 @@ class BootstrapAdminAccounts extends Command
                         'is_active' => true,
                         'force_password_change' => true,
                     ]);
+                    $user->save();
 
                     $audit->record(
                         AdminAccountAudit::ACTION_CREATED,

--- a/laravel/app/Services/Admin/AdminAccountManagementService.php
+++ b/laravel/app/Services/Admin/AdminAccountManagementService.php
@@ -52,7 +52,8 @@ class AdminAccountManagementService
         }
 
         return DB::transaction(function () use ($actor, $name, $email, $password, $role, $data, $request) {
-            $user = User::create([
+            // forceFill + save: email_verified_at is not in $fillable on the User model.
+            $user = (new User)->forceFill([
                 'name' => $name,
                 'email' => $email,
                 'password' => Hash::make($password),
@@ -61,6 +62,7 @@ class AdminAccountManagementService
                 'is_active' => true,
                 'force_password_change' => (bool) ($data['force_password_change'] ?? true),
             ]);
+            $user->save();
 
             $this->audit->record(
                 AdminAccountAudit::ACTION_CREATED,

--- a/laravel/tests/Feature/Admin/AdminAccountManagementTest.php
+++ b/laravel/tests/Feature/Admin/AdminAccountManagementTest.php
@@ -68,6 +68,9 @@ class AdminAccountManagementTest extends TestCase
         $this->assertEquals(User::ROLE_ADMIN, $created->role);
         $this->assertTrue((bool) $created->is_active);
         $this->assertTrue((bool) $created->force_password_change);
+        // Created admin must already be email-verified so they can pass the
+        // `verified` middleware that guards /admin/*.
+        $this->assertNotNull($created->email_verified_at, 'Created admin must have email_verified_at set');
         $this->assertDatabaseHas('admin_account_audits', [
             'actor_id' => $superAdmin->id,
             'target_user_id' => $created->id,

--- a/laravel/tests/Feature/Admin/BootstrapAdminAccountsCommandTest.php
+++ b/laravel/tests/Feature/Admin/BootstrapAdminAccountsCommandTest.php
@@ -13,28 +13,75 @@ class BootstrapAdminAccountsCommandTest extends TestCase
 {
     use RefreshDatabase;
 
+    private array $envBackup = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Snapshot and clear admin bootstrap env vars so dotenv values from
+        // .env do not leak into the test (env() reads $_ENV/$_SERVER first).
+        foreach ([
+            'INITIAL_ADMIN_EMAIL',
+            'INITIAL_ADMIN_PASSWORD',
+            'INITIAL_SUPER_ADMIN_EMAIL',
+            'INITIAL_SUPER_ADMIN_PASSWORD',
+        ] as $key) {
+            $this->envBackup[$key] = $_ENV[$key] ?? $_SERVER[$key] ?? false;
+            unset($_ENV[$key], $_SERVER[$key]);
+            putenv($key);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envBackup as $key => $value) {
+            if ($value === false) {
+                unset($_ENV[$key], $_SERVER[$key]);
+                putenv($key);
+            } else {
+                $_ENV[$key] = $value;
+                $_SERVER[$key] = $value;
+                putenv($key.'='.$value);
+            }
+        }
+        $this->envBackup = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * Set the four bootstrap env vars in a way that env() will pick up.
+     */
+    private function setBootstrapEnv(string $admin, string $adminPass, string $superAdmin, string $superAdminPass): void
+    {
+        $values = [
+            'INITIAL_ADMIN_EMAIL' => $admin,
+            'INITIAL_ADMIN_PASSWORD' => $adminPass,
+            'INITIAL_SUPER_ADMIN_EMAIL' => $superAdmin,
+            'INITIAL_SUPER_ADMIN_PASSWORD' => $superAdminPass,
+        ];
+        foreach ($values as $key => $value) {
+            $_ENV[$key] = $value;
+            $_SERVER[$key] = $value;
+            putenv($key.'='.$value);
+        }
+    }
+
     public function test_command_fails_when_env_credentials_missing(): void
     {
-        config([
-            'app.env' => 'testing',
-        ]);
-
-        // Ensure env getters return null
-        putenv('INITIAL_ADMIN_EMAIL');
-        putenv('INITIAL_ADMIN_PASSWORD');
-        putenv('INITIAL_SUPER_ADMIN_EMAIL');
-        putenv('INITIAL_SUPER_ADMIN_PASSWORD');
-
         $exitCode = Artisan::call('admin:bootstrap-accounts');
         $this->assertEquals(1, $exitCode);
     }
 
     public function test_command_creates_admin_and_super_admin_from_env(): void
     {
-        putenv('INITIAL_ADMIN_EMAIL=admin@example.go.id');
-        putenv('INITIAL_ADMIN_PASSWORD=temp-pass-1234');
-        putenv('INITIAL_SUPER_ADMIN_EMAIL=superadmin@example.go.id');
-        putenv('INITIAL_SUPER_ADMIN_PASSWORD=super-temp-1234');
+        $this->setBootstrapEnv(
+            'admin@example.go.id',
+            'temp-pass-1234',
+            'superadmin@example.go.id',
+            'super-temp-1234',
+        );
 
         $exitCode = Artisan::call('admin:bootstrap-accounts');
         $this->assertEquals(0, $exitCode);
@@ -52,6 +99,13 @@ class BootstrapAdminAccountsCommandTest extends TestCase
             'force_password_change' => true,
         ]);
 
+        // Bootstrap accounts must be email-verified so the `verified` middleware
+        // does not block them on /admin/* routes.
+        $admin = User::where('email', 'admin@example.go.id')->firstOrFail();
+        $superAdmin = User::where('email', 'superadmin@example.go.id')->firstOrFail();
+        $this->assertNotNull($admin->email_verified_at, 'Bootstrapped admin must have email_verified_at set');
+        $this->assertNotNull($superAdmin->email_verified_at, 'Bootstrapped super admin must have email_verified_at set');
+
         $this->assertDatabaseHas('admin_account_audits', [
             'action' => AdminAccountAudit::ACTION_CREATED,
         ]);
@@ -59,10 +113,12 @@ class BootstrapAdminAccountsCommandTest extends TestCase
 
     public function test_command_is_idempotent_for_existing_users(): void
     {
-        putenv('INITIAL_ADMIN_EMAIL=admin@example.go.id');
-        putenv('INITIAL_ADMIN_PASSWORD=temp-pass-1234');
-        putenv('INITIAL_SUPER_ADMIN_EMAIL=superadmin@example.go.id');
-        putenv('INITIAL_SUPER_ADMIN_PASSWORD=super-temp-1234');
+        $this->setBootstrapEnv(
+            'admin@example.go.id',
+            'temp-pass-1234',
+            'superadmin@example.go.id',
+            'super-temp-1234',
+        );
 
         Artisan::call('admin:bootstrap-accounts');
         $countBefore = User::count();
@@ -73,10 +129,12 @@ class BootstrapAdminAccountsCommandTest extends TestCase
 
     public function test_command_force_reset_password_updates_password(): void
     {
-        putenv('INITIAL_ADMIN_EMAIL=admin@example.go.id');
-        putenv('INITIAL_ADMIN_PASSWORD=initial-pass-1234');
-        putenv('INITIAL_SUPER_ADMIN_EMAIL=superadmin@example.go.id');
-        putenv('INITIAL_SUPER_ADMIN_PASSWORD=initial-super-1234');
+        $this->setBootstrapEnv(
+            'admin@example.go.id',
+            'initial-pass-1234',
+            'superadmin@example.go.id',
+            'initial-super-1234',
+        );
 
         Artisan::call('admin:bootstrap-accounts');
 
@@ -84,7 +142,12 @@ class BootstrapAdminAccountsCommandTest extends TestCase
         $admin->forceFill(['password' => Hash::make('manually-changed')])->save();
 
         // Re-run with force reset and a new password
-        putenv('INITIAL_ADMIN_PASSWORD=new-reset-pass-1234');
+        $this->setBootstrapEnv(
+            'admin@example.go.id',
+            'new-reset-pass-1234',
+            'superadmin@example.go.id',
+            'initial-super-1234',
+        );
         Artisan::call('admin:bootstrap-accounts', ['--force-reset-password' => true]);
 
         $admin->refresh();


### PR DESCRIPTION
Refs: #245
Refs: #246 (follow-up bug discovered during deploy)

## Masalah
Saat deploy production untuk #245:
- `admin:bootstrap-accounts` sukses membuat 2 akun (admin + super_admin), tapi `email_verified_at` ternyata NULL.
- Akibat: `verified` middleware menolak akses ke `/admin/*` meskipun login berhasil.

## Akar Masalah
`User::$fillable` tidak mencantumkan `email_verified_at`, sehingga `User::create([... 'email_verified_at' => now() ...])` di-strip oleh mass-assignment guard tanpa error.

## Patch
- `BootstrapAdminAccounts`: ganti `User::create()` jadi `(new User)->forceFill([...])->save()` agar `email_verified_at` ikut tersimpan.
- `AdminAccountManagementService::create()`: pola yang sama saat super admin membuat akun admin baru via UI.
- Tambah assertion `email_verified_at != null` di `BootstrapAdminAccountsCommandTest` dan `AdminAccountManagementTest` supaya regresi ini ketangkap test.
- Bonus: `BootstrapAdminAccountsCommandTest` sekarang clean `$_ENV/$_SERVER` pada `setUp/tearDown` agar tidak terpengaruh `INITIAL_*` di `.env` lokal.

## Verifikasi
```
cd laravel && php artisan test
Tests: 510 passed (2127 assertions)
```
Smoke production setelah data NULL diperbaiki manual:
- `GET /admin/login` → 200
- `POST /admin/login` (admin valid) → 302 ke `/admin` → 302 ke `/admin/password/change` (force_password_change flow jalan)

## Catatan deploy
Akun production yang sudah keburu dibuat dengan `email_verified_at=NULL` sudah di-update manual saat deploy. Setelah PR ini merge, bootstrap berikutnya (kalau ada akun baru) langsung verified.