### PR TITLE
[codex] Refresh admin monitoring UI

### DIFF
--- a/issue/issue-238-admin-overview-visual-refresh-2026-05-19.md
+++ b/issue/issue-238-admin-overview-visual-refresh-2026-05-19.md
@@ -1,0 +1,59 @@
+# Redesign Admin Overview sesuai referensi
+
+## Latar Belakang
+Halaman `/admin` saat ini sudah menampilkan metrik operasional, tetapi susunan visualnya masih berupa blok KPI generik dan belum mengikuti referensi yang diberikan: sidebar lebih ringan, topbar dengan breadcrumb dan search, hero ringkasan operasional, kartu metrik ringkas, grafik garis, donut distribusi, ringkasan insiden, tabel aktivitas, dan daftar error.
+
+## Tujuan
+Menyusun ulang halaman admin overview agar tampak sangat dekat dengan referensi gambar, tanpa mengubah kontrak data monitoring, kontrol akses, atau isi sensitif yang sengaja tidak ditampilkan.
+
+## Ruang Lingkup
+- Update layout admin bersama untuk sidebar dan topbar yang terlihat pada halaman overview.
+- Update view Livewire `AdminDashboard` untuk hero, kartu ringkasan, grafik, donut, ringkasan insiden, tabel aktivitas, dan daftar error.
+- Update CSS admin design system yang dibutuhkan oleh tampilan baru.
+- Sambungkan teks tren hero dan ringkasan insiden ke perbandingan nyata dari `AdminMetricsService`.
+- Pertahankan tautan ke halaman admin yang sudah ada.
+
+## Di Luar Scope
+- Tidak menambah chart library JavaScript baru.
+- Tidak mengubah model monitoring atau skema database.
+- Tidak mengubah akses admin, auth, logout, atau page admin lain di luar dampak visual shell bersama.
+- Tidak melakukan deploy production.
+
+## Area / File Terkait
+- `laravel/resources/views/layouts/admin.blade.php`
+- `laravel/resources/views/components/layouts/admin.blade.php`
+- `laravel/resources/views/components/admin/sidebar.blade.php`
+- `laravel/resources/views/livewire/admin/admin-dashboard.blade.php`
+- `laravel/resources/css/app.css`
+- `laravel/app/Services/Admin/AdminMetricsService.php`
+- Test admin existing di `laravel/tests/Feature/Admin`
+- Unit test service di `laravel/tests/Unit/Services/Admin/AdminMetricsServiceTest.php`
+
+## Risiko
+- Shell admin dipakai halaman admin lain, sehingga perubahan topbar/sidebar harus tetap responsif dan tidak merusak navigasi.
+- Grafik SVG/donut CSS harus tetap aman ketika data kosong.
+- Perhitungan tren harus menampilkan state "belum ada pembanding" saat periode pembanding kosong agar tidak menampilkan angka palsu.
+- Test snapshot berbasis teks/class dapat gagal jika class penting hilang.
+
+## Langkah Implementasi
+1. Petakan markup dashboard, layout, sidebar, dan CSS admin yang sudah ada.
+2. Refactor sidebar menjadi dua grup menu seperti referensi dan tetap pertahankan link super admin.
+3. Refactor topbar menjadi breadcrumb, search, tombol tema, kembali ke chat, logout, dan profil.
+4. Ubah overview menjadi hero ringkasan, empat kartu metrik, grid grafik/donut/insiden, tabel aktivitas, dan error list.
+5. Tambahkan perhitungan tren hari ini vs kemarin dan 7 hari terakhir vs 7 hari sebelumnya.
+6. Tambahkan kelas CSS khusus admin overview untuk visual yang lebih dekat dengan referensi.
+7. Jalankan build asset dan test Laravel yang relevan.
+8. Simplifikasi overview agar tidak terlalu ramai: hero hanya 3 KPI utama, card ringkas memakai satu angka utama, distribusi fitur dipindahkan ke tab Usage, panel error digabung menjadi insiden terbaru, dan tabel aktivitas dibatasi 3 baris.
+9. Kembalikan header empat card ringkasan ke gaya sebelumnya: icon kecil dan judul merah, tetapi isi card tetap ringkas.
+
+## Rencana Test
+- `cd laravel && npm run build`
+- `cd laravel && php artisan test tests/Unit/Services/Admin/AdminMetricsServiceTest.php`
+- `cd laravel && php artisan test tests/Feature/Admin/AdminAccessTest.php tests/Feature/Admin/AdminLayoutTest.php tests/Feature/Admin/AdminMonitoringDashboardTest.php`
+- Jika ada kegagalan akibat perubahan markup yang disengaja, update test secara minimal selama coverage perilaku tetap sama.
+
+## Kriteria Selesai
+- Halaman `/admin` memiliki struktur visual sesuai referensi gambar.
+- Navigasi admin, tombol kembali ke chat, logout, dark mode, dan profil tetap tersedia.
+- Data sensitif prompt/jawaban tetap tidak tampil.
+- Build frontend dan test admin relevan lulus atau kegagalannya terdokumentasi jelas.

--- a/issue/issue-239-admin-users-redesign-2026-05-19.md
+++ b/issue/issue-239-admin-users-redesign-2026-05-19.md
@@ -1,0 +1,19 @@
+# Issue 239 - Admin Users Redesign
+
+## Tujuan
+Mengubah tampilan `/admin/users` agar mengikuti referensi screenshot: halaman ringkas, read-only, dengan KPI presence di atas filter dan tabel user yang lebih rapi.
+
+## Scope
+- Tambahkan KPI dinamis untuk total user, online, idle, dan offline.
+- Rapikan hero/header halaman Users agar konsisten dengan desain admin overview.
+- Ubah filter menjadi panel lebar dengan search/status/role dan reset di kanan.
+- Ubah tabel user agar memakai avatar inisial, badge status/role, densitas seperti referensi, dan pagination 15 user per halaman.
+- Rapikan kolom total agar conv/doc/memo tidak bertumpuk secara acak.
+
+## Risiko
+- Perubahan CSS admin harus tetap terisolasi agar tidak mengganggu halaman monitoring lain.
+- Query KPI presence harus tetap read-only dan tidak membuka isi percakapan/dokumen/memo.
+
+## Verifikasi
+- Jalankan build Vite.
+- Jalankan test admin monitoring dan unit service terkait presence.

--- a/issue/issue-240-admin-usage-redesign-2026-05-19.md
+++ b/issue/issue-240-admin-usage-redesign-2026-05-19.md
@@ -1,0 +1,18 @@
+# Issue 240 - Admin Usage Redesign
+
+## Tujuan
+Merapikan `/admin/usage` agar konsisten dengan halaman admin Overview dan Users, serta mengganti ikon Usage di sidebar yang saat ini menyerupai ikon musik.
+
+## Scope
+- Ganti ikon sidebar Usage menjadi ikon grafik/aktivitas.
+- Ubah heading/topbar Usage agar konsisten.
+- Tambahkan KPI compact untuk total event, sukses, pending, dan gagal/blocked berbasis query backend.
+- Rapikan filter, tabel event, dan panel distribusi fitur dengan ukuran dan ritme visual seperti tab Users.
+
+## Risiko
+- Query KPI harus tetap read-only dan tidak mengambil isi percakapan/dokumen/memo.
+- CSS baru harus terisolasi di class `admin-usage-*`.
+
+## Verifikasi
+- Jalankan build Vite.
+- Jalankan test admin monitoring dan unit service metrics.

--- a/issue/issue-241-admin-errors-redesign-2026-05-19.md
+++ b/issue/issue-241-admin-errors-redesign-2026-05-19.md
@@ -1,0 +1,19 @@
+# Issue 241 - Admin Errors Redesign
+
+## Tujuan
+Merapikan `/admin/errors` agar konsisten dengan halaman admin Overview, Users, dan Usage.
+
+## Scope
+- Ubah heading, badge, filter, tabel error, dan panel ringkasan ke pola visual compact admin terbaru.
+- Tambahkan KPI error yang dihitung dari filter aktif.
+- Batasi tabel error menjadi 5 baris per halaman dengan pagination.
+- Tetap tampilkan `request_id` untuk debugging tanpa membuat tabel penuh.
+
+## Risiko
+- Halaman harus tetap read-only dan tidak menampilkan isi percakapan, dokumen, atau memo.
+- Summary error harus dihitung dari keseluruhan filter aktif, bukan hanya row halaman saat ini.
+- CSS baru harus terisolasi di class `admin-errors-*`.
+
+## Verifikasi
+- Jalankan build Vite.
+- Jalankan test admin monitoring dan unit service metrics.

--- a/issue/issue-242-admin-usage-model-errors-detail-2026-05-19.md
+++ b/issue/issue-242-admin-usage-model-errors-detail-2026-05-19.md
@@ -1,0 +1,21 @@
+# Issue 242 - Admin Usage Model and Error Detail
+
+## Tujuan
+Membedakan fokus `/admin/usage` dan `/admin/errors` agar Usage menjadi observability request normal, sedangkan Errors menjadi incident/debugging view.
+
+## Scope
+- Tambahkan metadata model AI (`model_label`, `model_provider`, `model_name`) pada event chat ketika Python stream mengirim marker model.
+- Tampilkan kolom Model di tabel Usage.
+- Tambahkan severity otomatis pada Errors berdasarkan `error_code`, status, feature, dan metadata.
+- Tambahkan tombol aksi Detail pada Errors yang membuka modal berisi informasi lengkap, metadata aman, kemungkinan penyebab, dan langkah penanganan.
+- Pertahankan privasi: tidak menampilkan prompt, jawaban, isi dokumen, atau memo.
+
+## Risiko
+- Event lama belum memiliki metadata model; UI harus menampilkan fallback yang rapi.
+- Severity dihitung otomatis tanpa migration, jadi harus deterministik dan mudah dipahami.
+- Modal detail harus mengambil data dari event yang sudah terfilter sebagai error/blocked.
+
+## Verifikasi
+- Jalankan build Vite.
+- Jalankan test admin monitoring, tracking event AI, dan unit service metrics.
+- Jalankan test Python terkait metadata stream bila relevan.

--- a/issue/issue-admin-account-management-ui-consistency-2026-05-19.md
+++ b/issue/issue-admin-account-management-ui-consistency-2026-05-19.md
@@ -1,0 +1,57 @@
+# Redesign Admin Account Management UI
+
+## Latar Belakang
+Halaman Account Management masih memakai layout lama, sementara tab admin lain sudah memakai pola compact: hero, KPI dot-card, filter panel, table panel, dan modal/drawer yang rapi.
+
+## Tujuan
+- Menyamakan tampilan Account Management dengan Overview, Users, Usage, Errors, dan Documents.
+- Menjaga semua aksi sensitif tetap memakai service dan guard yang ada.
+- Menampilkan ringkasan akun admin secara dinamis.
+
+## Ruang Lingkup
+- Redesign Blade Account Management.
+- Tambah summary data di Livewire render tanpa mengubah aturan bisnis.
+- Tambah CSS khusus `admin-accounts-*`.
+- Update test feature yang relevan bila assertion UI berubah.
+- Refinement tabel admin mengikuti referensi: kolom akun/role/status/login/aksi, tanpa 2FA, tanpa kolom password, dan tanpa kartu prioritas akun.
+
+## Di Luar Scope
+- Tidak mengubah permission super admin.
+- Tidak mengubah logic create/edit/deactivate/reset password.
+- Tidak mengubah audit log atau skema database.
+
+## Area / File Terkait
+- `laravel/app/Livewire/Admin/AdminAccounts.php`
+- `laravel/resources/views/livewire/admin/admin-accounts.blade.php`
+- `laravel/resources/css/app.css`
+- `laravel/tests/Feature/Admin/AdminAccountManagementTest.php`
+
+## Risiko
+- Aksi akun sensitif tidak boleh kehilangan confirm/validation.
+- Modal create/edit/deactivate harus tetap memetakan error Livewire dengan benar.
+- Header dan table harus tetap memuat teks yang dipakai test.
+
+## Langkah Implementasi
+1. Tambah summary akun di Livewire.
+2. Redesign halaman dengan pola admin modern.
+3. Buat filter panel dan table compact.
+4. Samakan modal create/edit/deactivate dengan gaya drawer/modal admin terbaru.
+5. Jalankan test dan build.
+6. Refinement tabel admin: hapus kolom password, aksi menjadi Edit + toggle status + Reset Password, dan ubah panel kanan menjadi Ringkasan Keamanan tanpa data 2FA.
+7. Padatkan ukuran KPI/card dan hilangkan kebutuhan scrollbar horizontal pada tabel admin.
+8. Samakan avatar, role badge, dan status badge tabel Account Management dengan pola tabel Users.
+9. Pastikan pagination Account Management tetap 15 akun per halaman dan header aksi tidak menempel ke sisi kanan tabel.
+10. Perbaiki Ringkasan Keamanan agar item memakai ikon berwarna seperti referensi dan tetap tanpa 2FA.
+11. Hapus panel Ringkasan Keamanan dan lebarkan tabel Account Management menjadi full-width.
+12. Ubah 4 KPI header Account Management mengikuti referensi tanpa ikon: total akun, akun aktif, perlu reset password, dan super admin aktif.
+
+## Rencana Test
+- `php artisan test tests/Feature/Admin/AdminAccountManagementTest.php`
+- `php artisan test tests/Feature/Admin/AdminMonitoringDashboardTest.php`
+- `npm run build`
+- `git diff --check`
+
+## Kriteria Selesai
+- UI Account Management konsisten dengan tab admin lain.
+- Semua aksi akun tetap tersedia.
+- Test dan build lulus.

--- a/issue/issue-admin-ai-configuration-ui-consistency-2026-05-19.md
+++ b/issue/issue-admin-ai-configuration-ui-consistency-2026-05-19.md
@@ -1,0 +1,51 @@
+# Redesign Admin AI Configuration UI
+
+## Latar Belakang
+Halaman AI Configuration masih berupa placeholder, sementara tab admin lain sudah memakai pola compact: hero, KPI dot-card, panel konfigurasi, tabel/status list, dan detail operasional yang rapi.
+
+## Tujuan
+- Menyamakan tampilan AI Configuration dengan Overview, Users, Usage, Errors, Documents, dan Account Management.
+- Menampilkan konfigurasi AI yang sudah tersedia dari Laravel config tanpa membuka secret.
+- Membuat halaman terasa seperti pusat kendali AI, walau backend editor prompt/model penuh belum tersedia.
+
+## Ruang Lingkup
+- Redesign Blade `admin.ai-config`.
+- Tambah CSS khusus `admin-ai-config-*`.
+- Pakai nilai dari `services.ai_service` dan `services.ai_document_service` bila tersedia.
+- Update test akses/layout untuk assertion UI baru.
+
+## Di Luar Scope
+- Tidak membuat tabel konfigurasi AI baru.
+- Tidak menambah aksi simpan/activate/rollback.
+- Tidak menampilkan token/API key mentah.
+- Tidak mengubah runtime model resolver atau service AI.
+
+## Area / File Terkait
+- `laravel/resources/views/admin/ai-config.blade.php`
+- `laravel/resources/css/app.css`
+- `laravel/tests/Feature/Admin/AdminAccessTest.php`
+- `laravel/tests/Feature/Admin/AdminLayoutTest.php`
+
+## Risiko
+- UI tidak boleh memberi kesan konfigurasi tersimpan bila backend belum ada.
+- Nilai endpoint tidak boleh menampilkan token.
+- Copy perlu jelas sebagai status operasional, bukan fitur edit penuh.
+
+## Langkah Implementasi
+1. Bangun hero dan KPI dot-card konsisten dengan tab admin lain.
+2. Tampilkan routing model/pipeline per fitur sebagai tabel ringkas.
+3. Tampilkan parameter service dan prompt profile sebagai panel compact.
+4. Tampilkan guardrail dan rollout status tanpa aksi destruktif.
+5. Tambah CSS responsive dan dark mode.
+6. Update test dan jalankan verifikasi.
+
+## Rencana Test
+- `cd laravel && php artisan test tests/Feature/Admin/AdminAccessTest.php tests/Feature/Admin/AdminLayoutTest.php`
+- `cd laravel && npm run build`
+- `git diff --check`
+
+## Kriteria Selesai
+- AI Configuration tidak lagi placeholder.
+- Tampilan konsisten dengan tab admin lain.
+- Secret tetap tidak muncul.
+- Test dan build lulus.

--- a/issue/issue-admin-documents-ai-pipeline-ui-2026-05-19.md
+++ b/issue/issue-admin-documents-ai-pipeline-ui-2026-05-19.md
@@ -1,0 +1,60 @@
+# Redesign Admin Documents Menjadi AI Pipeline View
+
+## Latar Belakang
+Tab Admin Documents saat ini sudah konsisten secara visual dengan tab monitoring lain, tetapi masih terasa seperti file list biasa. Untuk platform AI document, admin perlu melihat dokumen sebagai pipeline: uploaded, parsed, indexed, lalu ready.
+
+## Tujuan
+- Membuat Documents terlihat modern sebagai AI document pipeline.
+- Menampilkan file icon sesuai tipe dokumen.
+- Menampilkan status chip, progress pipeline, owner, size, waktu upload.
+- Menambah filter by type, status, user, dan date.
+- Menambah detail drawer metadata file dan status pipeline tanpa membuka isi dokumen.
+
+## Ruang Lingkup
+- Update Livewire admin documents untuk filter tambahan, pagination, selected document detail.
+- Update service admin metrics untuk filter dokumen, owner options, chunk count, dan metadata aman.
+- Update Blade/CSS Documents agar konsisten dengan Overview, Users, Usage, Errors.
+- Tambah relasi/model minimal untuk menghitung `document_chunks`.
+- Update test feature/unit yang relevan.
+
+## Di Luar Scope
+- Tidak menambah kolom database baru.
+- Tidak membaca atau menampilkan isi dokumen.
+- Tidak mengubah job parsing/embedding Python.
+- Tidak mengubah lifecycle upload/process dokumen.
+
+## Area / File Terkait
+- `laravel/app/Livewire/Admin/AdminDocuments.php`
+- `laravel/app/Services/Admin/AdminMetricsService.php`
+- `laravel/app/Models/Document.php`
+- `laravel/app/Models/DocumentChunk.php`
+- `laravel/resources/views/livewire/admin/admin-documents.blade.php`
+- `laravel/resources/css/app.css`
+- `laravel/tests/Feature/Admin/AdminMonitoringDashboardTest.php`
+- `laravel/tests/Unit/Services/Admin/AdminMetricsServiceTest.php`
+
+## Risiko
+- Pipeline status perlu diturunkan dari field yang ada (`status`, `preview_status`, chunk count), sehingga label harus jelas sebagai metadata operasional, bukan klaim isi dokumen.
+- Filter user/date/type harus tetap aman terhadap input query string malformed.
+- Detail drawer tidak boleh membocorkan konten dokumen atau chunk text.
+
+## Langkah Implementasi
+1. Tambahkan model/relasi `DocumentChunk` hanya untuk menghitung chunk count.
+2. Perluas `AdminMetricsService::documentListing()` dengan filter type, user, date, chunk count, dan helper owner options.
+3. Perluas `AdminDocuments` dengan state filter dan detail drawer.
+4. Redesign Blade Documents: icon tipe, status chip, progress pipeline, filter lengkap, dan drawer detail metadata.
+5. Tambahkan CSS khusus Documents pipeline.
+6. Update test untuk filter, pagination, chunk count/detail drawer.
+
+## Rencana Test
+- Jalankan feature test admin monitoring.
+- Jalankan unit test admin metrics.
+- Jalankan `npm run build`.
+- Jalankan `git diff --check`.
+
+## Kriteria Selesai
+- Documents tampil sebagai AI pipeline view.
+- Filter type/status/user/date bekerja.
+- Detail drawer menampilkan metadata file, parsing status, chunk count, embedding status.
+- Tidak ada isi dokumen yang bocor.
+- Test dan build relevan lulus.

--- a/issue/issue-admin-kpi-card-header-consistency-2026-05-19.md
+++ b/issue/issue-admin-kpi-card-header-consistency-2026-05-19.md
@@ -1,0 +1,44 @@
+# Samakan Header KPI Card Admin
+
+## Latar Belakang
+Empat card ringkasan di Overview sudah memakai gaya yang lebih disukai: icon kecil dan judul merah. KPI card di tab lain masih memakai dot marker sehingga terasa kurang konsisten.
+
+## Tujuan
+- Menyamakan header KPI card bagian atas di semua tab admin.
+- Memakai pola icon kecil + judul merah seperti Overview.
+- Menjaga isi card tetap ringkas dan tidak mengubah data atau aksi.
+
+## Ruang Lingkup
+- Users
+- Usage
+- Errors
+- Documents
+- Account Management
+- AI Configuration
+
+## Di Luar Scope
+- Panel kerja seperti Filter, tabel, chart, drawer, dan modal.
+- Perubahan query/backend.
+- Perubahan wording besar selain penambahan icon.
+
+## Area / File Terkait
+- `laravel/resources/views/livewire/admin/admin-users.blade.php`
+- `laravel/resources/views/livewire/admin/admin-usage.blade.php`
+- `laravel/resources/views/livewire/admin/admin-errors.blade.php`
+- `laravel/resources/views/livewire/admin/admin-documents.blade.php`
+- `laravel/resources/views/livewire/admin/admin-accounts.blade.php`
+- `laravel/resources/views/admin/ai-config.blade.php`
+- `laravel/resources/css/app.css`
+- Test admin feature terkait
+
+## Langkah Implementasi
+1. Tambahkan path icon pada array KPI tiap tab.
+2. Ganti marker dot menjadi SVG icon pada markup KPI.
+3. Tambah CSS umum untuk header KPI icon + label merah.
+4. Update assertion test ringan agar ikon KPI ikut terjaga.
+5. Jalankan test admin dan build frontend.
+
+## Rencana Test
+- `cd laravel && php artisan test tests/Feature/Admin/AdminMonitoringDashboardTest.php tests/Feature/Admin/AdminAccountManagementTest.php tests/Feature/Admin/AdminLayoutTest.php`
+- `cd laravel && npm run build`
+- `git diff --check`

--- a/laravel/app/Http/Controllers/Chat/ChatStreamController.php
+++ b/laravel/app/Http/Controllers/Chat/ChatStreamController.php
@@ -194,6 +194,7 @@ class ChatStreamController extends Controller
             $streamBuffer = '';
             $sources = [];
             $errorStreamDetected = false;
+            $modelMetadata = [];
 
             try {
                 foreach (
@@ -205,6 +206,7 @@ class ChatStreamController extends Controller
                         $sourcePolicy,
                         $allowAutoRealtimeWeb,
                         $resolvedDocumentIds,
+                        $requestId,
                     ) as $rawChunk
                 ) {
                     // Abort if browser disconnected
@@ -218,6 +220,7 @@ class ChatStreamController extends Controller
                     );
 
                     if ($parsedModelName !== null) {
+                        $modelMetadata = $usageEvents->modelMetadata($parsedModelName);
                         $this->sendSseEvent('model-name', $parsedModelName);
                     }
 
@@ -260,6 +263,7 @@ class ChatStreamController extends Controller
                         'has_documents' => $hasDocumentContext,
                         'document_count' => count($resolvedDocumentIds),
                         'reason' => 'stream_exception',
+                        ...$modelMetadata,
                     ],
                     requestId: $requestId,
                     latencyMs: $usageEvents->latencyMsSince($streamStartedAt),
@@ -290,6 +294,7 @@ class ChatStreamController extends Controller
                         'has_documents' => $hasDocumentContext,
                         'document_count' => count($resolvedDocumentIds),
                         'reason' => 'error_sentinel',
+                        ...$modelMetadata,
                     ],
                     requestId: $requestId,
                     latencyMs: $usageEvents->latencyMsSince($streamStartedAt),
@@ -336,6 +341,7 @@ class ChatStreamController extends Controller
                         'sources_count' => count($sources),
                         'has_sources' => ! empty($sources),
                         'response_length' => strlen($cleanContent),
+                        ...$modelMetadata,
                     ],
                     requestId: $requestId,
                     latencyMs: $usageEvents->latencyMsSince($streamStartedAt),

--- a/laravel/app/Jobs/GenerateChatResponse.php
+++ b/laravel/app/Jobs/GenerateChatResponse.php
@@ -125,6 +125,7 @@ class GenerateChatResponse implements ShouldQueue
         $fullResponse = '';
         $streamBuffer = '';
         $sources = [];
+        $modelMetadata = [];
 
         $pythonCallStart = microtime(true) * 1000;
 
@@ -140,10 +141,14 @@ class GenerateChatResponse implements ShouldQueue
                 $requestId,
             ) as $chunk
         ) {
-            [$chunk, $streamBuffer, $_modelName, $parsedSources] = $orchestrator->extractStreamMetadata(
+            [$chunk, $streamBuffer, $parsedModelName, $parsedSources] = $orchestrator->extractStreamMetadata(
                 (string) $chunk,
                 $streamBuffer
             );
+
+            if ($parsedModelName !== null) {
+                $modelMetadata = $usageEvents->modelMetadata($parsedModelName);
+            }
 
             if (! empty($parsedSources)) {
                 $sources = $parsedSources;
@@ -184,6 +189,7 @@ class GenerateChatResponse implements ShouldQueue
                     'has_documents' => $hasDocumentContext,
                     'document_count' => count($documentIds),
                     'reason' => 'error_sentinel',
+                    ...$modelMetadata,
                 ],
                 requestId: $requestId,
                 latencyMs: $usageEvents->latencyMsSince($jobStartedAt),
@@ -234,6 +240,7 @@ class GenerateChatResponse implements ShouldQueue
                     'sources_count' => count($sources),
                     'has_sources' => ! empty($sources),
                     'response_length' => strlen($cleanContent),
+                    ...$modelMetadata,
                 ],
                 requestId: $requestId,
                 latencyMs: $usageEvents->latencyMsSince($jobStartedAt),

--- a/laravel/app/Livewire/Admin/AdminAccounts.php
+++ b/laravel/app/Livewire/Admin/AdminAccounts.php
@@ -81,6 +81,14 @@ class AdminAccounts extends Component
         $this->resetPage();
     }
 
+    public function resetFilters(): void
+    {
+        $this->reset(['search', 'roleFilter', 'statusFilter']);
+        $this->roleFilter = 'all';
+        $this->statusFilter = 'all';
+        $this->resetPage();
+    }
+
     public function openCreateModal(): void
     {
         $this->reset(['newName', 'newEmail', 'newPassword']);
@@ -295,11 +303,34 @@ class AdminAccounts extends Component
             $query->where('is_active', false);
         }
 
+        $summary = [
+            'total' => (clone $query)->count(),
+            'active' => (clone $query)->where('is_active', true)->count(),
+            'inactive' => (clone $query)->where('is_active', false)->count(),
+            'force_password_change' => (clone $query)->where('force_password_change', true)->count(),
+            'active_super_admins' => (clone $query)
+                ->where('role', User::ROLE_SUPER_ADMIN)
+                ->where('is_active', true)
+                ->count(),
+        ];
+
         $accounts = $query->paginate(15);
 
         return view('livewire.admin.admin-accounts', [
             'accounts' => $accounts,
-            'totalActiveSuperAdmins' => $service->activeSuperAdminsCount(),
+            'accountsPerPage' => 15,
+            'accountSummary' => $summary,
+            'editingUser' => $this->editingUserId ? User::query()->find($this->editingUserId) : null,
+            'roleOptions' => [
+                'all' => 'Semua',
+                User::ROLE_ADMIN => 'Admin',
+                User::ROLE_SUPER_ADMIN => 'Super Admin',
+            ],
+            'statusOptions' => [
+                'all' => 'Semua',
+                'active' => 'Aktif',
+                'inactive' => 'Nonaktif',
+            ],
         ]);
     }
 

--- a/laravel/app/Livewire/Admin/AdminDashboard.php
+++ b/laravel/app/Livewire/Admin/AdminDashboard.php
@@ -35,17 +35,16 @@ class AdminDashboard extends Component
     {
         $kpis = $metrics->overviewKpis();
         $series = $metrics->dailyActivitySeries($this->rangeDays);
-        $distribution = $metrics->featureDistribution(
-            now()->subDays($this->rangeDays - 1)->startOfDay(),
-            now(),
-        );
-        $recentEvents = $metrics->recentEvents([], 10);
-        $recentErrors = $metrics->recentErrors([], 5);
+        $recentEvents = $metrics->recentEvents([], 3);
+        $recentErrors = $metrics->recentErrors([], 2);
+        $comparisons = $metrics->overviewComparisons();
+        $lastUpdatedAt = $metrics->lastOverviewActivityAt();
 
         return view('livewire.admin.admin-dashboard', [
             'kpis' => $kpis,
+            'comparisons' => $comparisons,
+            'lastUpdatedAt' => $lastUpdatedAt,
             'series' => $series,
-            'distribution' => $distribution,
             'recentEvents' => $recentEvents,
             'recentErrors' => $recentErrors,
             'rangeDays' => $this->rangeDays,

--- a/laravel/app/Livewire/Admin/AdminDocuments.php
+++ b/laravel/app/Livewire/Admin/AdminDocuments.php
@@ -5,13 +5,28 @@ namespace App\Livewire\Admin;
 use App\Services\Admin\AdminMetricsService;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
+use Livewire\WithPagination;
 
 #[Layout('layouts.admin', ['title' => 'Documents', 'heading' => 'Dokumen'])]
 class AdminDocuments extends Component
 {
+    use WithPagination;
+
+    private const DOCUMENTS_PER_PAGE = 10;
+
     public string $search = '';
 
     public string $status = '';
+
+    public string $type = '';
+
+    public string $ownerId = '';
+
+    public string $startDate = '';
+
+    public string $endDate = '';
+
+    public ?int $selectedDocumentId = null;
 
     /**
      * @var array<string, array<int, string>>
@@ -19,31 +34,106 @@ class AdminDocuments extends Component
     protected $queryString = [
         'search' => ['except' => ''],
         'status' => ['except' => ''],
+        'type' => ['except' => ''],
+        'ownerId' => ['except' => ''],
+        'startDate' => ['except' => ''],
+        'endDate' => ['except' => ''],
     ];
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingStatus(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingType(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingOwnerId(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingStartDate(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingEndDate(): void
+    {
+        $this->resetPage();
+    }
 
     public function resetFilters(): void
     {
-        $this->reset(['search', 'status']);
+        $this->reset(['search', 'status', 'type', 'ownerId', 'startDate', 'endDate']);
+        $this->resetPage();
+    }
+
+    public function showDetail(int $documentId): void
+    {
+        $this->selectedDocumentId = $documentId;
+    }
+
+    public function closeDetail(): void
+    {
+        $this->selectedDocumentId = null;
     }
 
     public function render(AdminMetricsService $metrics)
     {
         $payload = $metrics->documentListing([
             'search' => $this->search ?: null,
-            'status' => $this->status ?: null,
-        ], AdminMetricsService::RECENT_ROWS_LIMIT);
+            'status' => $this->normalizedStatus(),
+            'type' => $this->normalizedType(),
+            'user_id' => $this->normalizedOwnerId(),
+            'start_date' => $this->startDate ?: null,
+            'end_date' => $this->endDate ?: null,
+        ], self::DOCUMENTS_PER_PAGE, $this->getPage());
 
         return view('livewire.admin.admin-documents', [
             'documents' => $payload['rows'],
+            'documentsPerPage' => self::DOCUMENTS_PER_PAGE,
             'statusCounts' => $payload['status_counts'],
             'mimeCounts' => $payload['mime_counts'],
             'totalSizeBytes' => $payload['total_size_bytes'],
+            'ownerOptions' => $metrics->documentOwnerOptions(),
+            'selectedDocument' => $metrics->documentDetail($this->selectedDocumentId),
+            'typeOptions' => [
+                'pdf' => 'PDF',
+                'csv' => 'CSV',
+                'xlsx' => 'XLS / XLSX',
+                'docx' => 'DOCX',
+            ],
             'statusOptions' => [
                 'pending' => 'Pending',
                 'processing' => 'Processing',
                 'ready' => 'Ready',
-                'error' => 'Error',
+                'error' => 'Failed',
             ],
         ]);
+    }
+
+    private function normalizedStatus(): ?string
+    {
+        return in_array($this->status, ['pending', 'processing', 'ready', 'error'], true)
+            ? $this->status
+            : null;
+    }
+
+    private function normalizedType(): ?string
+    {
+        return in_array($this->type, ['pdf', 'csv', 'xlsx', 'docx'], true) ? $this->type : null;
+    }
+
+    private function normalizedOwnerId(): ?int
+    {
+        return ctype_digit($this->ownerId) ? (int) $this->ownerId : null;
     }
 }

--- a/laravel/app/Livewire/Admin/AdminErrors.php
+++ b/laravel/app/Livewire/Admin/AdminErrors.php
@@ -6,10 +6,15 @@ use App\Models\AIUsageEvent;
 use App\Services\Admin\AdminMetricsService;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
+use Livewire\WithPagination;
 
-#[Layout('layouts.admin', ['title' => 'Errors', 'heading' => 'AI Errors'])]
+#[Layout('layouts.admin', ['title' => 'Errors', 'heading' => 'Errors'])]
 class AdminErrors extends Component
 {
+    use WithPagination;
+
+    private const ERRORS_PER_PAGE = 5;
+
     public string $feature = '';
 
     public string $startDate = '';
@@ -17,6 +22,8 @@ class AdminErrors extends Component
     public string $endDate = '';
 
     public string $requestId = '';
+
+    public ?int $selectedErrorId = null;
 
     /**
      * @var array<string, array<int, string>>
@@ -28,9 +35,45 @@ class AdminErrors extends Component
         'requestId' => ['except' => ''],
     ];
 
+    public function updatingFeature(): void
+    {
+        $this->resetPage();
+        $this->closeDetail();
+    }
+
+    public function updatingStartDate(): void
+    {
+        $this->resetPage();
+        $this->closeDetail();
+    }
+
+    public function updatingEndDate(): void
+    {
+        $this->resetPage();
+        $this->closeDetail();
+    }
+
+    public function updatingRequestId(): void
+    {
+        $this->resetPage();
+        $this->closeDetail();
+    }
+
     public function resetFilters(): void
     {
         $this->reset(['feature', 'startDate', 'endDate', 'requestId']);
+        $this->resetPage();
+        $this->closeDetail();
+    }
+
+    public function showDetail(int $eventId): void
+    {
+        $this->selectedErrorId = $eventId;
+    }
+
+    public function closeDetail(): void
+    {
+        $this->selectedErrorId = null;
     }
 
     public function render(AdminMetricsService $metrics)
@@ -42,15 +85,19 @@ class AdminErrors extends Component
             'request_id' => $this->requestId ?: null,
         ];
 
-        $errors = $metrics->recentErrors($filters, AdminMetricsService::RECENT_ROWS_LIMIT);
-
-        $byFeature = $errors->groupBy('feature')->map->count()->sortDesc();
-        $byCode = $errors->whereNotNull('error_code')->groupBy('error_code')->map->count()->sortDesc();
+        $errors = $metrics->errorEventsListing($filters, self::ERRORS_PER_PAGE, $this->getPage());
+        $errorSummary = $metrics->errorEventSummary($filters);
+        $selectedError = $this->selectedErrorId !== null
+            ? $metrics->errorEventDetail($this->selectedErrorId)
+            : null;
 
         return view('livewire.admin.admin-errors', [
             'errors' => $errors,
-            'byFeature' => $byFeature,
-            'byCode' => $byCode,
+            'errorsPerPage' => self::ERRORS_PER_PAGE,
+            'selectedError' => $selectedError,
+            'errorSummary' => $errorSummary,
+            'byFeature' => $errorSummary['by_feature'],
+            'byCode' => $errorSummary['by_code'],
             'featureOptions' => [
                 AIUsageEvent::FEATURE_CHAT => 'Chat',
                 AIUsageEvent::FEATURE_DOCUMENT_RAG => 'Chat Dokumen (RAG)',

--- a/laravel/app/Livewire/Admin/AdminUsage.php
+++ b/laravel/app/Livewire/Admin/AdminUsage.php
@@ -6,10 +6,15 @@ use App\Models\AIUsageEvent;
 use App\Services\Admin\AdminMetricsService;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
+use Livewire\WithPagination;
 
-#[Layout('layouts.admin', ['title' => 'Usage', 'heading' => 'AI Usage'])]
+#[Layout('layouts.admin', ['title' => 'Usage', 'heading' => 'Usage'])]
 class AdminUsage extends Component
 {
+    use WithPagination;
+
+    private const EVENTS_PER_PAGE = 5;
+
     public string $feature = '';
 
     public string $status = '';
@@ -28,9 +33,30 @@ class AdminUsage extends Component
         'endDate' => ['except' => ''],
     ];
 
+    public function updatingFeature(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingStatus(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingStartDate(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingEndDate(): void
+    {
+        $this->resetPage();
+    }
+
     public function resetFilters(): void
     {
         $this->reset(['feature', 'status', 'startDate', 'endDate']);
+        $this->resetPage();
     }
 
     public function render(AdminMetricsService $metrics)
@@ -42,7 +68,8 @@ class AdminUsage extends Component
             'end_date' => $this->endDate ?: null,
         ];
 
-        $events = $metrics->recentEvents($filters, AdminMetricsService::RECENT_ROWS_LIMIT);
+        $events = $metrics->usageEventsListing($filters, self::EVENTS_PER_PAGE, $this->getPage());
+        $totals = $metrics->usageEventSummary($filters);
 
         // Normalize dates safely. Malformed query strings are dropped here so
         // the dashboard never throws a 500 on unparseable input. Default
@@ -58,15 +85,9 @@ class AdminUsage extends Component
 
         $distribution = $metrics->featureDistribution($distributionStart, $distributionEnd);
 
-        $totals = [
-            'total' => $events->count(),
-            'success' => $events->where('status', AIUsageEvent::STATUS_SUCCESS)->count(),
-            'failed' => $events->where('status', AIUsageEvent::STATUS_ERROR)->count(),
-            'pending' => $events->where('status', AIUsageEvent::STATUS_PENDING)->count(),
-        ];
-
         return view('livewire.admin.admin-usage', [
             'events' => $events,
+            'eventsPerPage' => self::EVENTS_PER_PAGE,
             'distribution' => $distribution,
             'totals' => $totals,
             'featureOptions' => $this->featureOptions(),

--- a/laravel/app/Livewire/Admin/AdminUsers.php
+++ b/laravel/app/Livewire/Admin/AdminUsers.php
@@ -8,10 +8,12 @@ use Livewire\Attributes\Layout;
 use Livewire\Component;
 use Livewire\WithPagination;
 
-#[Layout('layouts.admin', ['title' => 'Users', 'heading' => 'User Activity'])]
+#[Layout('layouts.admin', ['title' => 'Users', 'heading' => 'Users'])]
 class AdminUsers extends Component
 {
     use WithPagination;
+
+    private const USERS_PER_PAGE = 15;
 
     public string $search = '';
 
@@ -57,11 +59,15 @@ class AdminUsers extends Component
                 'role' => $this->normalizedRole(),
                 'search' => $this->search,
             ],
-            AdminMetricsService::RECENT_ROWS_LIMIT,
+            self::USERS_PER_PAGE,
+            null,
+            $this->getPage(),
         );
 
         return view('livewire.admin.admin-users', [
             'users' => $users,
+            'usersPerPage' => self::USERS_PER_PAGE,
+            'presenceSummary' => $metrics->userPresenceSummary(),
             'statusOptions' => [
                 'online' => 'Online',
                 'idle' => 'Idle',

--- a/laravel/app/Models/Document.php
+++ b/laravel/app/Models/Document.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 class Document extends Model
@@ -104,6 +105,11 @@ class Document extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function chunks(): HasMany
+    {
+        return $this->hasMany(DocumentChunk::class);
     }
 
     public function cloudStorageFiles(): MorphMany

--- a/laravel/app/Models/DocumentChunk.php
+++ b/laravel/app/Models/DocumentChunk.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DocumentChunk extends Model
+{
+    protected $fillable = [
+        'document_id',
+        'page_number',
+        'text_content',
+    ];
+
+    public function document(): BelongsTo
+    {
+        return $this->belongsTo(Document::class);
+    }
+}

--- a/laravel/app/Services/Admin/AIUsageEventService.php
+++ b/laravel/app/Services/Admin/AIUsageEventService.php
@@ -71,6 +71,9 @@ class AIUsageEventService
         'page_count',
         'job_class',
         'job_attempts',
+        'model_label',
+        'model_name',
+        'model_provider',
         'subject_label',
         'subject_kind',
     ];
@@ -190,6 +193,36 @@ class AIUsageEventService
     }
 
     /**
+     * Convert the Python stream model marker into safe event metadata.
+     *
+     * @return array<string, string>
+     */
+    public function modelMetadata(?string $modelLabel): array
+    {
+        $label = trim((string) $modelLabel);
+
+        if ($label === '') {
+            return [];
+        }
+
+        $metadata = [
+            'model_label' => $label,
+        ];
+
+        $provider = $this->inferModelProvider($label);
+        if ($provider !== null) {
+            $metadata['model_provider'] = $provider;
+        }
+
+        $modelName = $this->inferModelName($label);
+        if ($modelName !== null) {
+            $metadata['model_name'] = $modelName;
+        }
+
+        return $metadata;
+    }
+
+    /**
      * Sanitize event metadata so prompts, answers, and document content
      * cannot leak into the database.
      *
@@ -271,6 +304,43 @@ class AIUsageEventService
 
             return null;
         }
+    }
+
+    private function inferModelProvider(string $label): ?string
+    {
+        $lower = strtolower($label);
+
+        return match (true) {
+            str_contains($lower, 'bedrock') => 'bedrock',
+            str_contains($lower, 'groq') => 'groq',
+            str_contains($lower, 'mistral') => 'github_models',
+            str_contains($lower, 'gpt') => 'github_models',
+            str_contains($lower, 'glm') => 'bedrock',
+            str_contains($lower, 'nova') => 'bedrock',
+            str_contains($label, ':') => trim(strtolower(strtok($label, ':'))) ?: null,
+            default => null,
+        };
+    }
+
+    private function inferModelName(string $label): ?string
+    {
+        $lower = strtolower($label);
+
+        return match (true) {
+            str_contains($lower, 'gpt-4.1 mini') => 'openai/gpt-4.1-mini',
+            str_contains($lower, 'gpt-4.1 nano') => 'openai/gpt-4.1-nano',
+            str_contains($lower, 'gpt-4.1') => 'openai/gpt-4.1',
+            str_contains($lower, 'gpt-4o') => 'openai/gpt-4o',
+            str_contains($lower, 'llama 3.3') => 'groq/llama-3.3-70b-versatile',
+            str_contains($lower, 'mistral medium') => 'mistral-ai/mistral-medium-2505',
+            str_contains($lower, 'mistral small') => 'mistral-ai/mistral-small-2503',
+            str_contains($lower, 'gpt-oss 120b') => 'openai.gpt-oss-120b-1:0',
+            str_contains($lower, 'glm 4.7 flash') => 'zai.glm-4.7-flash',
+            str_contains($lower, 'glm 4.7') => 'zai.glm-4.7',
+            str_contains($lower, 'nova micro') => 'amazon.nova-micro-v1:0',
+            str_contains($label, ':') => trim(substr($label, strpos($label, ':') + 1)) ?: null,
+            default => null,
+        };
     }
 
     private function sanitizeValue(mixed $value, int $depth = 0): mixed

--- a/laravel/app/Services/Admin/AdminMetricsService.php
+++ b/laravel/app/Services/Admin/AdminMetricsService.php
@@ -11,6 +11,7 @@ use App\Models\User;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
@@ -125,6 +126,124 @@ class AdminMetricsService
     }
 
     /**
+     * Presence counters for the /admin/users KPI cards.
+     *
+     * @return array{total: int, online: int, idle: int, offline: int}
+     */
+    public function userPresenceSummary(?CarbonInterface $now = null): array
+    {
+        $now = $now ? $now->copy() : now();
+        $total = User::query()->count();
+
+        $online = User::query()
+            ->whereNotNull('last_seen_at')
+            ->where('last_seen_at', '>=', $now->copy()->subMinutes(self::PRESENCE_ONLINE_MINUTES))
+            ->count();
+
+        $idle = User::query()
+            ->whereNotNull('last_seen_at')
+            ->where('last_seen_at', '<', $now->copy()->subMinutes(self::PRESENCE_ONLINE_MINUTES))
+            ->where('last_seen_at', '>=', $now->copy()->subMinutes(self::PRESENCE_IDLE_MINUTES))
+            ->count();
+
+        return [
+            'total' => $total,
+            'online' => $online,
+            'idle' => $idle,
+            'offline' => max(0, $total - $online - $idle),
+        ];
+    }
+
+    /**
+     * Compare headline overview metrics against their previous period.
+     *
+     * @return array<string, array<string, float|int|string|bool|null>>
+     */
+    public function overviewComparisons(?CarbonInterface $now = null): array
+    {
+        $now = $now ? $now->copy() : now();
+        $todayStart = $now->copy()->startOfDay();
+        $yesterdayStart = $now->copy()->subDay()->startOfDay();
+        $yesterdayEnd = $now->copy()->subDay()->endOfDay();
+
+        $currentDayCounts = $this->eventStatusCountsBetween($todayStart, $now);
+        $previousDayCounts = $this->eventStatusCountsBetween($yesterdayStart, $yesterdayEnd);
+
+        $currentDayLatency = $this->averageLatencyBetween($todayStart, $now);
+        $previousDayLatency = $this->averageLatencyBetween($yesterdayStart, $yesterdayEnd);
+
+        $currentSevenStart = $now->copy()->subDays(6)->startOfDay();
+        $previousSevenStart = $now->copy()->subDays(13)->startOfDay();
+        $previousSevenEnd = $now->copy()->subDays(7)->endOfDay();
+
+        $currentSevenCounts = $this->eventStatusCountsBetween($currentSevenStart, $now);
+        $previousSevenCounts = $this->eventStatusCountsBetween($previousSevenStart, $previousSevenEnd);
+
+        return [
+            'ai_requests' => $this->comparisonPayload(
+                $currentDayCounts['total'],
+                $previousDayCounts['total'],
+                $previousDayCounts['total'] > 0,
+                'percent',
+                true,
+            ),
+            'success_rate' => $this->comparisonPayload(
+                $this->rate($currentDayCounts['success'], $currentDayCounts['total']),
+                $this->rate($previousDayCounts['success'], $previousDayCounts['total']),
+                $previousDayCounts['total'] > 0,
+                'percentage_points',
+                true,
+            ),
+            'avg_latency_ms' => $this->comparisonPayload(
+                $currentDayLatency,
+                $previousDayLatency,
+                $currentDayLatency !== null && $previousDayLatency !== null,
+                'milliseconds',
+                false,
+            ),
+            'error_rate' => $this->comparisonPayload(
+                $this->rate($currentDayCounts['failed'], $currentDayCounts['total']),
+                $this->rate($previousDayCounts['failed'], $previousDayCounts['total']),
+                $previousDayCounts['total'] > 0,
+                'percentage_points',
+                false,
+            ),
+            'errors_7d' => $this->comparisonPayload(
+                $currentSevenCounts['failed'],
+                $previousSevenCounts['failed'],
+                $previousSevenCounts['failed'] > 0,
+                'percent',
+                false,
+            ),
+            'error_rate_7d' => $this->comparisonPayload(
+                $this->rate($currentSevenCounts['failed'], $currentSevenCounts['total']),
+                $this->rate($previousSevenCounts['failed'], $previousSevenCounts['total']),
+                $previousSevenCounts['total'] > 0,
+                'percentage_points',
+                false,
+            ),
+        ];
+    }
+
+    /**
+     * Latest timestamp among operational data that can change overview metrics.
+     */
+    public function lastOverviewActivityAt(): ?Carbon
+    {
+        return collect([
+            AIUsageEvent::query()->max('created_at'),
+            Conversation::query()->max('updated_at'),
+            Document::query()->max('updated_at'),
+            Memo::query()->max('updated_at'),
+            Message::query()->max('created_at'),
+        ])
+            ->filter()
+            ->map(fn ($value) => Carbon::parse($value))
+            ->sortDesc()
+            ->first();
+    }
+
+    /**
      * Build a daily activity series suitable for a small chart on the
      * overview page (events per day for the last $days days).
      *
@@ -208,6 +327,47 @@ class AdminMetricsService
     }
 
     /**
+     * Paginated AI usage events for the dedicated /admin/usage table.
+     *
+     * @param  array<string, mixed>  $filters
+     */
+    public function usageEventsListing(array $filters = [], int $perPage = 5, ?int $page = null): LengthAwarePaginator
+    {
+        $perPage = max(1, min($perPage, self::RECENT_ROWS_LIMIT));
+
+        return $this->applyEventFilters(AIUsageEvent::query(), $filters)
+            ->with('user:id,name,email,role')
+            ->orderByDesc('created_at')
+            ->paginate($perPage, ['*'], 'page', $page);
+    }
+
+    /**
+     * Aggregate usage KPI counters for the /admin/usage page.
+     *
+     * @param  array<string, mixed>  $filters
+     * @return array{total: int, success: int, pending: int, failed: int}
+     */
+    public function usageEventSummary(array $filters = []): array
+    {
+        $row = $this->applyEventFilters(AIUsageEvent::query(), $filters)
+            ->selectRaw('COUNT(*) as total')
+            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as success', [AIUsageEvent::STATUS_SUCCESS])
+            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as pending', [AIUsageEvent::STATUS_PENDING])
+            ->selectRaw('SUM(CASE WHEN status IN (?, ?) THEN 1 ELSE 0 END) as failed', [
+                AIUsageEvent::STATUS_ERROR,
+                AIUsageEvent::STATUS_BLOCKED,
+            ])
+            ->first();
+
+        return [
+            'total' => (int) ($row->total ?? 0),
+            'success' => (int) ($row->success ?? 0),
+            'pending' => (int) ($row->pending ?? 0),
+            'failed' => (int) ($row->failed ?? 0),
+        ];
+    }
+
+    /**
      * Recent failed/blocked events for the errors page.
      *
      * @param  array<string, mixed>  $filters
@@ -216,12 +376,290 @@ class AdminMetricsService
     {
         $limit = max(1, min($limit, self::RECENT_ROWS_LIMIT));
 
-        return $this->applyEventFilters(AIUsageEvent::query(), $filters)
-            ->whereIn('status', [AIUsageEvent::STATUS_ERROR, AIUsageEvent::STATUS_BLOCKED])
+        return $this->errorEventsQuery($filters)
             ->with('user:id,name,email,role')
             ->orderByDesc('created_at')
             ->limit($limit)
-            ->get();
+            ->get()
+            ->map(fn (AIUsageEvent $event) => $this->attachErrorAttributes($event));
+    }
+
+    /**
+     * Paginated failed/blocked events for the dedicated /admin/errors table.
+     *
+     * @param  array<string, mixed>  $filters
+     */
+    public function errorEventsListing(array $filters = [], int $perPage = 5, ?int $page = null): LengthAwarePaginator
+    {
+        $perPage = max(1, min($perPage, self::RECENT_ROWS_LIMIT));
+
+        $errors = $this->errorEventsQuery($filters)
+            ->with('user:id,name,email,role')
+            ->orderByDesc('created_at')
+            ->paginate($perPage, ['*'], 'page', $page);
+
+        $errors->setCollection(
+            $errors->getCollection()->map(fn (AIUsageEvent $event) => $this->attachErrorAttributes($event))
+        );
+
+        return $errors;
+    }
+
+    /**
+     * Aggregate failed/blocked event counters for the /admin/errors page.
+     *
+     * @param  array<string, mixed>  $filters
+     * @return array{total: int, error: int, blocked: int, unique_codes: int, latest_at: Carbon|null, by_feature: array<int, array{feature: string, total: int}>, by_code: array<int, array{code: string, total: int}>}
+     */
+    public function errorEventSummary(array $filters = []): array
+    {
+        $baseQuery = $this->errorEventsQuery($filters);
+
+        $row = (clone $baseQuery)
+            ->selectRaw('COUNT(*) as total')
+            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as error', [AIUsageEvent::STATUS_ERROR])
+            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as blocked', [AIUsageEvent::STATUS_BLOCKED])
+            ->selectRaw("COUNT(DISTINCT COALESCE(error_code, 'unknown_error')) as unique_codes")
+            ->first();
+
+        $latestAt = (clone $baseQuery)->max('created_at');
+
+        $byFeature = (clone $baseQuery)
+            ->selectRaw('feature, COUNT(*) as total')
+            ->groupBy('feature')
+            ->orderByDesc('total')
+            ->get()
+            ->map(fn ($row) => [
+                'feature' => (string) $row->feature,
+                'total' => (int) $row->total,
+            ])
+            ->all();
+
+        $byCode = (clone $baseQuery)
+            ->selectRaw("COALESCE(error_code, 'unknown_error') as code, COUNT(*) as total")
+            ->groupByRaw("COALESCE(error_code, 'unknown_error')")
+            ->orderByDesc('total')
+            ->get()
+            ->map(fn ($row) => [
+                'code' => (string) $row->code,
+                'total' => (int) $row->total,
+            ])
+            ->all();
+
+        return [
+            'total' => (int) ($row->total ?? 0),
+            'error' => (int) ($row->error ?? 0),
+            'blocked' => (int) ($row->blocked ?? 0),
+            'unique_codes' => (int) ($row->unique_codes ?? 0),
+            'latest_at' => $latestAt ? Carbon::parse($latestAt) : null,
+            'by_feature' => $byFeature,
+            'by_code' => $byCode,
+        ];
+    }
+
+    public function errorEventDetail(int $eventId): ?AIUsageEvent
+    {
+        $event = AIUsageEvent::query()
+            ->whereKey($eventId)
+            ->whereIn('status', [AIUsageEvent::STATUS_ERROR, AIUsageEvent::STATUS_BLOCKED])
+            ->with('user:id,name,email,role')
+            ->first();
+
+        return $event instanceof AIUsageEvent ? $this->attachErrorAttributes($event) : null;
+    }
+
+    /**
+     * @return array{level: string, label: string, tone: string, description: string}
+     */
+    public function errorSeverity(AIUsageEvent $event): array
+    {
+        $code = strtolower((string) ($event->error_code ?: 'unknown_error'));
+        $reason = strtolower((string) data_get($event->metadata, 'reason', ''));
+
+        $criticalCodes = ['job_failed', 'ai_unavailable', 'service_unavailable', 'all_models_failed'];
+        $highCodes = ['error_sentinel', 'stream_exception', 'document_context_unavailable', 'ingest_failed'];
+        $mediumCodes = ['drive_download_failed', 'drive_temp_unavailable', 'storage_failed', 'persist_failed', 'draft_request_failed', 'unsupported_provider'];
+        $lowCodes = ['invalid_mime_type', 'file_too_large', 'validation_failed', 'format_requires_table', 'already_imported'];
+
+        if (in_array($code, $criticalCodes, true) || str_contains($reason, 'all_models')) {
+            return [
+                'level' => 'critical',
+                'label' => 'Critical',
+                'tone' => 'critical',
+                'description' => 'Kemungkinan gangguan sistem atau pipeline AI utama.',
+            ];
+        }
+
+        if (in_array($code, $highCodes, true)) {
+            return [
+                'level' => 'high',
+                'label' => 'High',
+                'tone' => 'danger',
+                'description' => 'Request user gagal dan perlu pengecekan operasional.',
+            ];
+        }
+
+        if ($event->status === AIUsageEvent::STATUS_BLOCKED || in_array($code, $mediumCodes, true)) {
+            return [
+                'level' => 'medium',
+                'label' => 'Medium',
+                'tone' => 'warning',
+                'description' => 'Masalah integrasi, policy, atau proses yang perlu dipantau.',
+            ];
+        }
+
+        if (in_array($code, $lowCodes, true)) {
+            return [
+                'level' => 'low',
+                'label' => 'Low',
+                'tone' => 'neutral',
+                'description' => 'Masalah validasi atau input yang biasanya bisa diperbaiki user.',
+            ];
+        }
+
+        return [
+            'level' => 'medium',
+            'label' => 'Medium',
+            'tone' => 'warning',
+            'description' => 'Belum ada klasifikasi khusus untuk kode error ini.',
+        ];
+    }
+
+    /**
+     * @return array{summary: string, causes: array<int, string>, steps: array<int, string>}
+     */
+    public function errorHandlingGuidance(AIUsageEvent $event): array
+    {
+        $code = strtolower((string) ($event->error_code ?: 'unknown_error'));
+
+        return match ($code) {
+            'error_sentinel' => [
+                'summary' => 'Python AI service mengembalikan sentinel error, biasanya setelah provider/model tidak berhasil memberi respons.',
+                'causes' => [
+                    'Provider AI terkena rate limit atau timeout.',
+                    'Token provider tidak valid atau sudah melewati kuota.',
+                    'Semua fallback model gagal sebelum menghasilkan jawaban.',
+                ],
+                'steps' => [
+                    'Cari request ID di log Laravel dan Python AI.',
+                    'Cek health service Python AI dan koneksi provider.',
+                    'Periksa token, rate limit, dan urutan fallback model.',
+                    'Minta user ulangi request setelah service/model pulih.',
+                ],
+            ],
+            'stream_exception' => [
+                'summary' => 'Streaming jawaban terputus karena exception saat Laravel membaca respons AI.',
+                'causes' => [
+                    'Koneksi SSE terputus atau timeout.',
+                    'Python AI service menutup stream secara tidak normal.',
+                    'Ada exception saat parsing metadata stream.',
+                ],
+                'steps' => [
+                    'Cek log request ID pada Laravel.',
+                    'Bandingkan waktu error dengan log Python AI.',
+                    'Uji ulang chat singkat untuk memastikan stream pulih.',
+                ],
+            ],
+            'document_context_unavailable' => [
+                'summary' => 'Request membutuhkan konteks dokumen, tetapi dokumen belum siap atau tidak tersedia untuk retrieval.',
+                'causes' => [
+                    'Dokumen masih pending/processing.',
+                    'Indexing atau Chroma belum memuat dokumen.',
+                    'Dokumen dihapus, bukan milik user, atau gagal diproses.',
+                ],
+                'steps' => [
+                    'Cek status dokumen pada tab Documents.',
+                    'Pastikan dokumen berstatus ready dan punya hasil indexing.',
+                    'Ulang proses dokumen bila status error atau indexing kosong.',
+                ],
+            ],
+            'job_failed' => [
+                'summary' => 'Background job chat gagal setelah retry queue.',
+                'causes' => [
+                    'Worker queue berhenti atau timeout.',
+                    'Dependency AI/Python sedang tidak stabil.',
+                    'Exception tidak tertangani pada pipeline job fallback.',
+                ],
+                'steps' => [
+                    'Cek worker queue dan failed jobs.',
+                    'Cari stack trace dengan request ID atau conversation ID.',
+                    'Restart worker setelah akar masalah diperbaiki.',
+                ],
+            ],
+            'ingest_failed' => [
+                'summary' => 'Proses ingest dokumen gagal sehingga dokumen tidak siap dipakai RAG.',
+                'causes' => [
+                    'File tidak bisa diekstrak atau format bermasalah.',
+                    'Embedding provider gagal atau rate limited.',
+                    'Storage/vector index tidak tersedia.',
+                ],
+                'steps' => [
+                    'Cek detail dokumen dan log proses ingest.',
+                    'Pastikan embedding provider dan Chroma tersedia.',
+                    'Minta user upload ulang bila file rusak.',
+                ],
+            ],
+            'format_requires_table' => [
+                'summary' => 'User meminta export spreadsheet, tetapi jawaban AI tidak memiliki tabel.',
+                'causes' => [
+                    'Konten jawaban berupa paragraf biasa.',
+                    'Format export tidak cocok dengan struktur jawaban.',
+                ],
+                'steps' => [
+                    'Minta user menghasilkan jawaban dalam bentuk tabel.',
+                    'Gunakan format dokumen non-spreadsheet untuk konten naratif.',
+                ],
+            ],
+            'invalid_mime_type', 'file_too_large', 'validation_failed' => [
+                'summary' => 'Request ditolak karena validasi input atau batasan file.',
+                'causes' => [
+                    'Format file tidak didukung.',
+                    'Ukuran file melewati batas.',
+                    'Input tidak memenuhi aturan validasi.',
+                ],
+                'steps' => [
+                    'Sampaikan format dan ukuran yang didukung ke user.',
+                    'Minta user memperbaiki input lalu mencoba ulang.',
+                ],
+            ],
+            default => [
+                'summary' => 'Error belum memiliki panduan khusus, tetapi metadata aman dan trace dapat dipakai untuk investigasi.',
+                'causes' => [
+                    'Kegagalan berasal dari fitur atau integrasi terkait.',
+                    'Kode error belum diklasifikasikan secara spesifik.',
+                ],
+                'steps' => [
+                    'Cari request ID pada log aplikasi.',
+                    'Cek feature, status, latency, dan metadata pada modal ini.',
+                    'Tambahkan klasifikasi khusus bila error ini sering muncul.',
+                ],
+            ],
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $filters
+     */
+    private function errorEventsQuery(array $filters = []): Builder
+    {
+        return $this->applyEventFilters(AIUsageEvent::query(), $filters)
+            ->whereIn('status', [AIUsageEvent::STATUS_ERROR, AIUsageEvent::STATUS_BLOCKED]);
+    }
+
+    private function attachErrorAttributes(AIUsageEvent $event): AIUsageEvent
+    {
+        $severity = $this->errorSeverity($event);
+        $guidance = $this->errorHandlingGuidance($event);
+
+        $event->setAttribute('severity_level', $severity['level']);
+        $event->setAttribute('severity_label', $severity['label']);
+        $event->setAttribute('severity_tone', $severity['tone']);
+        $event->setAttribute('severity_description', $severity['description']);
+        $event->setAttribute('handling_summary', $guidance['summary']);
+        $event->setAttribute('handling_causes', $guidance['causes']);
+        $event->setAttribute('handling_steps', $guidance['steps']);
+
+        return $event;
     }
 
     /**
@@ -230,10 +668,10 @@ class AdminMetricsService
      *
      * @param  array<string, mixed>  $filters
      */
-    public function userPresenceListing(array $filters = [], int $limit = self::RECENT_ROWS_LIMIT, ?CarbonInterface $now = null): Collection
+    public function userPresenceListing(array $filters = [], int $perPage = 15, ?CarbonInterface $now = null, ?int $page = null): LengthAwarePaginator
     {
         $now = $now ? $now->copy() : now();
-        $limit = max(1, min($limit, self::RECENT_ROWS_LIMIT));
+        $perPage = max(1, min($perPage, self::RECENT_ROWS_LIMIT));
         $startOfToday = $now->copy()->startOfDay();
         $startOfWeek = $now->copy()->subDays(6)->startOfDay();
 
@@ -284,14 +722,13 @@ class AdminMetricsService
             ->orderByRaw('CASE WHEN last_seen_at IS NULL THEN 1 ELSE 0 END')
             ->orderByDesc('last_seen_at')
             ->orderBy('name')
-            ->limit($limit)
-            ->get();
+            ->paginate($perPage, ['*'], 'page', $page);
 
-        if ($users->isEmpty()) {
+        if ($users->getCollection()->isEmpty()) {
             return $users;
         }
 
-        $ids = $users->pluck('id')->all();
+        $ids = $users->getCollection()->pluck('id')->all();
 
         $eventsToday = AIUsageEvent::query()
             ->whereIn('user_id', $ids)
@@ -325,7 +762,7 @@ class AdminMetricsService
             ->groupBy('user_id')
             ->pluck('total', 'user_id');
 
-        return $users->map(function (User $user) use ($now, $eventsToday, $eventsWeek, $conversationCounts, $documentCounts, $memoCounts) {
+        $users->setCollection($users->getCollection()->map(function (User $user) use ($now, $eventsToday, $eventsWeek, $conversationCounts, $documentCounts, $memoCounts) {
             $user->setAttribute('presence_status', $this->presenceStatus($user, $now));
             $user->setAttribute('events_today', (int) ($eventsToday[$user->id] ?? 0));
             $user->setAttribute('events_week', (int) ($eventsWeek[$user->id] ?? 0));
@@ -334,32 +771,114 @@ class AdminMetricsService
             $user->setAttribute('memo_count', (int) ($memoCounts[$user->id] ?? 0));
 
             return $user;
-        });
+        }));
+
+        return $users;
     }
 
     /**
      * Document listing for the /admin/documents page with status counters.
      *
      * @param  array<string, mixed>  $filters
-     * @return array{rows: Collection, status_counts: array<string, int>, mime_counts: array<string, int>, total_size_bytes: int}
+     * @return array{rows: LengthAwarePaginator, status_counts: array<string, int>, mime_counts: array<string, int>, total_size_bytes: int}
      */
-    public function documentListing(array $filters = [], int $limit = self::RECENT_ROWS_LIMIT): array
+    public function documentListing(array $filters = [], int $perPage = 10, ?int $page = null): array
     {
-        $limit = max(1, min($limit, self::RECENT_ROWS_LIMIT));
+        $perPage = max(1, min($perPage, self::RECENT_ROWS_LIMIT));
 
-        $query = Document::query()
+        $query = $this->applyDocumentFilters(Document::query(), $filters);
+
+        $rows = (clone $query)
             ->select([
                 'id',
                 'user_id',
                 'original_name',
                 'mime_type',
                 'file_size_bytes',
+                'source_provider',
+                'source_external_id',
+                'source_synced_at',
                 'status',
+                'preview_html_path',
                 'preview_status',
                 'created_at',
                 'updated_at',
-            ]);
+            ])
+            ->with('user:id,name,email')
+            ->withCount('chunks')
+            ->orderByDesc('created_at')
+            ->paginate($perPage, ['*'], 'page', $page);
 
+        $statusCounts = (clone $query)
+            ->selectRaw('status, COUNT(*) as total')
+            ->groupBy('status')
+            ->pluck('total', 'status')
+            ->mapWithKeys(fn ($total, $status) => [(string) ($status ?: 'unknown') => (int) $total])
+            ->all();
+
+        $mimeCounts = (clone $query)
+            ->selectRaw('mime_type, COUNT(*) as total')
+            ->groupBy('mime_type')
+            ->pluck('total', 'mime_type')
+            ->mapWithKeys(fn ($total, $mime) => [(string) ($mime ?: 'unknown') => (int) $total])
+            ->all();
+
+        $totalSize = (int) (clone $query)->sum('file_size_bytes');
+
+        return [
+            'rows' => $rows,
+            'status_counts' => $statusCounts,
+            'mime_counts' => $mimeCounts,
+            'total_size_bytes' => $totalSize,
+        ];
+    }
+
+    public function documentDetail(?int $documentId): ?Document
+    {
+        if ($documentId === null || $documentId < 1) {
+            return null;
+        }
+
+        return Document::query()
+            ->select([
+                'id',
+                'user_id',
+                'filename',
+                'original_name',
+                'file_path',
+                'mime_type',
+                'file_size_bytes',
+                'source_provider',
+                'source_external_id',
+                'source_synced_at',
+                'status',
+                'preview_html_path',
+                'preview_status',
+                'created_at',
+                'updated_at',
+            ])
+            ->with('user:id,name,email')
+            ->withCount('chunks')
+            ->find($documentId);
+    }
+
+    public function documentOwnerOptions(int $limit = 100): Collection
+    {
+        $limit = max(1, min($limit, self::RECENT_ROWS_LIMIT));
+
+        return User::query()
+            ->select(['id', 'name', 'email'])
+            ->whereIn('id', Document::query()->select('user_id'))
+            ->orderBy('name')
+            ->limit($limit)
+            ->get();
+    }
+
+    /**
+     * @param  array<string, mixed>  $filters
+     */
+    private function applyDocumentFilters(Builder $query, array $filters = []): Builder
+    {
         if (! empty($filters['status'])) {
             $query->where('status', $filters['status']);
         }
@@ -368,37 +887,38 @@ class AdminMetricsService
             $query->where('user_id', $filters['user_id']);
         }
 
+        if (! empty($filters['type'])) {
+            $mimeTypes = match ((string) $filters['type']) {
+                'pdf' => ['application/pdf'],
+                'csv' => ['text/csv', 'text/plain', 'application/csv'],
+                'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel'],
+                'docx' => ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+                default => [],
+            };
+
+            if ($mimeTypes !== []) {
+                $query->whereIn('mime_type', $mimeTypes);
+            }
+        }
+
         if (! empty($filters['search'])) {
             $query->where('original_name', 'like', '%'.trim((string) $filters['search']).'%');
         }
 
-        $rows = $query->with('user:id,name,email')
-            ->orderByDesc('created_at')
-            ->limit($limit)
-            ->get();
+        [$start, $end] = $this->safeDateRange(
+            $filters['start_date'] ?? null,
+            $filters['end_date'] ?? null,
+        );
 
-        $statusCounts = Document::query()
-            ->selectRaw('status, COUNT(*) as total')
-            ->groupBy('status')
-            ->pluck('total', 'status')
-            ->mapWithKeys(fn ($total, $status) => [(string) ($status ?: 'unknown') => (int) $total])
-            ->all();
+        if ($start !== null) {
+            $query->where('created_at', '>=', $start);
+        }
 
-        $mimeCounts = Document::query()
-            ->selectRaw('mime_type, COUNT(*) as total')
-            ->groupBy('mime_type')
-            ->pluck('total', 'mime_type')
-            ->mapWithKeys(fn ($total, $mime) => [(string) ($mime ?: 'unknown') => (int) $total])
-            ->all();
+        if ($end !== null) {
+            $query->where('created_at', '<=', $end);
+        }
 
-        $totalSize = (int) Document::query()->sum('file_size_bytes');
-
-        return [
-            'rows' => $rows,
-            'status_counts' => $statusCounts,
-            'mime_counts' => $mimeCounts,
-            'total_size_bytes' => $totalSize,
-        ];
+        return $query;
     }
 
     /**
@@ -425,7 +945,7 @@ class AdminMetricsService
         }
 
         if (! empty($filters['request_id'])) {
-            $query->where('request_id', $filters['request_id']);
+            $query->where('request_id', 'like', '%'.trim((string) $filters['request_id']).'%');
         }
 
         [$start, $end] = $this->safeDateRange(
@@ -539,6 +1059,100 @@ class AdminMetricsService
         }
 
         return (int) round($value);
+    }
+
+    /**
+     * @return array{total: int, success: int, failed: int}
+     */
+    private function eventStatusCountsBetween(CarbonInterface $start, CarbonInterface $end): array
+    {
+        $row = AIUsageEvent::query()
+            ->selectRaw('COUNT(*) as total')
+            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as success', [AIUsageEvent::STATUS_SUCCESS])
+            ->selectRaw('SUM(CASE WHEN status IN (?, ?) THEN 1 ELSE 0 END) as failed', [
+                AIUsageEvent::STATUS_ERROR,
+                AIUsageEvent::STATUS_BLOCKED,
+            ])
+            ->whereBetween('created_at', [$start, $end])
+            ->first();
+
+        return [
+            'total' => (int) ($row->total ?? 0),
+            'success' => (int) ($row->success ?? 0),
+            'failed' => (int) ($row->failed ?? 0),
+        ];
+    }
+
+    private function averageLatencyBetween(CarbonInterface $start, CarbonInterface $end): ?int
+    {
+        return $this->roundedAverage(
+            AIUsageEvent::query()
+                ->whereBetween('created_at', [$start, $end])
+                ->where('action', AIUsageEvent::ACTION_COMPLETED)
+                ->where('status', AIUsageEvent::STATUS_SUCCESS)
+                ->whereNotNull('latency_ms')
+                ->avg('latency_ms')
+        );
+    }
+
+    private function rate(int $part, int $total): float
+    {
+        if ($total <= 0) {
+            return 0.0;
+        }
+
+        return ($part / $total) * 100;
+    }
+
+    /**
+     * @return array<string, float|int|string|bool|null>
+     */
+    private function comparisonPayload(
+        int|float|null $current,
+        int|float|null $previous,
+        bool $hasComparison,
+        string $unit,
+        bool $higherIsBetter,
+    ): array {
+        if (! $hasComparison || $current === null || $previous === null) {
+            return [
+                'current' => $current,
+                'previous' => $previous,
+                'delta' => null,
+                'delta_percent' => null,
+                'direction' => 'none',
+                'tone' => 'neutral',
+                'unit' => $unit,
+                'has_comparison' => false,
+            ];
+        }
+
+        $delta = $current - $previous;
+        $direction = match (true) {
+            $delta > 0 => 'up',
+            $delta < 0 => 'down',
+            default => 'flat',
+        };
+
+        $tone = match (true) {
+            $direction === 'flat' => 'neutral',
+            $higherIsBetter && $direction === 'up' => 'success',
+            $higherIsBetter && $direction === 'down' => 'danger',
+            ! $higherIsBetter && $direction === 'down' => 'success',
+            ! $higherIsBetter && $direction === 'up' => 'danger',
+            default => 'neutral',
+        };
+
+        return [
+            'current' => $current,
+            'previous' => $previous,
+            'delta' => $delta,
+            'delta_percent' => $previous != 0 ? ($delta / abs($previous)) * 100 : null,
+            'direction' => $direction,
+            'tone' => $tone,
+            'unit' => $unit,
+            'has_comparison' => true,
+        ];
     }
 
     private function parseDate(mixed $value): ?Carbon

--- a/laravel/resources/css/app.css
+++ b/laravel/resources/css/app.css
@@ -153,10 +153,12 @@
     }
 
     .admin-shell {
+        height: var(--app-viewport-height);
+        min-height: var(--app-viewport-height);
+        overflow: hidden;
         background:
-            radial-gradient(circle at top left, rgba(245, 158, 11, 0.06) 0%, transparent 30%),
-            radial-gradient(circle at bottom right, rgba(139, 8, 54, 0.06) 0%, transparent 36%),
-            #fbfaf8;
+            radial-gradient(circle at top left, rgba(212, 175, 55, 0.05) 0%, transparent 28%),
+            linear-gradient(180deg, #fffdf9 0%, #fbfaf8 42%, #f8f6f1 100%);
         @apply text-stone-800 dark:text-gray-100;
     }
 
@@ -168,23 +170,50 @@
     }
 
     .admin-sidebar {
-        @apply fixed inset-y-0 left-0 z-40 flex w-72 flex-col border-r border-stone-200/80 bg-white/95 backdrop-blur-xl transition-transform duration-200 dark:border-gray-800 dark:bg-gray-950/95 lg:static lg:z-auto lg:translate-x-0;
+        @apply fixed inset-y-0 left-0 z-40 flex w-72 flex-col border-r border-stone-200/80 bg-white/95 shadow-[18px_0_35px_rgba(28,25,23,0.04)] backdrop-blur-xl transition-transform duration-200 dark:border-gray-800 dark:bg-gray-950/95 dark:shadow-none lg:static lg:z-auto lg:translate-x-0;
+        height: var(--app-viewport-height);
+        min-height: 0;
+        flex: 0 0 18rem;
+    }
+
+    .admin-content {
+        @apply flex min-w-0 flex-1 flex-col overflow-hidden;
+        height: var(--app-viewport-height);
+        min-height: 0;
     }
 
     .admin-topbar {
-        @apply sticky top-0 z-20 flex w-full flex-wrap items-center justify-between gap-3 border-b border-stone-200/80 bg-white/85 px-4 py-3.5 backdrop-blur-xl dark:border-gray-800 dark:bg-gray-900/80 sm:px-6;
+        @apply z-20 flex w-full flex-none items-center justify-between gap-4 border-b border-stone-200/80 bg-white/90 px-4 py-3 backdrop-blur-xl dark:border-gray-800 dark:bg-gray-900/90 sm:px-5 lg:px-6;
     }
 
     .admin-main {
-        @apply mx-auto w-full max-w-7xl flex-1 px-4 py-6 sm:px-6 lg:px-8;
+        @apply mx-auto w-full max-w-[96rem] flex-1 overflow-y-auto overscroll-contain px-4 py-4 sm:px-5 lg:px-6;
+        min-height: 0;
+    }
+
+    .admin-breadcrumb {
+        @apply flex items-center gap-3 text-sm font-semibold;
+    }
+
+    .admin-icon-button {
+        @apply inline-flex h-9 w-9 items-center justify-center rounded-lg text-stone-900 transition hover:bg-stone-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/30 dark:text-gray-100 dark:hover:bg-gray-800;
+    }
+
+    .admin-action-button {
+        @apply inline-flex h-9 items-center gap-2 rounded-lg border border-stone-200 bg-white px-3 text-xs font-semibold text-stone-900 shadow-[0_1px_0_rgba(28,25,23,0.03)] transition hover:border-ista-primary/30 hover:text-ista-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/30 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100 dark:hover:border-ista-primary/40 dark:hover:text-amber-300;
+    }
+
+    .admin-sidebar-heading {
+        @apply px-2 pb-2.5 text-[0.65rem] font-bold uppercase text-stone-400 dark:text-gray-500;
+        letter-spacing: 0;
     }
 
     .admin-nav-link {
-        @apply flex items-center gap-3 rounded-lg px-3 py-2 text-stone-600 transition hover:bg-stone-100 hover:text-ista-primary dark:text-gray-300 dark:hover:bg-gray-900 dark:hover:text-amber-300;
+        @apply flex min-h-[2.9rem] items-center gap-3 rounded-lg px-3.5 py-2.5 text-stone-900 transition hover:bg-stone-100 hover:text-ista-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:text-gray-200 dark:hover:bg-gray-900 dark:hover:text-amber-300;
     }
 
     .admin-nav-link__icon {
-        @apply flex h-8 w-8 flex-none items-center justify-center rounded-md border border-stone-200 bg-white text-stone-500 transition group-hover:border-ista-primary/30 group-hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400 dark:group-hover:border-ista-primary/40 dark:group-hover:text-amber-300;
+        @apply flex h-5 w-5 flex-none items-center justify-center text-stone-900 transition group-hover:text-ista-primary dark:text-gray-300 dark:group-hover:text-amber-300;
     }
 
     .admin-nav-link--active {
@@ -192,11 +221,11 @@
     }
 
     .admin-nav-link--active .admin-nav-link__icon {
-        @apply border-ista-primary/30 bg-ista-primary/10 text-ista-primary dark:border-ista-primary/40 dark:bg-ista-primary/20 dark:text-amber-300;
+        @apply text-ista-primary dark:text-amber-300;
     }
 
     .admin-section {
-        @apply rounded-2xl border border-stone-200/80 bg-white shadow-[0_1px_2px_rgba(28,25,23,0.04)] transition-colors dark:border-gray-800 dark:bg-gray-900/80;
+        @apply rounded-xl border border-stone-200/80 bg-white shadow-[0_8px_24px_rgba(28,25,23,0.04)] transition-colors dark:border-gray-800 dark:bg-gray-900/80;
     }
 
     .admin-section__header {
@@ -212,7 +241,7 @@
     }
 
     .admin-kpi {
-        @apply flex flex-col rounded-2xl border border-stone-200/80 bg-white p-5 shadow-[0_1px_2px_rgba(28,25,23,0.04)] transition-colors dark:border-gray-800 dark:bg-gray-900/80;
+        @apply flex flex-col rounded-xl border border-stone-200/80 bg-white p-5 shadow-[0_8px_24px_rgba(28,25,23,0.04)] transition-colors dark:border-gray-800 dark:bg-gray-900/80;
     }
 
     .admin-kpi__icon {
@@ -234,7 +263,8 @@
     }
 
     .admin-table__th {
-        @apply border-b border-stone-200 bg-stone-50/60 px-4 py-2.5 text-left text-[11px] font-bold uppercase tracking-[0.08em] text-stone-500 dark:border-gray-800 dark:bg-gray-900/80 dark:text-gray-400;
+        @apply border-b border-stone-200 bg-white px-4 py-3 text-left text-[11px] font-bold uppercase text-stone-500 dark:border-gray-800 dark:bg-gray-900/80 dark:text-gray-400;
+        letter-spacing: 0;
     }
 
     .admin-table__th[data-align="right"], .admin-table__td[data-align="right"] { text-align: right; }
@@ -260,12 +290,17 @@
     .admin-badge--success { @apply border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300; }
     .admin-badge--warning { @apply border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300; }
     .admin-badge--danger { @apply border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-300; }
-    .admin-badge--info { @apply border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-300; }
+    .admin-badge--info { @apply border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-400/30 dark:bg-amber-300/10 dark:text-amber-300; }
     .admin-badge--gold { @apply border-amber-300 bg-amber-100/70 text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/15 dark:text-amber-300; }
     .admin-badge--primary { @apply border-ista-primary/30 bg-ista-primary/10 text-ista-primary dark:border-ista-primary/40 dark:bg-ista-primary/20 dark:text-amber-300; }
 
     .admin-empty-state {
         @apply flex flex-col items-center justify-center rounded-xl border border-dashed border-stone-200 bg-stone-50/40 px-6 py-10 text-center dark:border-gray-800 dark:bg-gray-900/40;
+    }
+
+    .admin-panel .admin-empty-state {
+        @apply px-4 py-7;
+        min-height: 10rem;
     }
 
     .admin-empty-state__icon {
@@ -318,6 +353,2232 @@
 
     .admin-page-title {
         @apply ista-brand-title text-2xl text-stone-900 not-italic dark:text-gray-100;
+    }
+
+    .admin-users-page {
+        @apply pb-6 text-stone-900 dark:text-gray-100;
+    }
+
+    .admin-users-hero {
+        @apply mb-4 flex flex-wrap items-start justify-between gap-4;
+    }
+
+    .admin-users-eyebrow {
+        @apply text-[0.64rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-users-title {
+        font-family: "Fraunces", serif;
+        @apply mt-1 text-[1.38rem] font-semibold leading-tight text-stone-950 dark:text-gray-100;
+        letter-spacing: 0;
+    }
+
+    .admin-users-title span {
+        font-family: "Plus Jakarta Sans", "Inter", system-ui, sans-serif;
+        @apply text-[1.12rem] font-semibold not-italic;
+    }
+
+    .admin-users-description {
+        @apply mt-2 max-w-xl text-[0.82rem] leading-relaxed text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-users-readonly {
+        @apply px-3.5 py-1.5 text-[0.72rem] font-medium;
+    }
+
+    .admin-users-kpi-grid {
+        @apply grid gap-3 sm:grid-cols-2 xl:grid-cols-4;
+    }
+
+    .admin-users-kpi-card {
+        @apply flex min-h-[5.75rem] items-start gap-3 rounded-lg border border-stone-200/80 bg-white px-3.5 pb-3.5 pt-4 shadow-[0_8px_24px_rgba(28,25,23,0.04)] transition-colors dark:border-gray-800 dark:bg-gray-900/80;
+    }
+
+    .admin-users-kpi-card__marker {
+        @apply mt-1.5 flex w-3 flex-none items-center justify-center;
+    }
+
+    .admin-users-kpi-card__marker span {
+        @apply block h-2 w-2 rounded-full;
+    }
+
+    .admin-users-kpi-card--primary .admin-users-kpi-card__marker span { @apply bg-ista-primary dark:bg-amber-300; }
+    .admin-users-kpi-card--success .admin-users-kpi-card__marker span { @apply bg-emerald-500; }
+    .admin-users-kpi-card--warning .admin-users-kpi-card__marker span { @apply bg-amber-500; }
+    .admin-users-kpi-card--neutral .admin-users-kpi-card__marker span { @apply bg-stone-400 dark:bg-gray-500; }
+
+    .admin-users-kpi-card__label {
+        @apply text-xs font-medium text-stone-700 dark:text-gray-200;
+    }
+
+    .admin-users-kpi-card strong {
+        @apply mt-1.5 block text-2xl font-semibold leading-none text-stone-950 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-users-kpi-card__description {
+        @apply mt-1.5 text-[0.7rem] font-medium text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-users-kpi-card--success .admin-users-kpi-card__description { @apply text-emerald-600 dark:text-emerald-400; }
+    .admin-users-kpi-card--warning .admin-users-kpi-card__description { @apply text-amber-600 dark:text-amber-400; }
+
+    .admin-users-filter-panel {
+        @apply mt-3 overflow-hidden rounded-lg;
+    }
+
+    .admin-users-filter-panel__header {
+        @apply flex flex-wrap items-start justify-between gap-3 px-4 pt-3.5;
+    }
+
+    .admin-users-filter-panel__header h3,
+    .admin-users-table-panel__header h3 {
+        @apply text-[0.95rem] font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-users-reset-group {
+        @apply flex items-center justify-end;
+    }
+
+    .admin-users-reset-group > span {
+        @apply text-[0.6rem] font-bold uppercase text-stone-500 dark:text-gray-400;
+        letter-spacing: 0;
+    }
+
+    .admin-users-reset-button {
+        @apply inline-flex items-center gap-1.5 text-[0.72rem] font-semibold text-ista-primary transition hover:text-rose-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/30 dark:text-rose-300 dark:hover:text-rose-200;
+    }
+
+    .admin-users-filter-grid {
+        @apply grid gap-3 px-4 pb-3.5 pt-3 md:grid-cols-[minmax(15rem,1fr)_minmax(10rem,0.7fr)_minmax(10rem,0.85fr)_minmax(5rem,0.25fr)];
+    }
+
+    .admin-users-filter {
+        @apply flex flex-col gap-1.5;
+    }
+
+    .admin-users-filter span {
+        @apply text-[0.6rem] font-bold uppercase text-stone-500 dark:text-gray-400;
+        letter-spacing: 0;
+    }
+
+    .admin-users-control,
+    .admin-users-search-control {
+        @apply h-9 w-full rounded-lg border border-stone-200 bg-white text-xs text-stone-800 shadow-[inset_0_1px_0_rgba(28,25,23,0.02)] transition focus:border-ista-primary focus:outline-none focus:ring-2 focus:ring-ista-primary/15 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100;
+    }
+
+    .admin-users-control {
+        @apply px-3;
+    }
+
+    .admin-users-search-control {
+        @apply flex items-center gap-2 px-3 text-stone-500 focus-within:border-ista-primary focus-within:ring-2 focus-within:ring-ista-primary/15 dark:text-gray-400;
+    }
+
+    .admin-users-control--search {
+        @apply h-auto min-w-0 flex-1 border-0 bg-transparent p-0 shadow-none placeholder:text-stone-400 focus:border-0 focus:ring-0 dark:bg-transparent dark:placeholder:text-gray-500;
+    }
+
+    .admin-users-table-panel {
+        @apply mt-3 overflow-hidden rounded-lg;
+    }
+
+    .admin-users-table-panel__header {
+        @apply px-4 pb-2.5 pt-3.5;
+    }
+
+    .admin-users-table-panel__header p {
+        @apply mt-1 text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-users-table-panel__body {
+        @apply px-3.5 pb-3.5;
+    }
+
+    .admin-users-table {
+        @apply rounded-lg;
+    }
+
+    .admin-users-table .admin-table__th {
+        @apply bg-white px-3 py-2.5 text-[0.61rem] text-stone-500 dark:bg-gray-900/80 dark:text-gray-400;
+    }
+
+    .admin-users-table .admin-table__td {
+        @apply px-3 py-2;
+    }
+
+    .admin-users-table .admin-badge {
+        @apply whitespace-nowrap px-2 py-0.5 text-[0.65rem];
+    }
+
+    .admin-users-table tbody tr {
+        @apply transition hover:bg-stone-50/80 dark:hover:bg-gray-800/50;
+    }
+
+    .admin-users-user-cell {
+        @apply flex min-w-[12rem] items-center gap-2.5;
+    }
+
+    .admin-user-avatar {
+        @apply flex h-7 w-7 flex-none items-center justify-center rounded-full bg-ista-primary text-[0.62rem] font-bold text-amber-200 shadow-sm;
+    }
+
+    .admin-users-user-cell__name {
+        @apply block truncate text-xs font-semibold text-stone-800 dark:text-gray-100;
+    }
+
+    .admin-users-user-cell__email {
+        @apply block truncate text-[0.68rem] text-stone-500 dark:text-gray-500;
+    }
+
+    .admin-users-status-badge {
+        @apply min-w-[4.1rem] justify-center whitespace-nowrap px-2 py-0.5 text-[0.65rem];
+    }
+
+    .admin-users-status-dot {
+        @apply h-1.5 w-1.5 rounded-full;
+    }
+
+    .admin-users-status-dot--online { @apply bg-emerald-500; }
+    .admin-users-status-dot--idle { @apply bg-amber-500; }
+    .admin-users-status-dot--offline { @apply bg-stone-400 dark:bg-gray-500; }
+
+    .admin-users-muted {
+        @apply text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-users-feature {
+        @apply font-mono text-[0.66rem] uppercase text-stone-500 dark:text-gray-400;
+        letter-spacing: 0;
+    }
+
+    .admin-users-number {
+        @apply font-mono text-[0.72rem] font-medium text-stone-800 dark:text-gray-200;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-users-total-cell {
+        @apply inline-grid min-w-[5.25rem] justify-items-end gap-0.5 text-[0.68rem] leading-tight text-stone-500 dark:text-gray-400;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-users-total-cell__primary {
+        @apply whitespace-nowrap font-medium text-stone-700 dark:text-gray-200;
+    }
+
+    .admin-users-total-cell__meta {
+        @apply whitespace-nowrap;
+    }
+
+    .admin-users-pagination {
+        @apply mt-3 border-t border-stone-100 pt-3 dark:border-gray-800;
+    }
+
+    .admin-usage-page {
+        @apply pb-6 text-stone-900 dark:text-gray-100;
+    }
+
+    .admin-usage-hero {
+        @apply mb-4 flex flex-wrap items-start justify-between gap-4;
+    }
+
+    .admin-usage-eyebrow {
+        @apply text-[0.64rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-usage-title {
+        font-family: "Fraunces", serif;
+        @apply mt-1 text-[1.38rem] font-semibold leading-tight text-stone-950 dark:text-gray-100;
+        letter-spacing: 0;
+    }
+
+    .admin-usage-description {
+        @apply mt-2 max-w-xl text-[0.82rem] leading-relaxed text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-usage-readonly {
+        @apply px-3.5 py-1.5 text-[0.72rem] font-medium;
+    }
+
+    .admin-usage-kpi-grid {
+        @apply grid gap-3 sm:grid-cols-2 xl:grid-cols-4;
+    }
+
+    .admin-usage-kpi-card {
+        @apply flex min-h-[5.75rem] items-start gap-3 rounded-lg border border-stone-200/80 bg-white px-3.5 pb-3.5 pt-4 shadow-[0_8px_24px_rgba(28,25,23,0.04)] transition-colors dark:border-gray-800 dark:bg-gray-900/80;
+    }
+
+    .admin-usage-kpi-card__marker {
+        @apply mt-1.5 flex w-3 flex-none items-center justify-center;
+    }
+
+    .admin-usage-kpi-card__marker span {
+        @apply block h-2 w-2 rounded-full;
+    }
+
+    .admin-usage-kpi-card--primary .admin-usage-kpi-card__marker span { @apply bg-ista-primary dark:bg-amber-300; }
+    .admin-usage-kpi-card--success .admin-usage-kpi-card__marker span { @apply bg-emerald-500; }
+    .admin-usage-kpi-card--warning .admin-usage-kpi-card__marker span { @apply bg-amber-500; }
+    .admin-usage-kpi-card--danger .admin-usage-kpi-card__marker span { @apply bg-rose-500; }
+
+    .admin-usage-kpi-card__label {
+        @apply text-xs font-medium text-stone-700 dark:text-gray-200;
+    }
+
+    .admin-usage-kpi-card strong {
+        @apply mt-1.5 block text-2xl font-semibold leading-none text-stone-950 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-usage-kpi-card__description {
+        @apply mt-1.5 text-[0.7rem] font-medium text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-usage-kpi-card--success .admin-usage-kpi-card__description { @apply text-emerald-600 dark:text-emerald-400; }
+    .admin-usage-kpi-card--warning .admin-usage-kpi-card__description { @apply text-amber-600 dark:text-amber-400; }
+    .admin-usage-kpi-card--danger .admin-usage-kpi-card__description { @apply text-rose-600 dark:text-rose-400; }
+
+    .admin-usage-filter-panel {
+        @apply mt-3 overflow-hidden rounded-lg;
+    }
+
+    .admin-usage-filter-panel__header,
+    .admin-usage-table-panel__header,
+    .admin-usage-distribution-panel__header {
+        @apply flex flex-wrap items-start justify-between gap-3 px-4 pt-3.5;
+    }
+
+    .admin-usage-filter-panel__header h3,
+    .admin-usage-table-panel__header h3,
+    .admin-usage-distribution-panel__header h3 {
+        @apply text-[0.95rem] font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-usage-table-panel__header p,
+    .admin-usage-distribution-panel__header p {
+        @apply mt-1 text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-usage-reset-group {
+        @apply flex items-center justify-end;
+    }
+
+    .admin-usage-reset-button {
+        @apply inline-flex items-center gap-1.5 text-[0.72rem] font-semibold text-ista-primary transition hover:text-rose-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/30 dark:text-rose-300 dark:hover:text-rose-200;
+    }
+
+    .admin-usage-filter-grid {
+        @apply grid gap-3 px-4 pb-3.5 pt-3 md:grid-cols-2 xl:grid-cols-4;
+    }
+
+    .admin-usage-filter {
+        @apply flex flex-col gap-1.5;
+    }
+
+    .admin-usage-filter span {
+        @apply text-[0.6rem] font-bold uppercase text-stone-500 dark:text-gray-400;
+        letter-spacing: 0;
+    }
+
+    .admin-usage-control {
+        @apply h-9 w-full rounded-lg border border-stone-200 bg-white px-3 text-xs text-stone-800 shadow-[inset_0_1px_0_rgba(28,25,23,0.02)] transition focus:border-ista-primary focus:outline-none focus:ring-2 focus:ring-ista-primary/15 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100;
+    }
+
+    .admin-usage-content-grid {
+        @apply mt-3 grid gap-3 xl:grid-cols-[minmax(0,1.85fr)_minmax(18rem,0.7fr)];
+    }
+
+    .admin-usage-table-panel,
+    .admin-usage-distribution-panel {
+        @apply overflow-hidden rounded-lg;
+    }
+
+    .admin-usage-table-panel__body,
+    .admin-usage-distribution-panel__body {
+        @apply px-3.5 pb-3.5 pt-3;
+    }
+
+    .admin-usage-table {
+        @apply rounded-lg;
+    }
+
+    .admin-usage-table .admin-table__th {
+        @apply bg-white px-3 py-2.5 text-[0.61rem] text-stone-500 dark:bg-gray-900/80 dark:text-gray-400;
+    }
+
+    .admin-usage-table .admin-table__td {
+        @apply px-3 py-2;
+    }
+
+    .admin-usage-table .admin-badge {
+        @apply whitespace-nowrap px-2 py-0.5 text-[0.65rem];
+    }
+
+    .admin-usage-table tbody tr {
+        @apply transition hover:bg-stone-50/80 dark:hover:bg-gray-800/50;
+    }
+
+    .admin-usage-user-cell {
+        @apply flex min-w-[10rem] flex-col;
+    }
+
+    .admin-usage-user-cell__name {
+        @apply block truncate text-xs font-semibold text-stone-800 dark:text-gray-100;
+    }
+
+    .admin-usage-user-cell__email {
+        @apply block truncate text-[0.68rem] text-stone-500 dark:text-gray-500;
+    }
+
+    .admin-usage-status-badge {
+        @apply min-w-[4.3rem] justify-center;
+    }
+
+    .admin-usage-feature {
+        @apply block max-w-[12rem] truncate font-mono text-[0.66rem] uppercase text-stone-500 dark:text-gray-400;
+        letter-spacing: 0;
+    }
+
+    .admin-usage-model {
+        @apply inline-block max-w-[8.5rem] truncate rounded-md bg-amber-50 px-2 py-0.5 text-[0.66rem] font-semibold text-ista-primary ring-1 ring-amber-100 dark:bg-amber-300/10 dark:text-amber-200 dark:ring-amber-300/20;
+    }
+
+    .admin-usage-model--muted {
+        @apply bg-stone-50 text-stone-400 ring-stone-100 dark:bg-gray-900 dark:text-gray-500 dark:ring-gray-800;
+    }
+
+    .admin-usage-number {
+        @apply whitespace-nowrap font-mono text-[0.72rem] font-medium text-stone-800 dark:text-gray-200;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-usage-muted {
+        @apply text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-usage-pagination {
+        @apply mt-3 border-t border-stone-100 pt-3 dark:border-gray-800;
+    }
+
+    .admin-usage-distribution-list {
+        @apply space-y-3;
+    }
+
+    .admin-usage-distribution-list li {
+        @apply rounded-lg border border-stone-100 bg-stone-50/40 p-3 dark:border-gray-800 dark:bg-gray-950/40;
+    }
+
+    .admin-usage-distribution-list__top {
+        @apply flex items-center justify-between gap-3;
+    }
+
+    .admin-usage-distribution-list__top span {
+        @apply truncate font-mono text-[0.66rem] uppercase text-stone-600 dark:text-gray-300;
+        letter-spacing: 0;
+    }
+
+    .admin-usage-distribution-list__top strong {
+        @apply text-xs font-semibold text-stone-900 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-usage-distribution-bar {
+        @apply mt-2 h-1.5 overflow-hidden rounded-full bg-stone-200/70 dark:bg-gray-800;
+    }
+
+    .admin-usage-distribution-bar span {
+        @apply block h-full rounded-full bg-ista-primary/80 dark:bg-amber-300/80;
+    }
+
+    .admin-usage-distribution-list__meta {
+        @apply mt-2 flex flex-wrap items-center justify-between gap-2 text-[0.62rem] font-semibold uppercase text-stone-400 dark:text-gray-500;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-page {
+        @apply pb-6 text-stone-900 dark:text-gray-100;
+    }
+
+    .admin-documents-hero {
+        @apply mb-4 flex flex-wrap items-start justify-between gap-4;
+    }
+
+    .admin-documents-eyebrow {
+        @apply text-[0.64rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-title {
+        font-family: "Fraunces", serif;
+        @apply mt-1 text-[1.38rem] font-semibold leading-tight text-stone-950 dark:text-gray-100;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-description {
+        @apply mt-2 max-w-xl text-[0.82rem] leading-relaxed text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-documents-readonly {
+        @apply px-3.5 py-1.5 text-[0.72rem] font-medium;
+    }
+
+    .admin-documents-kpi-grid {
+        @apply grid gap-3 sm:grid-cols-2 xl:grid-cols-4;
+    }
+
+    .admin-documents-kpi-card {
+        @apply flex min-h-[5.75rem] items-start gap-3 rounded-lg border border-stone-200/80 bg-white px-3.5 pb-3.5 pt-4 shadow-[0_8px_24px_rgba(28,25,23,0.04)] transition-colors dark:border-gray-800 dark:bg-gray-900/80;
+    }
+
+    .admin-documents-kpi-card__marker {
+        @apply mt-1.5 flex w-3 flex-none items-center justify-center;
+    }
+
+    .admin-documents-kpi-card__marker span {
+        @apply block h-2 w-2 rounded-full;
+    }
+
+    .admin-documents-kpi-card--primary .admin-documents-kpi-card__marker span { @apply bg-ista-primary dark:bg-amber-300; }
+    .admin-documents-kpi-card--success .admin-documents-kpi-card__marker span { @apply bg-emerald-500; }
+    .admin-documents-kpi-card--warning .admin-documents-kpi-card__marker span { @apply bg-amber-500; }
+    .admin-documents-kpi-card--danger .admin-documents-kpi-card__marker span { @apply bg-rose-500; }
+
+    .admin-documents-kpi-card__label {
+        @apply text-xs font-medium text-stone-700 dark:text-gray-200;
+    }
+
+    .admin-documents-kpi-card strong {
+        @apply mt-1.5 block text-2xl font-semibold leading-none text-stone-950 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-documents-kpi-card__description {
+        @apply mt-1.5 text-[0.7rem] font-medium text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-documents-kpi-card--success .admin-documents-kpi-card__description { @apply text-emerald-600 dark:text-emerald-400; }
+    .admin-documents-kpi-card--warning .admin-documents-kpi-card__description { @apply text-amber-600 dark:text-amber-400; }
+    .admin-documents-kpi-card--danger .admin-documents-kpi-card__description { @apply text-rose-600 dark:text-rose-400; }
+
+    .admin-documents-filter-panel {
+        @apply mt-3 overflow-hidden rounded-lg;
+    }
+
+    .admin-documents-filter-panel__header,
+    .admin-documents-table-panel__header,
+    .admin-documents-distribution-panel__header {
+        @apply flex flex-wrap items-start justify-between gap-3 px-4 pt-3.5;
+    }
+
+    .admin-documents-filter-panel__header h3,
+    .admin-documents-table-panel__header h3,
+    .admin-documents-distribution-panel__header h3 {
+        @apply text-[0.95rem] font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-documents-table-panel__header p,
+    .admin-documents-distribution-panel__header p {
+        @apply mt-1 text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-documents-reset-group {
+        @apply flex items-center justify-end;
+    }
+
+    .admin-documents-reset-button {
+        @apply inline-flex items-center gap-1.5 text-[0.72rem] font-semibold text-ista-primary transition hover:text-rose-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/30 dark:text-rose-300 dark:hover:text-rose-200;
+    }
+
+    .admin-documents-filter-grid {
+        @apply grid gap-3 px-4 pb-3.5 pt-3 md:grid-cols-2 xl:grid-cols-6;
+    }
+
+    .admin-documents-filter {
+        @apply flex flex-col gap-1.5;
+    }
+
+    .admin-documents-filter span {
+        @apply text-[0.6rem] font-bold uppercase text-stone-500 dark:text-gray-400;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-control {
+        @apply h-9 w-full rounded-lg border border-stone-200 bg-white px-3 text-xs text-stone-800 shadow-[inset_0_1px_0_rgba(28,25,23,0.02)] transition placeholder:text-stone-400 focus:border-ista-primary focus:outline-none focus:ring-2 focus:ring-ista-primary/15 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500;
+    }
+
+    .admin-documents-content-grid {
+        @apply mt-3 grid gap-3 xl:grid-cols-[minmax(0,1.85fr)_minmax(18rem,0.7fr)];
+    }
+
+    .admin-documents-side-grid {
+        @apply grid gap-3 content-start;
+    }
+
+    .admin-documents-table-panel,
+    .admin-documents-distribution-panel {
+        @apply overflow-hidden rounded-lg;
+    }
+
+    .admin-documents-table-panel__body,
+    .admin-documents-distribution-panel__body {
+        @apply px-3.5 pb-3.5 pt-3;
+    }
+
+    .admin-documents-table {
+        @apply rounded-lg;
+    }
+
+    .admin-documents-table .admin-table__th {
+        @apply bg-white px-3 py-2.5 text-[0.61rem] text-stone-500 dark:bg-gray-900/80 dark:text-gray-400;
+    }
+
+    .admin-documents-table .admin-table__td {
+        @apply px-3 py-2;
+    }
+
+    .admin-documents-table .admin-badge {
+        @apply whitespace-nowrap px-2 py-0.5 text-[0.65rem];
+    }
+
+    .admin-documents-table tbody tr {
+        @apply transition hover:bg-stone-50/80 dark:hover:bg-gray-800/50;
+    }
+
+    .admin-documents-file-cell {
+        @apply flex min-w-[12rem] items-center gap-2.5;
+    }
+
+    .admin-documents-user-cell {
+        @apply flex min-w-[9rem] flex-col;
+    }
+
+    .admin-documents-file-icon {
+        @apply inline-flex h-8 w-8 flex-none items-center justify-center rounded-lg font-mono text-[0.58rem] font-bold ring-1;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-file-icon--pdf {
+        @apply bg-rose-50 text-rose-600 ring-rose-100 dark:bg-rose-500/10 dark:text-rose-300 dark:ring-rose-400/20;
+    }
+
+    .admin-documents-file-icon--csv {
+        @apply bg-emerald-50 text-emerald-700 ring-emerald-100 dark:bg-emerald-400/10 dark:text-emerald-300 dark:ring-emerald-300/20;
+    }
+
+    .admin-documents-file-icon--xlsx {
+        @apply bg-teal-50 text-teal-700 ring-teal-100 dark:bg-teal-400/10 dark:text-teal-300 dark:ring-teal-300/20;
+    }
+
+    .admin-documents-file-icon--docx {
+        @apply bg-sky-50 text-sky-700 ring-sky-100 dark:bg-sky-400/10 dark:text-sky-300 dark:ring-sky-300/20;
+    }
+
+    .admin-documents-file-icon--file {
+        @apply bg-stone-100 text-stone-600 ring-stone-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700;
+    }
+
+    .admin-documents-file-cell__name,
+    .admin-documents-user-cell__name {
+        @apply block truncate text-xs font-semibold text-stone-800 dark:text-gray-100;
+    }
+
+    .admin-documents-file-cell__meta,
+    .admin-documents-user-cell__email {
+        @apply block truncate text-[0.68rem] text-stone-500 dark:text-gray-500;
+    }
+
+    .admin-documents-status-chip {
+        @apply inline-flex min-w-[4.6rem] items-center justify-center rounded-full px-2 py-0.5 text-[0.64rem] font-bold uppercase ring-1;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-status-chip--success {
+        @apply bg-emerald-50 text-emerald-700 ring-emerald-100 dark:bg-emerald-400/10 dark:text-emerald-300 dark:ring-emerald-300/20;
+    }
+
+    .admin-documents-status-chip--warning {
+        @apply bg-amber-50 text-amber-700 ring-amber-100 dark:bg-amber-400/10 dark:text-amber-300 dark:ring-amber-300/20;
+    }
+
+    .admin-documents-status-chip--danger {
+        @apply bg-rose-50 text-rose-700 ring-rose-100 dark:bg-rose-500/10 dark:text-rose-300 dark:ring-rose-400/20;
+    }
+
+    .admin-documents-status-chip--neutral {
+        @apply bg-stone-100 text-stone-600 ring-stone-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700;
+    }
+
+    .admin-documents-number {
+        @apply whitespace-nowrap font-mono text-[0.72rem] font-medium text-stone-800 dark:text-gray-200;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-documents-muted {
+        @apply text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-documents-pipeline {
+        @apply min-w-[8.5rem];
+    }
+
+    .admin-documents-pipeline__track {
+        @apply h-1.5 overflow-hidden rounded-full bg-stone-200/70 dark:bg-gray-800;
+    }
+
+    .admin-documents-pipeline__bar {
+        @apply block h-full rounded-full transition-all;
+    }
+
+    .admin-documents-pipeline__bar--success {
+        @apply bg-emerald-500/85 dark:bg-emerald-300/85;
+    }
+
+    .admin-documents-pipeline__bar--warning {
+        @apply bg-amber-500/85 dark:bg-amber-300/85;
+    }
+
+    .admin-documents-pipeline__bar--danger {
+        @apply bg-rose-500/85 dark:bg-rose-300/85;
+    }
+
+    .admin-documents-pipeline__meta {
+        @apply mt-1.5 flex items-center justify-between gap-2 text-[0.62rem] font-semibold uppercase text-stone-400 dark:text-gray-500;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-detail-button {
+        @apply inline-flex h-7 items-center justify-center rounded-md border border-stone-200 bg-white px-2.5 text-[0.68rem] font-semibold text-stone-700 transition hover:border-ista-primary/30 hover:text-ista-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-200 dark:hover:border-amber-300/30 dark:hover:text-amber-300;
+    }
+
+    .admin-documents-pagination {
+        @apply mt-3 border-t border-stone-100 pt-3 dark:border-gray-800;
+    }
+
+    .admin-documents-distribution-list {
+        @apply space-y-3;
+    }
+
+    .admin-documents-distribution-list li {
+        @apply rounded-lg border border-stone-100 bg-stone-50/40 p-3 dark:border-gray-800 dark:bg-gray-950/40;
+    }
+
+    .admin-documents-distribution-list__top {
+        @apply flex items-center justify-between gap-3;
+    }
+
+    .admin-documents-distribution-list__top span {
+        @apply truncate font-mono text-[0.66rem] uppercase text-stone-600 dark:text-gray-300;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-distribution-list__top strong,
+    .admin-documents-status-list b {
+        @apply text-xs font-semibold text-stone-900 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-documents-distribution-bar {
+        @apply mt-2 h-1.5 overflow-hidden rounded-full bg-stone-200/70 dark:bg-gray-800;
+    }
+
+    .admin-documents-distribution-bar span {
+        @apply block h-full rounded-full bg-ista-primary/80 dark:bg-amber-300/80;
+    }
+
+    .admin-documents-distribution-list__meta {
+        @apply mt-2 flex flex-wrap items-center justify-between gap-2 text-[0.62rem] font-semibold uppercase text-stone-400 dark:text-gray-500;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-status-list {
+        @apply space-y-2.5;
+    }
+
+    .admin-documents-status-list li {
+        @apply flex items-center gap-3 rounded-lg border border-stone-100 bg-stone-50/40 p-3 dark:border-gray-800 dark:bg-gray-950/40;
+    }
+
+    .admin-documents-status-list div {
+        @apply min-w-0 flex-1;
+    }
+
+    .admin-documents-status-list strong {
+        @apply block truncate text-xs font-semibold text-stone-800 dark:text-gray-100;
+    }
+
+    .admin-documents-status-list em {
+        @apply mt-0.5 block text-[0.62rem] not-italic text-stone-400 dark:text-gray-500;
+    }
+
+    .admin-documents-status-dot {
+        @apply h-2 w-2 flex-none rounded-full;
+    }
+
+    .admin-documents-status-dot--success { @apply bg-emerald-500; }
+    .admin-documents-status-dot--warning { @apply bg-amber-500; }
+    .admin-documents-status-dot--danger { @apply bg-rose-500; }
+    .admin-documents-status-dot--neutral { @apply bg-stone-400 dark:bg-gray-500; }
+
+    .admin-documents-drawer {
+        @apply fixed inset-0 z-50 flex justify-end;
+    }
+
+    .admin-documents-drawer__backdrop {
+        @apply absolute inset-0 bg-stone-950/35 backdrop-blur-sm dark:bg-black/60;
+    }
+
+    .admin-documents-drawer__panel {
+        @apply relative flex h-full w-full max-w-xl flex-col overflow-hidden border-l border-stone-200 bg-white shadow-[0_24px_80px_rgba(28,25,23,0.24)] dark:border-gray-800 dark:bg-gray-950;
+    }
+
+    .admin-documents-drawer__header {
+        @apply flex flex-none items-start justify-between gap-4 border-b border-stone-100 px-5 py-4 dark:border-gray-800;
+    }
+
+    .admin-documents-drawer__title-row {
+        @apply flex min-w-0 items-center gap-3;
+    }
+
+    .admin-documents-drawer__eyebrow {
+        @apply text-[0.6rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-drawer__header h3 {
+        @apply mt-1 truncate text-lg font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-documents-drawer__close {
+        @apply inline-flex h-8 w-8 flex-none items-center justify-center rounded-lg text-stone-500 transition hover:bg-stone-100 hover:text-stone-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-gray-100;
+    }
+
+    .admin-documents-drawer__body {
+        @apply min-h-0 flex-1 overflow-y-auto px-5 pb-5 pt-4;
+    }
+
+    .admin-documents-drawer__summary {
+        @apply grid gap-3 sm:grid-cols-2;
+    }
+
+    .admin-documents-drawer__summary > div {
+        @apply min-w-0 rounded-lg border border-stone-100 bg-stone-50/50 p-3 dark:border-gray-800 dark:bg-gray-900/50;
+    }
+
+    .admin-documents-drawer__summary span,
+    .admin-documents-metadata-grid dt {
+        @apply block text-[0.6rem] font-bold uppercase text-stone-400 dark:text-gray-500;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-drawer__summary strong {
+        @apply mt-1 block truncate text-xs font-semibold text-stone-900 dark:text-gray-100;
+    }
+
+    .admin-documents-drawer__summary strong.admin-documents-status-chip {
+        @apply inline-flex;
+    }
+
+    .admin-documents-drawer__summary em {
+        @apply mt-1 block truncate text-[0.68rem] not-italic text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-documents-drawer__section {
+        @apply mt-4 rounded-lg border border-stone-100 bg-white p-3.5 dark:border-gray-800 dark:bg-gray-900/40;
+    }
+
+    .admin-documents-drawer__section-heading {
+        @apply flex items-center justify-between gap-3;
+    }
+
+    .admin-documents-drawer__section h4 {
+        @apply text-[0.82rem] font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-documents-drawer__section-heading span {
+        @apply text-xs font-semibold text-stone-500 dark:text-gray-400;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-documents-pipeline--drawer {
+        @apply mt-3;
+    }
+
+    .admin-documents-stage-list {
+        @apply mt-3 grid gap-2 sm:grid-cols-4;
+    }
+
+    .admin-documents-stage-list__item {
+        @apply rounded-lg border border-stone-100 bg-stone-50/50 px-2.5 py-2 dark:border-gray-800 dark:bg-gray-950/50;
+    }
+
+    .admin-documents-stage-list__item span {
+        @apply mb-2 block h-1.5 w-full rounded-full bg-stone-200 dark:bg-gray-800;
+    }
+
+    .admin-documents-stage-list__item strong {
+        @apply block text-[0.68rem] font-semibold text-stone-600 dark:text-gray-300;
+    }
+
+    .admin-documents-stage-list__item--done span { @apply bg-emerald-500 dark:bg-emerald-300; }
+    .admin-documents-stage-list__item--active span { @apply bg-amber-500 dark:bg-amber-300; }
+    .admin-documents-stage-list__item--failed span { @apply bg-rose-500 dark:bg-rose-300; }
+
+    .admin-documents-metadata-grid {
+        @apply mt-3 grid gap-2 sm:grid-cols-2;
+    }
+
+    .admin-documents-metadata-grid div {
+        @apply min-w-0 rounded-md bg-stone-50 px-2.5 py-2 dark:bg-gray-950/70;
+    }
+
+    .admin-documents-metadata-grid dd {
+        @apply mt-1 break-words text-[0.74rem] font-semibold text-stone-700 dark:text-gray-200;
+    }
+
+    .admin-accounts-page {
+        @apply pb-6 text-stone-900 dark:text-gray-100;
+    }
+
+    .admin-accounts-hero {
+        @apply mb-4 flex flex-wrap items-start justify-between gap-4;
+    }
+
+    .admin-accounts-eyebrow {
+        @apply text-[0.64rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-accounts-title {
+        font-family: "Fraunces", serif;
+        @apply mt-1 text-[1.38rem] font-semibold leading-tight text-stone-950 dark:text-gray-100;
+        letter-spacing: 0;
+    }
+
+    .admin-accounts-description {
+        @apply mt-2 max-w-xl text-[0.82rem] leading-relaxed text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-accounts-hero__actions {
+        @apply flex flex-wrap items-center justify-end gap-2;
+    }
+
+    .admin-accounts-access-badge {
+        @apply inline-flex h-8 items-center gap-2 rounded-full border border-stone-200 bg-white px-3 text-[0.7rem] font-semibold text-stone-600 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300;
+    }
+
+    .admin-accounts-access-badge span {
+        @apply h-1.5 w-1.5 rounded-full bg-amber-500 dark:bg-amber-300;
+    }
+
+    .admin-accounts-primary-button,
+    .admin-accounts-secondary-button,
+    .admin-accounts-danger-button {
+        @apply inline-flex h-8 items-center justify-center gap-1.5 rounded-lg px-3 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-60;
+    }
+
+    .admin-accounts-primary-button {
+        @apply bg-ista-primary text-white shadow-[0_8px_20px_rgba(139,8,54,0.18)] hover:bg-rose-900 focus-visible:ring-ista-primary/30 dark:bg-amber-300 dark:text-gray-950 dark:hover:bg-amber-200;
+    }
+
+    .admin-accounts-secondary-button {
+        @apply border border-stone-200 bg-white text-stone-700 hover:border-ista-primary/30 hover:text-ista-primary focus-visible:ring-ista-primary/25 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-200 dark:hover:border-amber-300/30 dark:hover:text-amber-300;
+    }
+
+    .admin-accounts-danger-button {
+        @apply bg-rose-600 text-white hover:bg-rose-700 focus-visible:ring-rose-500/25 dark:bg-rose-500 dark:hover:bg-rose-400;
+    }
+
+    .admin-accounts-kpi-grid {
+        @apply grid gap-3 sm:grid-cols-2 xl:grid-cols-4;
+    }
+
+    .admin-accounts-kpi-card {
+        @apply flex min-h-[5rem] items-start gap-3 rounded-lg border border-stone-200/80 bg-white px-3.5 py-3 shadow-[0_8px_20px_rgba(28,25,23,0.035)] transition-colors dark:border-gray-800 dark:bg-gray-900/80;
+    }
+
+    .admin-accounts-kpi-card__marker {
+        @apply mt-1.5 flex w-3 flex-none items-center justify-center;
+    }
+
+    .admin-accounts-kpi-card__marker span {
+        @apply block h-2 w-2 rounded-full;
+    }
+
+    .admin-accounts-kpi-card--primary .admin-accounts-kpi-card__marker span { @apply bg-ista-primary dark:bg-amber-300; }
+    .admin-accounts-kpi-card--success .admin-accounts-kpi-card__marker span { @apply bg-emerald-500; }
+    .admin-accounts-kpi-card--danger .admin-accounts-kpi-card__marker span { @apply bg-rose-500; }
+    .admin-accounts-kpi-card--warning .admin-accounts-kpi-card__marker span { @apply bg-amber-500; }
+
+    .admin-accounts-kpi-card__label {
+        @apply text-xs font-medium text-stone-700 dark:text-gray-200;
+    }
+
+    .admin-accounts-kpi-card strong {
+        @apply mt-1 block text-[1.55rem] font-semibold leading-none text-stone-950 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-accounts-kpi-card__description {
+        @apply mt-1 text-[0.68rem] font-medium text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-accounts-kpi-card--success .admin-accounts-kpi-card__description { @apply text-emerald-600 dark:text-emerald-400; }
+    .admin-accounts-kpi-card--danger .admin-accounts-kpi-card__description { @apply text-rose-600 dark:text-rose-400; }
+    .admin-accounts-kpi-card--warning .admin-accounts-kpi-card__description { @apply text-amber-600 dark:text-amber-400; }
+
+    .admin-accounts-alert,
+    .admin-accounts-temp-password {
+        @apply mt-3 flex items-start justify-between gap-3 rounded-lg border px-4 py-3 text-xs;
+    }
+
+    .admin-accounts-alert--success {
+        @apply border-emerald-100 bg-emerald-50 text-emerald-700 dark:border-emerald-400/20 dark:bg-emerald-400/10 dark:text-emerald-300;
+    }
+
+    .admin-accounts-alert--danger {
+        @apply border-rose-100 bg-rose-50 text-rose-700 dark:border-rose-400/20 dark:bg-rose-500/10 dark:text-rose-300;
+    }
+
+    .admin-accounts-alert button,
+    .admin-accounts-temp-password button {
+        @apply inline-flex h-6 w-6 flex-none items-center justify-center rounded-md opacity-70 transition hover:bg-black/5 hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-400/20 dark:hover:bg-white/10;
+    }
+
+    .admin-accounts-temp-password {
+        @apply border-amber-100 bg-amber-50 text-amber-800 dark:border-amber-300/20 dark:bg-amber-300/10 dark:text-amber-200;
+    }
+
+    .admin-accounts-temp-password p {
+        @apply text-xs font-semibold;
+    }
+
+    .admin-accounts-temp-password span {
+        @apply mt-0.5 block text-[0.7rem] text-amber-700/80 dark:text-amber-200/75;
+    }
+
+    .admin-accounts-temp-password code {
+        @apply mt-2 block w-fit max-w-full break-all rounded-md bg-white px-2.5 py-1.5 font-mono text-[0.76rem] font-semibold text-stone-900 ring-1 ring-amber-100 dark:bg-gray-950 dark:text-amber-100 dark:ring-amber-300/20;
+    }
+
+    .admin-accounts-filter-panel {
+        @apply mt-3 overflow-hidden rounded-lg;
+    }
+
+    .admin-accounts-filter-panel__header,
+    .admin-accounts-table-panel__header {
+        @apply flex flex-wrap items-start justify-between gap-3 px-4 pt-3;
+    }
+
+    .admin-accounts-filter-panel__header h3,
+    .admin-accounts-table-panel__header h3 {
+        @apply text-[0.95rem] font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-accounts-table-panel__header p {
+        @apply mt-1 text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-accounts-reset-button {
+        @apply inline-flex items-center gap-1.5 text-[0.72rem] font-semibold text-ista-primary transition hover:text-rose-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/30 dark:text-rose-300 dark:hover:text-rose-200;
+    }
+
+    .admin-accounts-filter-grid {
+        @apply grid gap-3 px-4 pb-3 pt-2.5 md:grid-cols-3;
+    }
+
+    .admin-accounts-filter,
+    .admin-accounts-modal__field {
+        @apply flex flex-col gap-1.5;
+    }
+
+    .admin-accounts-filter span,
+    .admin-accounts-modal__field > span {
+        @apply text-[0.6rem] font-bold uppercase text-stone-500 dark:text-gray-400;
+        letter-spacing: 0;
+    }
+
+    .admin-accounts-control {
+        @apply h-9 w-full rounded-lg border border-stone-200 bg-white px-3 text-xs text-stone-800 shadow-[inset_0_1px_0_rgba(28,25,23,0.02)] transition placeholder:text-stone-400 focus:border-ista-primary focus:outline-none focus:ring-2 focus:ring-ista-primary/15 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500;
+    }
+
+    .admin-accounts-modal__field textarea.admin-accounts-control {
+        @apply min-h-[5.25rem] resize-none py-2 leading-relaxed;
+    }
+
+    .admin-accounts-content-grid {
+        @apply mt-3 grid gap-3;
+    }
+
+    .admin-accounts-table-panel {
+        @apply overflow-hidden rounded-lg;
+    }
+
+    .admin-accounts-table-panel__body {
+        @apply px-3.5 pb-3.5;
+    }
+
+    .admin-accounts-table {
+        @apply rounded-xl;
+    }
+
+    .admin-accounts-table .admin-table {
+        @apply table-fixed;
+    }
+
+    .admin-accounts-table .admin-table__th {
+        @apply bg-white px-3 py-2.5 text-[0.61rem] text-stone-500 dark:bg-gray-900/80 dark:text-gray-400;
+    }
+
+    .admin-accounts-table .admin-table__td {
+        @apply px-3 py-2;
+    }
+
+    .admin-accounts-table .admin-badge {
+        @apply whitespace-nowrap px-2 py-0.5 text-[0.65rem];
+    }
+
+    .admin-accounts-table tbody tr {
+        @apply transition hover:bg-stone-50/80 dark:hover:bg-gray-800/50;
+    }
+
+    .admin-accounts-user-cell {
+        @apply flex min-w-0 items-center gap-2.5;
+    }
+
+    .admin-accounts-avatar {
+        @apply inline-flex h-8 w-8 flex-none items-center justify-center rounded-full bg-ista-primary text-[0.66rem] font-bold text-white shadow-[0_5px_12px_rgba(139,8,54,0.2)] ring-1 ring-ista-primary/10 dark:bg-amber-300 dark:text-gray-950 dark:ring-amber-300/20;
+        letter-spacing: 0;
+    }
+
+    .admin-accounts-user-cell__name {
+        @apply block truncate text-xs font-semibold text-stone-800 dark:text-gray-100;
+    }
+
+    .admin-accounts-user-cell__email {
+        @apply block truncate text-[0.68rem] text-stone-500 dark:text-gray-500;
+    }
+
+    .admin-accounts-role-chip,
+    .admin-accounts-status-chip,
+    .admin-accounts-security-chip {
+        @apply inline-flex items-center justify-center rounded-full px-2.5 py-1 text-[0.64rem] font-bold ring-1;
+        letter-spacing: 0;
+    }
+
+    .admin-accounts-role-chip {
+        @apply min-w-[4.2rem];
+    }
+
+    .admin-accounts-role-chip--primary {
+        @apply bg-rose-50 text-ista-primary ring-rose-100 dark:bg-rose-500/10 dark:text-rose-300 dark:ring-rose-400/20;
+    }
+
+    .admin-accounts-role-chip--gold {
+        @apply bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-400/10 dark:text-amber-300 dark:ring-amber-300/20;
+    }
+
+    .admin-accounts-status-chip {
+        @apply min-w-[4.4rem] gap-1.5;
+    }
+
+    .admin-accounts-status-chip__dot {
+        @apply h-1.5 w-1.5 rounded-full;
+    }
+
+    .admin-accounts-status-chip--success {
+        @apply bg-emerald-50 text-emerald-700 ring-emerald-100 dark:bg-emerald-400/10 dark:text-emerald-300 dark:ring-emerald-300/20;
+    }
+
+    .admin-accounts-status-chip--success .admin-accounts-status-chip__dot {
+        @apply bg-emerald-500 dark:bg-emerald-300;
+    }
+
+    .admin-accounts-status-chip--danger {
+        @apply bg-rose-50 text-rose-700 ring-rose-100 dark:bg-rose-500/10 dark:text-rose-300 dark:ring-rose-400/20;
+    }
+
+    .admin-accounts-status-chip--danger .admin-accounts-status-chip__dot {
+        @apply bg-rose-500 dark:bg-rose-300;
+    }
+
+    .admin-accounts-security-chip {
+        @apply bg-stone-100 text-stone-600 ring-stone-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700;
+    }
+
+    .admin-accounts-security-chip--warning {
+        @apply bg-amber-50 text-amber-700 ring-amber-100 dark:bg-amber-400/10 dark:text-amber-300 dark:ring-amber-300/20;
+    }
+
+    .admin-accounts-muted {
+        @apply whitespace-nowrap text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-accounts-action-group {
+        @apply flex min-w-0 flex-nowrap items-center justify-end gap-1.5;
+    }
+
+    .admin-accounts-action-button {
+        @apply inline-flex h-8 flex-none items-center justify-center rounded-md border border-stone-200 bg-white px-2.5 text-[0.66rem] font-semibold text-stone-700 shadow-[0_1px_0_rgba(28,25,23,0.03)] transition hover:border-ista-primary/30 hover:text-ista-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-200 dark:hover:border-amber-300/30 dark:hover:text-amber-300;
+    }
+
+    .admin-accounts-action-button--success {
+        @apply border-emerald-100 bg-emerald-50 text-emerald-700 hover:border-emerald-200 hover:text-emerald-800 dark:border-emerald-300/20 dark:bg-emerald-400/10 dark:text-emerald-300;
+    }
+
+    .admin-accounts-action-button--danger {
+        @apply border-rose-100 bg-rose-50 text-rose-700 hover:border-rose-200 hover:text-rose-800 dark:border-rose-400/20 dark:bg-rose-500/10 dark:text-rose-300;
+    }
+
+    .admin-accounts-reset-password-button {
+        @apply inline-flex h-8 flex-none items-center justify-center whitespace-nowrap rounded-md border border-amber-200 bg-white px-2 text-[0.6rem] font-semibold text-amber-600 transition hover:border-amber-300 hover:bg-amber-50 hover:text-amber-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/25 dark:border-amber-300/30 dark:bg-gray-950 dark:text-amber-300 dark:hover:bg-amber-300/10;
+    }
+
+    .admin-accounts-toggle {
+        @apply relative inline-flex h-5 w-9 flex-none items-center rounded-full bg-stone-300 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:bg-gray-700;
+    }
+
+    .admin-accounts-toggle span {
+        @apply ml-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform dark:bg-gray-200;
+    }
+
+    .admin-accounts-toggle--active {
+        @apply bg-ista-primary dark:bg-amber-300;
+    }
+
+    .admin-accounts-toggle--active span {
+        @apply translate-x-4 dark:bg-gray-950;
+    }
+
+    .admin-accounts-pagination {
+        @apply mt-3 border-t border-stone-100 pt-3 dark:border-gray-800;
+    }
+
+    .admin-accounts-modal {
+        @apply fixed inset-0 z-50 flex items-center justify-center p-4;
+    }
+
+    .admin-accounts-modal__backdrop {
+        @apply absolute inset-0 bg-stone-950/35 backdrop-blur-sm dark:bg-black/60;
+    }
+
+    .admin-accounts-modal__panel {
+        @apply relative flex max-h-[86vh] w-full max-w-xl flex-col overflow-hidden rounded-xl border border-stone-200 bg-white shadow-[0_24px_80px_rgba(28,25,23,0.24)] dark:border-gray-800 dark:bg-gray-950;
+    }
+
+    .admin-accounts-modal__header {
+        @apply flex flex-none items-start justify-between gap-4 border-b border-stone-100 px-5 py-4 dark:border-gray-800;
+    }
+
+    .admin-accounts-modal__eyebrow {
+        @apply text-[0.6rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-accounts-modal__header h3 {
+        @apply mt-1 text-lg font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-accounts-modal__header span {
+        @apply mt-1 block text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-accounts-modal__close {
+        @apply inline-flex h-8 w-8 flex-none items-center justify-center rounded-lg text-stone-500 transition hover:bg-stone-100 hover:text-stone-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-gray-100;
+    }
+
+    .admin-accounts-modal__body {
+        @apply grid min-h-0 flex-1 gap-3 overflow-y-auto px-5 py-4;
+    }
+
+    .admin-accounts-modal__field em {
+        @apply text-[0.68rem] not-italic text-rose-600 dark:text-rose-300;
+    }
+
+    .admin-accounts-checkbox {
+        @apply flex items-center gap-2 rounded-lg border border-stone-100 bg-stone-50/50 px-3 py-2.5 text-xs font-medium text-stone-700 dark:border-gray-800 dark:bg-gray-900/50 dark:text-gray-200;
+    }
+
+    .admin-accounts-checkbox input {
+        @apply h-4 w-4 rounded border-stone-300 text-ista-primary focus:ring-ista-primary/20 dark:border-gray-700 dark:bg-gray-950;
+    }
+
+    .admin-accounts-password-row {
+        @apply flex flex-col gap-2 sm:flex-row;
+    }
+
+    .admin-accounts-password-row .admin-accounts-secondary-button {
+        @apply flex-none;
+    }
+
+    .admin-accounts-modal__footer {
+        @apply flex flex-none flex-wrap items-center justify-end gap-2 border-t border-stone-100 px-5 py-4 dark:border-gray-800;
+    }
+
+    .admin-ai-config-page {
+        @apply pb-6 text-stone-900 dark:text-gray-100;
+    }
+
+    .admin-ai-config-hero {
+        @apply mb-4 flex flex-wrap items-start justify-between gap-4;
+    }
+
+    .admin-ai-config-eyebrow {
+        @apply text-[0.64rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-ai-config-title {
+        font-family: "Fraunces", serif;
+        @apply mt-1 text-[1.38rem] font-semibold leading-tight text-stone-950 dark:text-gray-100;
+        letter-spacing: 0;
+    }
+
+    .admin-ai-config-description {
+        @apply mt-2 max-w-xl text-[0.82rem] leading-relaxed text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-ai-config-hero__actions {
+        @apply flex flex-wrap items-center justify-end gap-2;
+    }
+
+    .admin-ai-config-access-badge {
+        @apply inline-flex h-8 items-center gap-2 rounded-full border border-stone-200 bg-white px-3 text-[0.7rem] font-semibold text-stone-600 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300;
+    }
+
+    .admin-ai-config-access-badge span {
+        @apply h-1.5 w-1.5 rounded-full bg-amber-500 dark:bg-amber-300;
+    }
+
+    .admin-ai-config-readonly {
+        @apply px-3.5 py-1.5 text-[0.72rem] font-medium;
+    }
+
+    .admin-ai-config-kpi-grid {
+        @apply grid gap-3 sm:grid-cols-2 xl:grid-cols-4;
+    }
+
+    .admin-ai-config-kpi-card {
+        @apply flex min-h-[5rem] items-start gap-3 rounded-lg border border-stone-200/80 bg-white px-3.5 py-3 shadow-[0_8px_20px_rgba(28,25,23,0.035)] transition-colors dark:border-gray-800 dark:bg-gray-900/80;
+    }
+
+    .admin-ai-config-kpi-card__marker {
+        @apply mt-1.5 flex w-3 flex-none items-center justify-center;
+    }
+
+    .admin-ai-config-kpi-card__marker span {
+        @apply block h-2 w-2 rounded-full;
+    }
+
+    .admin-ai-config-kpi-card--primary .admin-ai-config-kpi-card__marker span { @apply bg-ista-primary dark:bg-amber-300; }
+    .admin-ai-config-kpi-card--success .admin-ai-config-kpi-card__marker span { @apply bg-emerald-500; }
+    .admin-ai-config-kpi-card--warning .admin-ai-config-kpi-card__marker span { @apply bg-amber-500; }
+    .admin-ai-config-kpi-card--info .admin-ai-config-kpi-card__marker span { @apply bg-amber-500; }
+
+    .admin-ai-config-kpi-card__label {
+        @apply text-xs font-medium text-stone-700 dark:text-gray-200;
+    }
+
+    .admin-ai-config-kpi-card strong {
+        @apply mt-1 block max-w-full truncate text-[1.35rem] font-semibold leading-none text-stone-950 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-ai-config-kpi-card__description {
+        @apply mt-1 text-[0.68rem] font-medium text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-ai-config-kpi-card--success .admin-ai-config-kpi-card__description { @apply text-emerald-600 dark:text-emerald-400; }
+    .admin-ai-config-kpi-card--warning .admin-ai-config-kpi-card__description { @apply text-amber-600 dark:text-amber-400; }
+    .admin-ai-config-kpi-card--info .admin-ai-config-kpi-card__description { @apply text-amber-600 dark:text-amber-300; }
+
+    .admin-ai-config-content-grid {
+        @apply mt-3 grid gap-3 xl:grid-cols-[minmax(0,1.65fr)_minmax(18rem,0.75fr)];
+    }
+
+    .admin-ai-config-lower-grid {
+        @apply mt-3 grid gap-3 xl:grid-cols-[minmax(0,1.25fr)_minmax(18rem,0.75fr)];
+    }
+
+    .admin-ai-config-side-grid {
+        @apply grid content-start gap-3;
+    }
+
+    .admin-ai-config-table-panel,
+    .admin-ai-config-parameter-panel,
+    .admin-ai-config-guardrail-panel,
+    .admin-ai-config-prompt-panel,
+    .admin-ai-config-endpoint-panel {
+        @apply overflow-hidden rounded-lg;
+    }
+
+    .admin-ai-config-panel__header {
+        @apply flex flex-wrap items-start justify-between gap-3 px-4 pt-3.5;
+    }
+
+    .admin-ai-config-panel__header h3 {
+        @apply text-[0.95rem] font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-ai-config-panel__header p {
+        @apply mt-1 text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-ai-config-source-chip {
+        @apply inline-flex h-7 items-center rounded-full border border-stone-200 bg-white px-2.5 text-[0.62rem] font-bold uppercase text-stone-500 shadow-sm dark:border-gray-800 dark:bg-gray-950 dark:text-gray-400;
+        letter-spacing: 0;
+    }
+
+    .admin-ai-config-table-panel__body,
+    .admin-ai-config-parameter-panel__body,
+    .admin-ai-config-guardrail-panel__body,
+    .admin-ai-config-prompt-panel__body,
+    .admin-ai-config-endpoint-panel__body {
+        @apply px-3.5 pb-3.5 pt-3;
+    }
+
+    .admin-ai-config-table {
+        @apply rounded-lg;
+    }
+
+    .admin-ai-config-table .admin-table {
+        @apply table-fixed;
+    }
+
+    .admin-ai-config-table .admin-table__th {
+        @apply bg-white px-3 py-2.5 text-[0.61rem] text-stone-500 dark:bg-gray-900/80 dark:text-gray-400;
+    }
+
+    .admin-ai-config-table .admin-table__td {
+        @apply px-3 py-2;
+    }
+
+    .admin-ai-config-table .admin-badge {
+        @apply whitespace-nowrap px-2 py-0.5 text-[0.65rem];
+    }
+
+    .admin-ai-config-table tbody tr {
+        @apply transition hover:bg-stone-50/80 dark:hover:bg-gray-800/50;
+    }
+
+    .admin-ai-config-feature {
+        @apply block truncate text-xs font-semibold text-stone-800 dark:text-gray-100;
+    }
+
+    .admin-ai-config-code {
+        @apply block max-w-[9rem] truncate font-mono text-[0.66rem] uppercase text-stone-500 dark:text-gray-400;
+        letter-spacing: 0;
+    }
+
+    .admin-ai-config-muted {
+        @apply block truncate text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-ai-config-status-badge {
+        @apply min-w-[4.1rem] justify-center;
+    }
+
+    .admin-ai-config-parameter-list {
+        @apply grid gap-2.5;
+    }
+
+    .admin-ai-config-parameter-list div,
+    .admin-ai-config-endpoint-list div {
+        @apply rounded-lg border border-stone-100 bg-stone-50/40 p-3 dark:border-gray-800 dark:bg-gray-950/40;
+    }
+
+    .admin-ai-config-parameter-list dt,
+    .admin-ai-config-endpoint-list dt {
+        @apply text-[0.6rem] font-bold uppercase text-stone-400 dark:text-gray-500;
+        letter-spacing: 0;
+    }
+
+    .admin-ai-config-parameter-list dd {
+        @apply mt-1 font-mono text-xs font-semibold text-stone-900 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-ai-config-guardrail-list {
+        @apply space-y-2.5;
+    }
+
+    .admin-ai-config-guardrail-list li {
+        @apply flex items-center gap-3 rounded-lg border border-stone-100 bg-stone-50/40 p-3 dark:border-gray-800 dark:bg-gray-950/40;
+    }
+
+    .admin-ai-config-guardrail-list div {
+        @apply min-w-0 flex-1;
+    }
+
+    .admin-ai-config-guardrail-list strong {
+        @apply block truncate text-xs font-semibold text-stone-800 dark:text-gray-100;
+    }
+
+    .admin-ai-config-guardrail-list em {
+        @apply mt-0.5 block truncate text-[0.62rem] not-italic text-stone-400 dark:text-gray-500;
+    }
+
+    .admin-ai-config-guardrail-dot {
+        @apply h-2 w-2 flex-none rounded-full;
+    }
+
+    .admin-ai-config-guardrail-dot--success { @apply bg-emerald-500; }
+    .admin-ai-config-guardrail-dot--warning { @apply bg-amber-500; }
+    .admin-ai-config-guardrail-dot--primary { @apply bg-ista-primary dark:bg-amber-300; }
+
+    .admin-ai-config-profile-grid {
+        @apply grid gap-3 sm:grid-cols-2;
+    }
+
+    .admin-ai-config-profile-card {
+        @apply flex min-h-[5rem] items-start gap-3 rounded-lg border border-stone-100 bg-stone-50/40 p-3 dark:border-gray-800 dark:bg-gray-950/40;
+    }
+
+    .admin-ai-config-profile-card > span {
+        @apply mt-1.5 h-2 w-2 flex-none rounded-full bg-ista-primary dark:bg-amber-300;
+    }
+
+    .admin-ai-config-profile-card strong {
+        @apply block text-xs font-semibold text-stone-900 dark:text-gray-100;
+    }
+
+    .admin-ai-config-profile-card p {
+        @apply mt-1 text-[0.7rem] leading-relaxed text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-ai-config-profile-card em {
+        @apply mt-2 inline-flex rounded-full bg-white px-2 py-0.5 text-[0.6rem] not-italic font-bold uppercase text-stone-400 ring-1 ring-stone-100 dark:bg-gray-900 dark:text-gray-500 dark:ring-gray-800;
+        letter-spacing: 0;
+    }
+
+    .admin-ai-config-endpoint-list {
+        @apply grid gap-2.5;
+    }
+
+    .admin-ai-config-endpoint-list dd {
+        @apply mt-1 break-all font-mono text-[0.7rem] font-semibold text-stone-800 dark:text-gray-200;
+    }
+
+    .admin-errors-page {
+        @apply pb-6 text-stone-900 dark:text-gray-100;
+    }
+
+    .admin-errors-hero {
+        @apply mb-4 flex flex-wrap items-start justify-between gap-4;
+    }
+
+    .admin-errors-eyebrow {
+        @apply text-[0.64rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-errors-title {
+        font-family: "Fraunces", serif;
+        @apply mt-1 text-[1.38rem] font-semibold leading-tight text-stone-950 dark:text-gray-100;
+        letter-spacing: 0;
+    }
+
+    .admin-errors-description {
+        @apply mt-2 max-w-xl text-[0.82rem] leading-relaxed text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-errors-readonly {
+        @apply px-3.5 py-1.5 text-[0.72rem] font-medium;
+    }
+
+    .admin-errors-kpi-grid {
+        @apply grid gap-3 sm:grid-cols-2 xl:grid-cols-4;
+    }
+
+    .admin-errors-kpi-card {
+        @apply flex min-h-[5.75rem] items-start gap-3 rounded-lg border border-stone-200/80 bg-white px-3.5 pb-3.5 pt-4 shadow-[0_8px_24px_rgba(28,25,23,0.04)] transition-colors dark:border-gray-800 dark:bg-gray-900/80;
+    }
+
+    .admin-errors-kpi-card__marker {
+        @apply mt-1.5 flex w-3 flex-none items-center justify-center;
+    }
+
+    .admin-errors-kpi-card__marker span {
+        @apply block h-2 w-2 rounded-full;
+    }
+
+    .admin-errors-kpi-card--primary .admin-errors-kpi-card__marker span { @apply bg-ista-primary dark:bg-amber-300; }
+    .admin-errors-kpi-card--danger .admin-errors-kpi-card__marker span { @apply bg-rose-500; }
+    .admin-errors-kpi-card--warning .admin-errors-kpi-card__marker span { @apply bg-amber-500; }
+    .admin-errors-kpi-card--neutral .admin-errors-kpi-card__marker span { @apply bg-stone-400 dark:bg-gray-500; }
+
+    .admin-errors-kpi-card__label {
+        @apply text-xs font-medium text-stone-700 dark:text-gray-200;
+    }
+
+    .admin-errors-kpi-card strong {
+        @apply mt-1.5 block text-2xl font-semibold leading-none text-stone-950 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-errors-kpi-card__description {
+        @apply mt-1.5 text-[0.7rem] font-medium text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-errors-kpi-card--danger .admin-errors-kpi-card__description { @apply text-rose-600 dark:text-rose-400; }
+    .admin-errors-kpi-card--warning .admin-errors-kpi-card__description { @apply text-amber-600 dark:text-amber-400; }
+
+    .admin-users-kpi-card,
+    .admin-usage-kpi-card,
+    .admin-documents-kpi-card,
+    .admin-accounts-kpi-card,
+    .admin-ai-config-kpi-card,
+    .admin-errors-kpi-card {
+        @apply block min-h-[5.75rem] overflow-hidden p-0;
+    }
+
+    .admin-users-kpi-card__header,
+    .admin-usage-kpi-card__header,
+    .admin-documents-kpi-card__header,
+    .admin-accounts-kpi-card__header,
+    .admin-ai-config-kpi-card__header,
+    .admin-errors-kpi-card__header {
+        @apply flex items-center gap-2.5 border-b border-stone-200/80 px-4 py-2.5 text-ista-primary dark:border-gray-800 dark:text-amber-300;
+    }
+
+    .admin-users-kpi-card__icon,
+    .admin-usage-kpi-card__icon,
+    .admin-documents-kpi-card__icon,
+    .admin-accounts-kpi-card__icon,
+    .admin-ai-config-kpi-card__icon,
+    .admin-errors-kpi-card__icon {
+        @apply inline-flex h-4 w-4 flex-none items-center justify-center;
+    }
+
+    .admin-users-kpi-card__label,
+    .admin-usage-kpi-card__label,
+    .admin-documents-kpi-card__label,
+    .admin-accounts-kpi-card__label,
+    .admin-ai-config-kpi-card__label,
+    .admin-errors-kpi-card__label {
+        @apply truncate text-[0.72rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-users-kpi-card__body,
+    .admin-usage-kpi-card__body,
+    .admin-documents-kpi-card__body,
+    .admin-accounts-kpi-card__body,
+    .admin-ai-config-kpi-card__body,
+    .admin-errors-kpi-card__body {
+        @apply min-w-0 px-4 py-3;
+    }
+
+    .admin-users-kpi-card__body strong,
+    .admin-usage-kpi-card__body strong,
+    .admin-documents-kpi-card__body strong,
+    .admin-accounts-kpi-card__body strong,
+    .admin-ai-config-kpi-card__body strong,
+    .admin-errors-kpi-card__body strong {
+        @apply mt-0;
+    }
+
+    .admin-errors-filter-panel {
+        @apply mt-3 overflow-hidden rounded-lg;
+    }
+
+    .admin-errors-filter-panel__header,
+    .admin-errors-table-panel__header,
+    .admin-errors-distribution-panel__header {
+        @apply flex flex-wrap items-start justify-between gap-3 px-4 pt-3.5;
+    }
+
+    .admin-errors-filter-panel__header h3,
+    .admin-errors-table-panel__header h3,
+    .admin-errors-distribution-panel__header h3 {
+        @apply text-[0.95rem] font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-errors-table-panel__header p,
+    .admin-errors-distribution-panel__header p {
+        @apply mt-1 text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-errors-latest {
+        @apply rounded-full bg-rose-50 px-2.5 py-1 text-[0.66rem] font-semibold text-rose-600 ring-1 ring-rose-100 dark:bg-rose-500/10 dark:text-rose-300 dark:ring-rose-400/20;
+    }
+
+    .admin-errors-reset-group {
+        @apply flex items-center justify-end;
+    }
+
+    .admin-errors-reset-button {
+        @apply inline-flex items-center gap-1.5 text-[0.72rem] font-semibold text-ista-primary transition hover:text-rose-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/30 dark:text-rose-300 dark:hover:text-rose-200;
+    }
+
+    .admin-errors-filter-grid {
+        @apply grid gap-3 px-4 pb-3.5 pt-3 md:grid-cols-2 xl:grid-cols-[minmax(13rem,0.95fr)_minmax(13rem,1fr)_minmax(10rem,0.75fr)_minmax(10rem,0.75fr)];
+    }
+
+    .admin-errors-filter {
+        @apply flex flex-col gap-1.5;
+    }
+
+    .admin-errors-filter span {
+        @apply text-[0.6rem] font-bold uppercase text-stone-500 dark:text-gray-400;
+        letter-spacing: 0;
+    }
+
+    .admin-errors-control {
+        @apply h-9 w-full rounded-lg border border-stone-200 bg-white px-3 text-xs text-stone-800 shadow-[inset_0_1px_0_rgba(28,25,23,0.02)] transition placeholder:text-stone-400 focus:border-ista-primary focus:outline-none focus:ring-2 focus:ring-ista-primary/15 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500;
+    }
+
+    .admin-errors-content-grid {
+        @apply mt-3 grid gap-3 xl:grid-cols-[minmax(0,1.85fr)_minmax(18rem,0.7fr)];
+    }
+
+    .admin-errors-side-grid {
+        @apply grid gap-3 content-start;
+    }
+
+    .admin-errors-table-panel,
+    .admin-errors-distribution-panel {
+        @apply overflow-hidden rounded-lg;
+    }
+
+    .admin-errors-table-panel__body,
+    .admin-errors-distribution-panel__body {
+        @apply px-3.5 pb-3.5 pt-3;
+    }
+
+    .admin-errors-table {
+        @apply rounded-lg;
+    }
+
+    .admin-errors-table .admin-table__th {
+        @apply bg-white px-3 py-2.5 text-[0.61rem] text-stone-500 dark:bg-gray-900/80 dark:text-gray-400;
+    }
+
+    .admin-errors-table .admin-table__td {
+        @apply px-3 py-2;
+    }
+
+    .admin-errors-table .admin-badge {
+        @apply whitespace-nowrap px-2 py-0.5 text-[0.65rem];
+    }
+
+    .admin-errors-table tbody tr {
+        @apply transition hover:bg-stone-50/80 dark:hover:bg-gray-800/50;
+    }
+
+    .admin-errors-user-cell {
+        @apply flex min-w-[10rem] flex-col;
+    }
+
+    .admin-errors-user-cell__name {
+        @apply block truncate text-xs font-semibold text-stone-800 dark:text-gray-100;
+    }
+
+    .admin-errors-user-cell__email {
+        @apply block truncate text-[0.68rem] text-stone-500 dark:text-gray-500;
+    }
+
+    .admin-errors-feature {
+        @apply block max-w-[12rem] truncate font-mono text-[0.66rem] uppercase text-stone-500 dark:text-gray-400;
+        letter-spacing: 0;
+    }
+
+    .admin-errors-code {
+        @apply inline-block max-w-[11rem] truncate rounded-md bg-rose-50 px-2 py-0.5 text-[0.66rem] font-semibold uppercase text-rose-600 ring-1 ring-rose-100 dark:bg-rose-500/10 dark:text-rose-300 dark:ring-rose-400/20;
+        letter-spacing: 0;
+    }
+
+    .admin-errors-severity {
+        @apply inline-flex min-w-[4.4rem] items-center justify-center rounded-full px-2 py-0.5 text-[0.64rem] font-bold uppercase;
+        letter-spacing: 0;
+    }
+
+    .admin-errors-severity--critical {
+        @apply bg-rose-600 text-white ring-1 ring-rose-700/20 dark:bg-rose-500 dark:text-white;
+    }
+
+    .admin-errors-severity--high {
+        @apply bg-rose-50 text-rose-700 ring-1 ring-rose-100 dark:bg-rose-500/10 dark:text-rose-300 dark:ring-rose-400/20;
+    }
+
+    .admin-errors-severity--medium {
+        @apply bg-amber-50 text-amber-700 ring-1 ring-amber-100 dark:bg-amber-400/10 dark:text-amber-300 dark:ring-amber-300/20;
+    }
+
+    .admin-errors-severity--low {
+        @apply bg-stone-100 text-stone-600 ring-1 ring-stone-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700;
+    }
+
+    .admin-errors-status-badge {
+        @apply min-w-[4.3rem] justify-center;
+    }
+
+    .admin-errors-number {
+        @apply whitespace-nowrap font-mono text-[0.72rem] font-medium text-stone-800 dark:text-gray-200;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-errors-muted {
+        @apply text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-errors-detail-button {
+        @apply inline-flex h-7 items-center justify-center rounded-md border border-stone-200 bg-white px-2.5 text-[0.68rem] font-semibold text-stone-700 transition hover:border-ista-primary/30 hover:text-ista-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-200 dark:hover:border-amber-300/30 dark:hover:text-amber-300;
+    }
+
+    .admin-errors-pagination {
+        @apply mt-3 border-t border-stone-100 pt-3 dark:border-gray-800;
+    }
+
+    .admin-errors-distribution-list {
+        @apply space-y-3;
+    }
+
+    .admin-errors-distribution-list li {
+        @apply rounded-lg border border-stone-100 bg-stone-50/40 p-3 dark:border-gray-800 dark:bg-gray-950/40;
+    }
+
+    .admin-errors-distribution-list__top {
+        @apply flex items-center justify-between gap-3;
+    }
+
+    .admin-errors-distribution-list__top span {
+        @apply truncate font-mono text-[0.66rem] uppercase text-stone-600 dark:text-gray-300;
+        letter-spacing: 0;
+    }
+
+    .admin-errors-distribution-list__top strong {
+        @apply text-xs font-semibold text-stone-900 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-errors-distribution-bar {
+        @apply mt-2 h-1.5 overflow-hidden rounded-full bg-stone-200/70 dark:bg-gray-800;
+    }
+
+    .admin-errors-distribution-bar span {
+        @apply block h-full rounded-full bg-rose-500/80 dark:bg-rose-300/80;
+    }
+
+    .admin-errors-distribution-list__meta {
+        @apply mt-2 flex flex-wrap items-center justify-between gap-2 text-[0.62rem] font-semibold uppercase text-stone-400 dark:text-gray-500;
+        letter-spacing: 0;
+    }
+
+    .admin-errors-code-list {
+        @apply space-y-2.5;
+    }
+
+    .admin-errors-code-list li {
+        @apply flex items-center justify-between gap-3 rounded-lg border border-stone-100 bg-stone-50/40 p-3 dark:border-gray-800 dark:bg-gray-950/40;
+    }
+
+    .admin-errors-code-list span {
+        @apply block max-w-[12rem] truncate font-mono text-[0.66rem] font-semibold uppercase text-rose-600 dark:text-rose-300;
+        letter-spacing: 0;
+    }
+
+    .admin-errors-code-list em {
+        @apply mt-1 block text-[0.62rem] not-italic text-stone-400 dark:text-gray-500;
+    }
+
+    .admin-errors-code-list strong {
+        @apply flex-none text-xs font-semibold text-stone-900 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-errors-modal {
+        @apply fixed inset-0 z-50 flex items-center justify-center p-4;
+    }
+
+    .admin-errors-modal__backdrop {
+        @apply absolute inset-0 bg-stone-950/35 backdrop-blur-sm dark:bg-black/60;
+    }
+
+    .admin-errors-modal__panel {
+        @apply relative flex max-h-[86vh] w-full max-w-4xl flex-col overflow-hidden rounded-xl border border-stone-200 bg-white shadow-[0_24px_80px_rgba(28,25,23,0.24)] dark:border-gray-800 dark:bg-gray-950;
+    }
+
+    .admin-errors-modal__header {
+        @apply flex flex-none items-start justify-between gap-4 border-b border-stone-100 px-5 py-4 dark:border-gray-800;
+    }
+
+    .admin-errors-modal__eyebrow {
+        @apply text-[0.6rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-errors-modal__header h3 {
+        @apply mt-1 text-lg font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-errors-modal__code {
+        @apply mt-2 inline-block rounded-md bg-rose-50 px-2 py-0.5 text-[0.68rem] font-semibold uppercase text-rose-600 ring-1 ring-rose-100 dark:bg-rose-500/10 dark:text-rose-300 dark:ring-rose-400/20;
+        letter-spacing: 0;
+    }
+
+    .admin-errors-modal__close {
+        @apply inline-flex h-8 w-8 flex-none items-center justify-center rounded-lg text-stone-500 transition hover:bg-stone-100 hover:text-stone-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-gray-100;
+    }
+
+    .admin-errors-modal__body {
+        @apply min-h-0 flex-1 overflow-y-auto px-5 pb-5 pt-4;
+    }
+
+    .admin-errors-modal__summary-grid {
+        @apply grid gap-3 md:grid-cols-2 xl:grid-cols-3;
+    }
+
+    .admin-errors-modal__summary-grid > div {
+        @apply rounded-lg border border-stone-100 bg-stone-50/50 p-3 dark:border-gray-800 dark:bg-gray-900/50;
+    }
+
+    .admin-errors-modal__summary-grid span {
+        @apply block text-[0.6rem] font-bold uppercase text-stone-400 dark:text-gray-500;
+        letter-spacing: 0;
+    }
+
+    .admin-errors-modal__summary-grid strong {
+        @apply mt-1 block truncate text-xs font-semibold text-stone-900 dark:text-gray-100;
+    }
+
+    .admin-errors-modal__summary-grid strong.admin-errors-severity {
+        @apply inline-flex;
+    }
+
+    .admin-errors-modal__summary-grid strong.admin-errors-modal__trace {
+        @apply whitespace-normal break-all font-mono leading-relaxed;
+        overflow: visible;
+        text-overflow: clip;
+    }
+
+    .admin-errors-modal__summary-grid em {
+        @apply mt-1 block truncate text-[0.68rem] not-italic text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-errors-modal__section {
+        @apply mt-4 rounded-lg border border-stone-100 bg-white p-3.5 dark:border-gray-800 dark:bg-gray-900/40;
+    }
+
+    .admin-errors-modal__section h4 {
+        @apply text-[0.82rem] font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-errors-modal__section p {
+        @apply mt-2 text-[0.76rem] leading-relaxed text-stone-600 dark:text-gray-300;
+    }
+
+    .admin-errors-modal__section ul,
+    .admin-errors-modal__section ol {
+        @apply mt-2 space-y-1.5 pl-4 text-[0.76rem] leading-relaxed text-stone-600 dark:text-gray-300;
+    }
+
+    .admin-errors-modal__section ul {
+        @apply list-disc;
+    }
+
+    .admin-errors-modal__section ol {
+        @apply list-decimal;
+    }
+
+    .admin-errors-modal__metadata {
+        @apply mt-2 grid gap-2 md:grid-cols-2;
+    }
+
+    .admin-errors-modal__metadata div {
+        @apply min-w-0 rounded-md bg-stone-50 px-2.5 py-2 dark:bg-gray-950/70;
+    }
+
+    .admin-errors-modal__metadata dt {
+        @apply text-[0.58rem] font-bold uppercase text-stone-400 dark:text-gray-500;
+        letter-spacing: 0;
+    }
+
+    .admin-errors-modal__metadata dd {
+        @apply mt-1 truncate font-mono text-[0.68rem] text-stone-700 dark:text-gray-300;
+    }
+
+    .admin-overview {
+        @apply text-stone-900 dark:text-gray-100;
+    }
+
+    .admin-overview-title {
+        font-family: "Fraunces", serif;
+        @apply text-[1.55rem] font-semibold leading-tight text-stone-950 dark:text-gray-100;
+        letter-spacing: 0;
+    }
+
+    .admin-health-pulse {
+        @apply relative inline-flex h-3.5 w-3.5 items-center justify-center rounded-full bg-emerald-100 text-emerald-600 ring-1 ring-emerald-200 dark:bg-emerald-400/10 dark:ring-emerald-400/25;
+    }
+
+    .admin-health-pulse::after {
+        @apply absolute rounded-full bg-emerald-400/30 content-[''];
+        inset: -0.28rem;
+        animation: adminHealthPulse 1.65s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+    }
+
+    .admin-health-pulse span {
+        @apply relative z-10 h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_10px_rgba(16,185,129,0.65)] dark:bg-emerald-300;
+    }
+
+    .admin-overview-hero {
+        @apply relative grid min-h-[8.75rem] overflow-hidden p-5 lg:grid-cols-[1.1fr_0.95fr] lg:items-center lg:p-5;
+    }
+
+    .admin-hero-stats {
+        @apply grid gap-0 overflow-hidden rounded-lg bg-white/30 backdrop-blur-sm sm:grid-cols-3;
+    }
+
+    .dark .admin-hero-stats {
+        background: rgba(15, 23, 42, 0.22);
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
+    }
+
+    .admin-hero-stat {
+        @apply border-stone-200/80 px-4 py-3 sm:border-l;
+    }
+
+    .dark .admin-hero-stat {
+        border-color: rgba(55, 65, 81, 0.72);
+    }
+
+    .admin-hero-stat span {
+        @apply block text-[0.72rem] font-medium leading-tight text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-hero-stat strong {
+        @apply mt-2 block text-[1.5rem] font-bold leading-none text-stone-950 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+        letter-spacing: 0;
+    }
+
+    .admin-hero-stat em {
+        @apply mt-2 block text-[0.7rem] leading-snug not-italic;
+    }
+
+    .admin-summary-grid {
+        @apply mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4;
+    }
+
+    .admin-summary-card {
+        @apply block min-h-[7rem] overflow-hidden rounded-lg p-0 transition hover:border-ista-primary/25 hover:shadow-[0_12px_28px_rgba(28,25,23,0.06)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:hover:border-amber-300/25;
+    }
+
+    .admin-summary-card__top {
+        @apply flex items-center gap-2.5 border-b border-stone-200/80 px-4 py-2.5 text-ista-primary dark:border-gray-800 dark:text-amber-300;
+    }
+
+    .admin-summary-card__icon {
+        @apply inline-flex h-4 w-4 flex-none items-center justify-center;
+    }
+
+    .admin-summary-card__top h3 {
+        @apply truncate text-[0.72rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-summary-card__body {
+        @apply px-4 py-3;
+    }
+
+    .admin-summary-card__body p {
+        @apply text-[0.7rem] font-medium text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-summary-card__body strong {
+        @apply mt-1.5 block truncate text-[1.65rem] font-bold leading-none text-stone-950 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-summary-card__body div {
+        @apply mt-2 flex flex-wrap items-center gap-x-3 gap-y-1;
+    }
+
+    .admin-summary-card__body em {
+        @apply text-[0.68rem] not-italic text-stone-500 dark:text-gray-500;
+    }
+
+    .admin-summary-card--primary .admin-summary-card__body em:first-child { @apply text-emerald-600 dark:text-emerald-400; }
+    .admin-summary-card--gold .admin-summary-card__body em:first-child { @apply text-ista-primary dark:text-amber-300; }
+    .admin-summary-card--success .admin-summary-card__body em:first-child { @apply text-amber-600 dark:text-amber-400; }
+    .admin-summary-card--warning .admin-summary-card__body em:first-child { @apply text-amber-600 dark:text-amber-300; }
+
+    .admin-overview-main-grid {
+        @apply mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.42fr)_minmax(20rem,0.78fr)];
+    }
+
+    .admin-activity-panel {
+        @apply mt-4;
+    }
+
+    .admin-panel {
+        @apply overflow-hidden p-0;
+    }
+
+    .admin-panel-header {
+        @apply flex min-h-[3.35rem] items-center justify-between gap-3 border-b border-stone-200/80 px-4 py-3 dark:border-gray-800;
+    }
+
+    .admin-panel-header h3 {
+        @apply text-sm font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-panel-header p {
+        @apply mt-1 text-[0.7rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-panel-header a {
+        @apply text-xs font-bold text-ista-primary transition hover:text-ista-dark dark:text-amber-300 dark:hover:text-amber-200;
+    }
+
+    .admin-range-select select {
+        @apply h-8 rounded-lg border border-stone-200 bg-white px-2.5 text-xs font-medium text-stone-700 focus:border-ista-primary focus:outline-none focus:ring-2 focus:ring-ista-primary/15 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100;
+    }
+
+    .admin-line-chart {
+        @apply px-4 pb-2 pt-4;
+    }
+
+    .admin-line-chart svg {
+        @apply h-44 w-full overflow-visible;
+    }
+
+    .admin-chart-grid {
+        stroke: rgba(214, 211, 209, 0.85);
+        stroke-width: 1;
+    }
+
+    .dark .admin-chart-grid {
+        stroke: rgba(55, 65, 81, 0.85);
+    }
+
+    .admin-chart-line {
+        fill: none;
+        stroke: #a4063a;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: 2.4;
+    }
+
+    .admin-chart-dot {
+        fill: #a4063a;
+        stroke: #ffffff;
+        stroke-width: 3;
+    }
+
+    .admin-chart-axis,
+    .admin-chart-label {
+        @apply fill-stone-500 text-[11px] font-medium dark:fill-gray-500;
+    }
+
+    .admin-chart-value {
+        @apply fill-stone-950 text-[10px] font-bold dark:fill-gray-100;
+    }
+
+    .admin-chart-legend {
+        @apply flex flex-wrap items-center justify-center gap-4 px-4 pb-4 text-[0.7rem] font-medium text-stone-600 dark:text-gray-400;
+    }
+
+    .admin-chart-legend span {
+        @apply inline-flex items-center gap-2;
+    }
+
+    .admin-chart-legend i {
+        @apply block h-2.5 w-2.5 rounded-full;
+    }
+
+    .admin-incident-summary {
+        @apply grid grid-cols-2 divide-x divide-stone-200/80 border-b border-stone-200/80 px-4 py-4 dark:divide-gray-800 dark:border-gray-800;
+    }
+
+    .admin-incident-summary--compact {
+        @apply py-3.5;
+    }
+
+    .admin-incident-summary span {
+        @apply block text-xs font-medium text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-incident-summary strong {
+        @apply mt-2 block text-[1.45rem] font-bold leading-none text-stone-950 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-incident-summary em {
+        @apply mt-2 block text-xs not-italic text-stone-500 dark:text-gray-500;
+    }
+
+    .admin-incident-summary div {
+        @apply px-4 first:pl-0 last:pr-0;
+    }
+
+    .admin-overview-table {
+        @apply rounded-none border-0;
+    }
+
+    .admin-overview-table .admin-table-wrapper {
+        @apply rounded-none border-0;
+    }
+
+    .admin-row-avatar {
+        @apply flex h-8 w-8 flex-none items-center justify-center rounded-full bg-ista-primary text-xs font-bold text-amber-300;
+    }
+
+    .admin-error-list {
+        @apply divide-y divide-stone-200/80 dark:divide-gray-800;
+    }
+
+    .admin-error-list li {
+        @apply flex items-center gap-3 px-4 py-3;
+    }
+
+    .admin-error-list--compact li {
+        @apply py-3.5;
+    }
+
+    .admin-error-icon {
+        @apply flex h-8 w-8 flex-none items-center justify-center rounded-lg bg-rose-50 text-rose-600 ring-1 ring-rose-100 dark:bg-rose-500/10 dark:text-rose-300 dark:ring-rose-500/20;
+    }
+
+    .admin-error-list p {
+        @apply truncate font-mono text-sm font-semibold uppercase text-stone-800 dark:text-gray-100;
+    }
+
+    .admin-error-list em {
+        @apply mt-1 block text-xs not-italic text-stone-500 dark:text-gray-500;
+    }
+
+    .admin-error-code {
+        @apply mt-1 block truncate font-mono text-[0.62rem] uppercase text-rose-500 dark:text-rose-300;
+        letter-spacing: 0;
+    }
+}
+
+@keyframes adminHealthPulse {
+    0% {
+        opacity: 0.72;
+        transform: scale(0.72);
+    }
+
+    70% {
+        opacity: 0;
+        transform: scale(1.65);
+    }
+
+    100% {
+        opacity: 0;
+        transform: scale(1.65);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .admin-health-pulse::after {
+        animation: none;
+        opacity: 0.4;
+        transform: scale(1);
     }
 }
 

--- a/laravel/resources/views/admin/ai-config.blade.php
+++ b/laravel/resources/views/admin/ai-config.blade.php
@@ -1,25 +1,297 @@
+@php
+    $aiServiceUrl = rtrim((string) config('services.ai_service.url', 'http://127.0.0.1:8001'), '/');
+    $documentServiceUrl = rtrim((string) config('services.ai_document_service.url', $aiServiceUrl), '/');
+    $connectTimeout = (int) config('services.ai_service.connect_timeout', 10);
+    $requestTimeout = (int) config('services.ai_service.timeout', 120);
+    $readTimeout = (int) config('services.ai_service.read_timeout', 120);
+    $retryCount = (int) config('services.ai_service.retries', 2);
+    $retryDelay = (int) config('services.ai_service.retry_delay_ms', 400);
+    $maxHistory = (int) config('services.ai_service.max_history_messages', 20);
+    $aiToken = config('services.ai_service.token');
+    $documentToken = config('services.ai_document_service.token');
+    $aiTokenConfigured = filled($aiToken);
+    $documentTokenConfigured = filled($documentToken);
+    $documentTokenStatus = match (true) {
+        ! $documentTokenConfigured => 'Belum diset',
+        $documentToken === $aiToken => 'Mengikuti AI token',
+        default => 'Tersedia',
+    };
+
+    $hostLabel = function (string $url): string {
+        $host = parse_url($url, PHP_URL_HOST);
+        $port = parse_url($url, PHP_URL_PORT);
+
+        if (! is_string($host) || $host === '') {
+            return '-';
+        }
+
+        return $host . ($port ? ':' . $port : '');
+    };
+
+    $runtimeCards = [
+        [
+            'label' => 'AI Service',
+            'value' => $hostLabel($aiServiceUrl),
+            'description' => 'Endpoint chat utama',
+            'tone' => 'primary',
+            'icon' => 'M5 12h14M7 5h10a2 2 0 012 2v10a2 2 0 01-2 2H7a2 2 0 01-2-2V7a2 2 0 012-2zM8 9h.01M8 15h.01',
+        ],
+        [
+            'label' => 'Document Service',
+            'value' => $hostLabel($documentServiceUrl),
+            'description' => 'Parsing, RAG, dan indexing',
+            'tone' => 'success',
+            'icon' => 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.5L19 9.5V19a2 2 0 01-2 2z',
+        ],
+        [
+            'label' => 'Retry Policy',
+            'value' => max(1, $retryCount) . 'x',
+            'description' => number_format(max(0, $retryDelay), 0, ',', '.') . ' ms backoff',
+            'tone' => 'warning',
+            'icon' => 'M4 4v6h6M20 20v-6h-6M5.5 14a7 7 0 0012 3M18.5 10a7 7 0 00-12-3',
+        ],
+        [
+            'label' => 'History Window',
+            'value' => max(0, $maxHistory),
+            'description' => 'Pesan konteks maksimum',
+            'tone' => 'info',
+            'icon' => 'M12 6v6l3 2M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+        ],
+    ];
+
+    $routingRows = [
+        [
+            'feature' => 'Chat Assistant',
+            'lane' => 'chat',
+            'strategy' => 'Python cascade',
+            'status' => 'Aktif',
+            'tone' => 'success',
+        ],
+        [
+            'feature' => 'Document RAG',
+            'lane' => 'document_rag',
+            'strategy' => 'Retrieval + chat cascade',
+            'status' => 'Aktif',
+            'tone' => 'success',
+        ],
+        [
+            'feature' => 'Memo Generator',
+            'lane' => 'memo_generation',
+            'strategy' => 'Prompt template + chat cascade',
+            'status' => 'Aktif',
+            'tone' => 'success',
+        ],
+        [
+            'feature' => 'Document Indexing',
+            'lane' => 'embedding',
+            'strategy' => 'Embedding fallback',
+            'status' => 'Aktif',
+            'tone' => 'success',
+        ],
+        [
+            'feature' => 'Web Search',
+            'lane' => 'web_search',
+            'strategy' => 'Realtime context gate',
+            'status' => 'Aktif',
+            'tone' => 'success',
+        ],
+    ];
+
+    $runtimeParameters = [
+        ['label' => 'Connect timeout', 'value' => $connectTimeout . 's'],
+        ['label' => 'Request timeout', 'value' => $requestTimeout . 's'],
+        ['label' => 'Read timeout', 'value' => $readTimeout . 's'],
+        ['label' => 'Retry delay', 'value' => number_format(max(0, $retryDelay), 0, ',', '.') . ' ms'],
+        ['label' => 'Max history', 'value' => max(0, $maxHistory) . ' pesan'],
+    ];
+
+    $promptProfiles = [
+        ['name' => 'System Prompt', 'scope' => 'Global assistant behavior', 'source' => 'Python config'],
+        ['name' => 'RAG Prompt', 'scope' => 'Jawaban berbasis dokumen', 'source' => 'Python config'],
+        ['name' => 'Memo Prompt', 'scope' => 'Generator memo dinas', 'source' => 'Python config'],
+        ['name' => 'Fallback Copy', 'scope' => 'Pesan saat konteks tidak tersedia', 'source' => 'Python config'],
+    ];
+
+    $guardrails = [
+        ['label' => 'API token', 'value' => $aiTokenConfigured ? 'Tersedia' : 'Belum diset', 'tone' => $aiTokenConfigured ? 'success' : 'warning'],
+        ['label' => 'Document token', 'value' => $documentTokenStatus, 'tone' => $documentTokenConfigured ? 'success' : 'warning'],
+        ['label' => 'Prompt logging', 'value' => 'Tidak disimpan', 'tone' => 'success'],
+        ['label' => 'Error sentinel', 'value' => 'Aktif', 'tone' => 'success'],
+    ];
+@endphp
+
 <x-layouts.admin title="AI Configuration" heading="AI Configuration">
-    <x-slot name="pageHeader">
-        <div class="flex flex-wrap items-end justify-between gap-3">
+    <div class="admin-ai-config-page">
+        <div class="admin-ai-config-hero">
             <div class="max-w-2xl">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Super Admin</p>
-                <h2 class="admin-page-title mt-1">AI Configuration</h2>
-                <p class="mt-2 text-sm leading-relaxed text-stone-500 dark:text-gray-400">
-                    Halaman ini akan menjadi pusat konfigurasi prompt, model AI, dan parameter generasi. Implementasi penuh akan dikerjakan pada child khusus.
+                <p class="admin-ai-config-eyebrow">Administration</p>
+                <h2 class="admin-ai-config-title">AI Configuration</h2>
+                <p class="admin-ai-config-description">
+                    Pantau routing model, prompt profile, parameter service, dan guardrail runtime AI.
                 </p>
             </div>
-            <x-admin.badge tone="gold">
-                <span class="h-1.5 w-1.5 rounded-full bg-amber-500"></span>
-                Akses terbatas
-            </x-admin.badge>
+            <div class="admin-ai-config-hero__actions">
+                <span class="admin-ai-config-access-badge">
+                    <span></span>
+                    Akses terbatas
+                </span>
+                <x-admin.badge tone="neutral" class="admin-ai-config-readonly">Read-only</x-admin.badge>
+            </div>
         </div>
-    </x-slot>
 
-    <x-admin.section
-        title="Placeholder"
-        description="Form konfigurasi akan dibangun di sini.">
-        <x-admin.empty-state
-            title="Belum ada konfigurasi"
-            description="Formulir prompt, pemilih model, dan parameter generasi akan tersedia pada child AI Configuration." />
-    </x-admin.section>
+        <div class="admin-ai-config-kpi-grid">
+            @foreach ($runtimeCards as $card)
+                <article class="admin-ai-config-kpi-card admin-ai-config-kpi-card--{{ $card['tone'] }}">
+                    <div class="admin-ai-config-kpi-card__header">
+                        <span class="admin-ai-config-kpi-card__icon" aria-hidden="true">
+                            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="{{ $card['icon'] }}"/>
+                            </svg>
+                        </span>
+                        <p class="admin-ai-config-kpi-card__label">{{ $card['label'] }}</p>
+                    </div>
+                    <div class="admin-ai-config-kpi-card__body">
+                        <strong title="{{ $card['value'] }}">{{ $card['value'] }}</strong>
+                        <p class="admin-ai-config-kpi-card__description">{{ $card['description'] }}</p>
+                    </div>
+                </article>
+            @endforeach
+        </div>
+
+        <div class="admin-ai-config-content-grid">
+            <section class="admin-ai-config-table-panel admin-section">
+                <header class="admin-ai-config-panel__header">
+                    <div>
+                        <h3>Model Routing</h3>
+                        <p>Alur fitur AI yang berjalan melalui service Python dan fallback provider.</p>
+                    </div>
+                    <span class="admin-ai-config-source-chip">Runtime</span>
+                </header>
+
+                <div class="admin-ai-config-table-panel__body">
+                    <x-admin.table
+                        class="admin-ai-config-table"
+                        :columns="[
+                            ['key' => 'feature', 'label' => 'Fitur', 'width' => '28%'],
+                            ['key' => 'lane', 'label' => 'Lane', 'width' => '21%'],
+                            ['key' => 'strategy', 'label' => 'Strategi', 'width' => '31%'],
+                            ['key' => 'status', 'label' => 'Status', 'align' => 'right', 'width' => '20%'],
+                        ]">
+                        @foreach ($routingRows as $row)
+                            <tr>
+                                <td class="admin-table__td">
+                                    <span class="admin-ai-config-feature">{{ $row['feature'] }}</span>
+                                </td>
+                                <td class="admin-table__td">
+                                    <span class="admin-ai-config-code">{{ $row['lane'] }}</span>
+                                </td>
+                                <td class="admin-table__td">
+                                    <span class="admin-ai-config-muted">{{ $row['strategy'] }}</span>
+                                </td>
+                                <td class="admin-table__td" data-align="right">
+                                    <x-admin.badge :tone="$row['tone']" class="admin-ai-config-status-badge">
+                                        {{ $row['status'] }}
+                                    </x-admin.badge>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </x-admin.table>
+                </div>
+            </section>
+
+            <aside class="admin-ai-config-side-grid">
+                <section class="admin-ai-config-parameter-panel admin-section">
+                    <header class="admin-ai-config-panel__header">
+                        <div>
+                            <h3>Parameter Runtime</h3>
+                            <p>Nilai dibaca dari Laravel config.</p>
+                        </div>
+                    </header>
+                    <div class="admin-ai-config-parameter-panel__body">
+                        <dl class="admin-ai-config-parameter-list">
+                            @foreach ($runtimeParameters as $parameter)
+                                <div>
+                                    <dt>{{ $parameter['label'] }}</dt>
+                                    <dd>{{ $parameter['value'] }}</dd>
+                                </div>
+                            @endforeach
+                        </dl>
+                    </div>
+                </section>
+
+                <section class="admin-ai-config-guardrail-panel admin-section">
+                    <header class="admin-ai-config-panel__header">
+                        <div>
+                            <h3>Guardrail</h3>
+                            <p>Status keamanan konfigurasi.</p>
+                        </div>
+                    </header>
+                    <div class="admin-ai-config-guardrail-panel__body">
+                        <ul class="admin-ai-config-guardrail-list" role="list">
+                            @foreach ($guardrails as $item)
+                                <li>
+                                    <span class="admin-ai-config-guardrail-dot admin-ai-config-guardrail-dot--{{ $item['tone'] }}" aria-hidden="true"></span>
+                                    <div>
+                                        <strong>{{ $item['label'] }}</strong>
+                                        <em>{{ $item['value'] }}</em>
+                                    </div>
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                </section>
+            </aside>
+        </div>
+
+        <div class="admin-ai-config-lower-grid">
+            <section class="admin-ai-config-prompt-panel admin-section">
+                <header class="admin-ai-config-panel__header">
+                    <div>
+                        <h3>Prompt Profiles</h3>
+                        <p>Profil prompt yang menjadi kontrak perilaku AI saat ini.</p>
+                    </div>
+                    <span class="admin-ai-config-source-chip">Config source</span>
+                </header>
+                <div class="admin-ai-config-prompt-panel__body">
+                    <div class="admin-ai-config-profile-grid">
+                        @foreach ($promptProfiles as $profile)
+                            <article class="admin-ai-config-profile-card">
+                                <span></span>
+                                <div>
+                                    <strong>{{ $profile['name'] }}</strong>
+                                    <p>{{ $profile['scope'] }}</p>
+                                    <em>{{ $profile['source'] }}</em>
+                                </div>
+                            </article>
+                        @endforeach
+                    </div>
+                </div>
+            </section>
+
+            <section class="admin-ai-config-endpoint-panel admin-section">
+                <header class="admin-ai-config-panel__header">
+                    <div>
+                        <h3>Service Endpoints</h3>
+                        <p>Endpoint runtime tanpa secret.</p>
+                    </div>
+                </header>
+                <div class="admin-ai-config-endpoint-panel__body">
+                    <dl class="admin-ai-config-endpoint-list">
+                        <div>
+                            <dt>AI service URL</dt>
+                            <dd title="{{ $aiServiceUrl }}">{{ $aiServiceUrl }}</dd>
+                        </div>
+                        <div>
+                            <dt>Document service URL</dt>
+                            <dd title="{{ $documentServiceUrl }}">{{ $documentServiceUrl }}</dd>
+                        </div>
+                        <div>
+                            <dt>Config ownership</dt>
+                            <dd>Env + Python YAML</dd>
+                        </div>
+                    </dl>
+                </div>
+            </section>
+        </div>
+    </div>
 </x-layouts.admin>

--- a/laravel/resources/views/admin/auth/login.blade.php
+++ b/laravel/resources/views/admin/auth/login.blade.php
@@ -1,8 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}"
-      x-data="{ darkMode: localStorage.getItem('theme') === 'dark' }"
-      x-init="$watch('darkMode', value => { localStorage.setItem('theme', value ? 'dark' : 'light'); document.documentElement.classList.toggle('dark', value); })"
-      :class="{ 'dark': darkMode }">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -18,11 +15,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
     <script>
-        if (localStorage.theme === 'dark') {
-            document.documentElement.classList.add('dark');
-        } else {
-            document.documentElement.classList.remove('dark');
-        }
+        (() => {
+            const storedTheme = localStorage.getItem('theme');
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const useDarkTheme = storedTheme ? storedTheme === 'dark' : prefersDark;
+
+            document.documentElement.classList.toggle('dark', useDarkTheme);
+        })();
     </script>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
@@ -35,13 +34,14 @@
 
         <div class="absolute right-4 top-4 sm:right-6 sm:top-6">
             <button type="button"
-                    @click="darkMode = !darkMode"
+                    data-admin-theme-toggle
                     class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-stone-200 bg-white text-stone-500 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-ista-primary/40 dark:hover:text-amber-300"
+                    aria-pressed="false"
                     aria-label="Toggle dark mode">
-                <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 dark:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />
                 </svg>
-                <svg x-show="darkMode === true" style="display: none;" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg xmlns="http://www.w3.org/2000/svg" class="hidden h-5 w-5 dark:block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z" />
                 </svg>
             </button>
@@ -49,14 +49,12 @@
 
         <main class="relative w-full max-w-md">
             <div class="mb-6 flex flex-col items-center text-center">
-                <a href="{{ route('admin.login') }}" class="flex items-center gap-3">
-                    <img src="{{ asset('images/ista/logo.png') }}" alt="ISTA AI" class="h-10 w-10 object-contain">
-                    <span class="ista-brand-title text-2xl text-ista-primary not-italic dark:text-amber-200">
+                <a href="{{ route('admin.login') }}" class="inline-flex items-center justify-center">
+                    <span class="ista-brand-title text-[1.9rem] leading-none text-ista-primary not-italic dark:text-amber-200">
                         ISTA <span class="font-light italic text-ista-gold dark:text-amber-300">AI</span>
                     </span>
                 </a>
-                <p class="mt-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-400 dark:text-gray-500">Admin Console</p>
-                <h1 class="mt-2 text-2xl font-semibold text-stone-900 dark:text-gray-50">Login Admin</h1>
+                <h1 class="mt-4 text-2xl font-semibold text-stone-900 dark:text-gray-50">Login Admin</h1>
                 <p class="mt-2 max-w-sm text-sm leading-relaxed text-stone-500 dark:text-gray-400">
                     Akses terbatas untuk administrator yang berwenang. Aktivitas login dicatat untuk keperluan audit.
                 </p>
@@ -104,7 +102,7 @@
                     <button type="submit"
                             class="inline-flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-ista-primary px-4 text-sm font-semibold uppercase tracking-wider text-amber-300 shadow-sm transition hover:bg-stone-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/40 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900">
                         <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M11 16l-4-4m0 0l4-4m-4 4h12m-4 8h2a2 2 0 002-2V6a2 2 0 00-2-2h-2"/>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M13 8l4 4m0 0l-4 4m4-4H5m4-8H7a2 2 0 00-2 2v12a2 2 0 002 2h2"/>
                         </svg>
                         Masuk ke Admin
                     </button>
@@ -120,5 +118,29 @@
             </p>
         </main>
     </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const toggle = document.querySelector('[data-admin-theme-toggle]');
+
+            if (! toggle) {
+                return;
+            }
+
+            const syncToggleState = () => {
+                toggle.setAttribute('aria-pressed', document.documentElement.classList.contains('dark') ? 'true' : 'false');
+            };
+
+            syncToggleState();
+
+            toggle.addEventListener('click', () => {
+                const useDarkTheme = ! document.documentElement.classList.contains('dark');
+
+                document.documentElement.classList.toggle('dark', useDarkTheme);
+                localStorage.setItem('theme', useDarkTheme ? 'dark' : 'light');
+                syncToggleState();
+            });
+        });
+    </script>
 </body>
 </html>

--- a/laravel/resources/views/components/admin/sidebar.blade.php
+++ b/laravel/resources/views/components/admin/sidebar.blade.php
@@ -1,6 +1,6 @@
 @php
     $user = auth()->user();
-    $items = [
+    $monitoringItems = [
         [
             'label' => 'Overview',
             'description' => 'Ringkasan dashboard',
@@ -19,7 +19,7 @@
             'label' => 'Usage',
             'description' => 'Event AI per fitur',
             'route' => 'admin.usage',
-            'icon' => 'M9 19V6l12-3v13M9 19c0 1.657-1.343 3-3 3s-3-1.343-3-3 1.343-3 3-3 3 1.343 3 3zm12-3c0 1.657-1.343 3-3 3s-3-1.343-3-3 1.343-3 3-3 3 1.343 3 3z',
+            'icon' => 'M4 19V10m5 9V5m5 14v-7m5 7V8M3 19h18',
             'visible' => true,
         ],
         [
@@ -38,8 +38,10 @@
         ],
     ];
 
+    $administrationItems = [];
+
     if ($user && method_exists($user, 'isSuperAdmin') && $user->isSuperAdmin()) {
-        $items[] = [
+        $administrationItems[] = [
             'label' => 'Account Management',
             'description' => 'Kelola akun admin',
             'route' => 'admin.accounts',
@@ -47,7 +49,7 @@
             'visible' => true,
         ];
 
-        $items[] = [
+        $administrationItems[] = [
             'label' => 'AI Configuration',
             'description' => 'Hanya super admin',
             'route' => 'admin.ai-config',
@@ -66,8 +68,8 @@
 <div class="flex h-full flex-col">
     <div class="flex items-center justify-between gap-3 border-b border-stone-200/80 px-6 py-5 dark:border-gray-800">
         <a href="{{ route('admin.dashboard') }}" class="group flex items-center gap-3">
-            <img src="{{ asset('images/ista/logo.png') }}" alt="ISTA AI" class="h-8 w-8 object-contain transition-transform duration-300 group-hover:rotate-6 group-hover:scale-110">
-            <div class="ista-brand-title text-lg text-ista-primary not-italic">
+            <img src="{{ asset('images/ista/logo.png') }}" alt="ISTA AI" class="h-9 w-9 object-contain transition-transform duration-300 group-hover:rotate-6 group-hover:scale-105">
+            <div class="ista-brand-title text-[1.15rem] text-ista-primary not-italic">
                 ISTA <span class="font-light italic text-ista-gold">AI</span>
             </div>
         </a>
@@ -81,49 +83,137 @@
         </button>
     </div>
 
-    <nav class="flex-1 overflow-y-auto px-3 py-4" aria-label="Navigasi admin">
-        <p class="px-3 pb-2 text-[10.5px] font-bold uppercase tracking-[0.16em] text-stone-400 dark:text-gray-500">Menu</p>
-        <ul class="space-y-1" role="list">
-            @foreach ($items as $item)
-                @continue(! ($item['visible'] ?? false))
-                @php
-                    $active = request()->routeIs($item['route']);
-                @endphp
-                <li>
-                    <a href="{{ route($item['route']) }}"
-                       @class([
-                           'admin-nav-link group',
-                           'admin-nav-link--active' => $active,
-                       ])
-                       @if ($active) aria-current="page" @endif>
-                        <span class="admin-nav-link__icon" aria-hidden="true">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="{{ $item['icon'] }}"/>
-                            </svg>
-                        </span>
-                        <span class="flex-1">
-                            <span class="block text-sm font-semibold leading-tight">{{ $item['label'] }}</span>
-                            @if (! empty($item['description']))
-                                <span class="mt-0.5 block text-[11px] font-medium text-stone-400 group-hover:text-ista-primary/60 dark:text-gray-500 dark:group-hover:text-amber-300/70">{{ $item['description'] }}</span>
-                            @endif
-                        </span>
-                    </a>
-                </li>
-            @endforeach
-        </ul>
+    <nav class="flex-1 overflow-y-auto px-4 py-5" aria-label="Navigasi admin">
+        <div class="admin-sidebar-group">
+            <p class="admin-sidebar-heading">Monitoring</p>
+            <ul class="space-y-2" role="list">
+                @foreach ($monitoringItems as $item)
+                    @continue(! ($item['visible'] ?? false))
+                    @php
+                        $active = request()->routeIs($item['route']);
+                    @endphp
+                    <li>
+                        <a href="{{ route($item['route']) }}"
+                           @class([
+                               'admin-nav-link group',
+                               'admin-nav-link--active' => $active,
+                           ])
+                           @if ($active) aria-current="page" @endif>
+                            <span class="admin-nav-link__icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="{{ $item['icon'] }}"/>
+                                </svg>
+                            </span>
+                            <span class="flex-1">
+                                <span class="block text-sm font-semibold leading-tight">{{ $item['label'] }}</span>
+                                @if (! empty($item['description']))
+                                    <span class="sr-only">{{ $item['description'] }}</span>
+                                @endif
+                            </span>
+                        </a>
+                    </li>
+                @endforeach
+            </ul>
+        </div>
+
+        @if (! empty($administrationItems))
+            <div class="admin-sidebar-group mt-6 border-t border-stone-200/80 pt-5 dark:border-gray-800">
+                <p class="admin-sidebar-heading">Administration</p>
+                <ul class="space-y-2" role="list">
+                    @foreach ($administrationItems as $item)
+                        @continue(! ($item['visible'] ?? false))
+                        @php
+                            $active = request()->routeIs($item['route']);
+                        @endphp
+                        <li>
+                            <a href="{{ route($item['route']) }}"
+                               @class([
+                                   'admin-nav-link group',
+                                   'admin-nav-link--active' => $active,
+                               ])
+                               @if ($active) aria-current="page" @endif>
+                                <span class="admin-nav-link__icon" aria-hidden="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="{{ $item['icon'] }}"/>
+                                    </svg>
+                                </span>
+                                <span class="flex-1">
+                                    <span class="block text-sm font-semibold leading-tight">{{ $item['label'] }}</span>
+                                    @if (! empty($item['description']))
+                                        <span class="sr-only">{{ $item['description'] }}</span>
+                                    @endif
+                                </span>
+                            </a>
+                        </li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
     </nav>
 
-    <div class="border-t border-stone-200/80 px-4 py-4 dark:border-gray-800">
+    <div class="relative border-t border-stone-200/80 px-6 py-4 dark:border-gray-800"
+         x-data="{ open: false }"
+         @click.outside="open = false"
+         @keydown.escape.window="open = false">
         @auth
-            <div class="flex items-center gap-3">
-                <div class="flex h-9 w-9 items-center justify-center rounded-full bg-ista-primary text-sm font-bold text-amber-300">
+            <div x-show="open"
+                 x-transition:enter="transition ease-out duration-150"
+                 x-transition:enter-start="translate-y-1 opacity-0"
+                 x-transition:enter-end="translate-y-0 opacity-100"
+                 x-transition:leave="transition ease-in duration-100"
+                 x-transition:leave-start="translate-y-0 opacity-100"
+                 x-transition:leave-end="translate-y-1 opacity-0"
+                 id="admin-sidebar-profile-menu"
+                 class="absolute bottom-full left-4 right-4 z-50 mb-2 overflow-hidden rounded-xl border border-stone-100 bg-white py-1 shadow-xl ring-1 ring-black/5 dark:border-gray-800 dark:bg-gray-900"
+                 role="menu"
+                 style="display: none;">
+                <a href="{{ route('admin.dashboard') }}"
+                   class="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-ista-primary transition hover:bg-stone-50 dark:text-amber-300 dark:hover:bg-gray-800"
+                   role="menuitem"
+                   @click="open = false">
+                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
+                    </svg>
+                    Dashboard Admin
+                </a>
+                <a href="{{ route('profile') }}"
+                   class="block px-4 py-2.5 text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-amber-300"
+                   role="menuitem"
+                   @click="open = false">
+                    Profil
+                </a>
+                <form method="POST" action="{{ route('admin.logout') }}">
+                    @csrf
+                    <button type="submit"
+                            class="block w-full border-t border-stone-100 px-4 py-2.5 text-left text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary dark:border-gray-800 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-amber-300"
+                            role="menuitem">
+                        Keluar
+                    </button>
+                </form>
+            </div>
+
+            <button type="button"
+                    class="-mx-2 flex w-[calc(100%+1rem)] items-center gap-3 rounded-xl px-2 py-2 text-left transition hover:bg-stone-100/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/30 dark:hover:bg-gray-900"
+                    aria-haspopup="menu"
+                    aria-controls="admin-sidebar-profile-menu"
+                    :aria-expanded="open ? 'true' : 'false'"
+                    @click="open = ! open">
+                <div class="flex h-9 w-9 items-center justify-center rounded-full bg-ista-primary text-sm font-bold text-amber-300 shadow-sm">
                     {{ substr(auth()->user()->name, 0, 1) }}
                 </div>
                 <div class="min-w-0 flex-1">
                     <p class="truncate text-sm font-semibold text-stone-800 dark:text-gray-100">{{ auth()->user()->name }}</p>
                     <p class="truncate text-[11px] font-medium uppercase tracking-wider text-stone-400 dark:text-gray-500">{{ $roleLabel }}</p>
                 </div>
-            </div>
+                <svg class="h-4 w-4 text-stone-900 transition dark:text-gray-200"
+                     :class="open ? 'rotate-180' : 'rotate-0'"
+                     fill="none"
+                     viewBox="0 0 24 24"
+                     stroke="currentColor"
+                     aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M19 9l-7 7-7-7" />
+                </svg>
+            </button>
         @endauth
     </div>
 </div>

--- a/laravel/resources/views/components/layouts/admin.blade.php
+++ b/laravel/resources/views/components/layouts/admin.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}"
       x-data="{ darkMode: localStorage.getItem('theme') === 'dark', sidebarOpen: false }"
-      x-init="$watch('darkMode', value => { localStorage.setItem('theme', value ? 'dark' : 'light'); document.documentElement.classList.toggle('dark', value); })"
+      x-init="document.documentElement.classList.toggle('dark', darkMode); $watch('darkMode', value => { localStorage.setItem('theme', value ? 'dark' : 'light'); document.documentElement.classList.toggle('dark', value); })"
       :class="{ 'dark': darkMode }">
 <head>
     <meta charset="utf-8">
@@ -25,7 +25,7 @@
     </script>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
-<body class="ista-shell ista-display-sans text-stone-800 dark:text-gray-100 transition-colors duration-300">
+<body class="ista-shell ista-display-sans overflow-hidden text-stone-800 dark:text-gray-100 transition-colors duration-300">
     <x-page-loader />
 
     <div class="admin-shell relative flex min-h-[var(--app-viewport-height)] w-full">
@@ -45,9 +45,9 @@
         </aside>
 
         <!-- Main column -->
-        <div class="flex min-w-0 flex-1 flex-col">
+        <div class="admin-content">
             <header class="admin-topbar">
-                <div class="flex items-center gap-3">
+                <div class="flex min-w-0 items-center gap-3">
                     <button type="button"
                             @click="sidebarOpen = true"
                             class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-stone-500 transition hover:bg-stone-100 dark:text-gray-300 dark:hover:bg-gray-800 lg:hidden"
@@ -57,9 +57,10 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 6h16M4 12h16M4 18h16" />
                         </svg>
                     </button>
-                    <div>
-                        <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Dashboard Admin</p>
-                        <h1 class="ista-brand-title text-xl text-stone-900 not-italic dark:text-gray-100">
+                    <div class="admin-breadcrumb min-w-0">
+                        <a href="{{ route('admin.dashboard') }}" class="truncate text-stone-500 transition hover:text-ista-primary dark:text-gray-400 dark:hover:text-amber-300">Dashboard Admin</a>
+                        <span class="text-stone-300 dark:text-gray-700">/</span>
+                        <h1 class="truncate text-sm font-bold text-stone-950 dark:text-gray-100">
                             {{ $heading ?? ($title ?? 'Admin') }}
                         </h1>
                     </div>
@@ -67,7 +68,8 @@
                 <div class="flex items-center gap-2 sm:gap-3">
                     <button type="button"
                             @click="darkMode = !darkMode"
-                            class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-stone-500 transition hover:bg-stone-100 dark:text-gray-300 dark:hover:bg-gray-800"
+                            class="admin-icon-button"
+                            :aria-pressed="darkMode ? 'true' : 'false'"
                             aria-label="Toggle dark mode">
                         <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />
@@ -77,24 +79,12 @@
                         </svg>
                     </button>
                     <a href="{{ route('chat') }}"
-                       class="hidden h-10 items-center gap-2 rounded-lg border border-stone-200 bg-white px-3 text-xs font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-ista-primary/40 dark:hover:text-amber-300 sm:inline-flex">
+                       class="admin-action-button hidden sm:inline-flex">
                         <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12H3m0 0l6-6m-6 6l6 6"/>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 12h18m0 0l-6-6m6 6l-6 6"/>
                         </svg>
-                        Kembali ke Chat
+                        Masuk ke Chat
                     </a>
-                    <form method="POST" action="{{ route('admin.logout') }}" class="inline-flex">
-                        @csrf
-                        <button type="submit"
-                                class="inline-flex h-10 items-center gap-2 rounded-lg border border-stone-200 bg-white px-3 text-xs font-semibold uppercase tracking-wider text-stone-600 transition hover:border-rose-400/40 hover:text-rose-600 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-rose-400/40 dark:hover:text-rose-300"
-                                aria-label="Keluar dari admin">
-                            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
-                            </svg>
-                            <span class="hidden sm:inline">Logout</span>
-                        </button>
-                    </form>
-                    <livewire:dashboard-nav-profile />
                 </div>
             </header>
 

--- a/laravel/resources/views/layouts/admin.blade.php
+++ b/laravel/resources/views/layouts/admin.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}"
       x-data="{ darkMode: localStorage.getItem('theme') === 'dark', sidebarOpen: false }"
-      x-init="$watch('darkMode', value => { localStorage.setItem('theme', value ? 'dark' : 'light'); document.documentElement.classList.toggle('dark', value); })"
+      x-init="document.documentElement.classList.toggle('dark', darkMode); $watch('darkMode', value => { localStorage.setItem('theme', value ? 'dark' : 'light'); document.documentElement.classList.toggle('dark', value); })"
       :class="{ 'dark': darkMode }">
 <head>
     <meta charset="utf-8">
@@ -25,7 +25,7 @@
     </script>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
-<body class="ista-shell ista-display-sans text-stone-800 dark:text-gray-100 transition-colors duration-300">
+<body class="ista-shell ista-display-sans overflow-hidden text-stone-800 dark:text-gray-100 transition-colors duration-300">
     <x-page-loader />
 
     <div class="admin-shell relative flex min-h-[var(--app-viewport-height)] w-full">
@@ -45,9 +45,9 @@
         </aside>
 
         <!-- Main column -->
-        <div class="flex min-w-0 flex-1 flex-col">
+        <div class="admin-content">
             <header class="admin-topbar">
-                <div class="flex items-center gap-3">
+                <div class="flex min-w-0 items-center gap-3">
                     <button type="button"
                             @click="sidebarOpen = true"
                             class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-stone-500 transition hover:bg-stone-100 dark:text-gray-300 dark:hover:bg-gray-800 lg:hidden"
@@ -57,9 +57,10 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 6h16M4 12h16M4 18h16" />
                         </svg>
                     </button>
-                    <div>
-                        <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Dashboard Admin</p>
-                        <h1 class="ista-brand-title text-xl text-stone-900 not-italic dark:text-gray-100">
+                    <div class="admin-breadcrumb min-w-0">
+                        <a href="{{ route('admin.dashboard') }}" class="truncate text-stone-500 transition hover:text-ista-primary dark:text-gray-400 dark:hover:text-amber-300">Dashboard Admin</a>
+                        <span class="text-stone-300 dark:text-gray-700">/</span>
+                        <h1 class="truncate text-sm font-bold text-stone-950 dark:text-gray-100">
                             {{ $heading ?? ($title ?? 'Admin') }}
                         </h1>
                     </div>
@@ -67,7 +68,8 @@
                 <div class="flex items-center gap-2 sm:gap-3">
                     <button type="button"
                             @click="darkMode = !darkMode"
-                            class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-stone-500 transition hover:bg-stone-100 dark:text-gray-300 dark:hover:bg-gray-800"
+                            class="admin-icon-button"
+                            :aria-pressed="darkMode ? 'true' : 'false'"
                             aria-label="Toggle dark mode">
                         <svg x-show="darkMode === false" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v2.5M12 18.5V21M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M3 12h2.5M18.5 12H21M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8M12 16a4 4 0 100-8 4 4 0 000 8z" />
@@ -77,24 +79,12 @@
                         </svg>
                     </button>
                     <a href="{{ route('chat') }}"
-                       class="hidden h-10 items-center gap-2 rounded-lg border border-stone-200 bg-white px-3 text-xs font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-ista-primary/40 dark:hover:text-amber-300 sm:inline-flex">
+                       class="admin-action-button hidden sm:inline-flex">
                         <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12H3m0 0l6-6m-6 6l6 6"/>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 12h18m0 0l-6-6m6 6l-6 6"/>
                         </svg>
-                        Kembali ke Chat
+                        Masuk ke Chat
                     </a>
-                    <form method="POST" action="{{ route('admin.logout') }}" class="inline-flex">
-                        @csrf
-                        <button type="submit"
-                                class="inline-flex h-10 items-center gap-2 rounded-lg border border-stone-200 bg-white px-3 text-xs font-semibold uppercase tracking-wider text-stone-600 transition hover:border-rose-400/40 hover:text-rose-600 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-rose-400/40 dark:hover:text-rose-300"
-                                aria-label="Keluar dari admin">
-                            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
-                            </svg>
-                            <span class="hidden sm:inline">Logout</span>
-                        </button>
-                    </form>
-                    <livewire:dashboard-nav-profile />
                 </div>
             </header>
 

--- a/laravel/resources/views/livewire/admin/admin-accounts.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-accounts.blade.php
@@ -1,316 +1,419 @@
-<div>
-    <div class="mb-6">
-        <div class="flex flex-wrap items-end justify-between gap-3">
-            <div class="max-w-2xl">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Super Admin</p>
-                <h2 class="admin-page-title mt-1">Account Management</h2>
-                <p class="mt-2 text-sm leading-relaxed text-stone-500 dark:text-gray-400">
-                    Kelola akun admin dan super admin. Buat akun baru, ubah role, aktifkan atau nonaktifkan akses, dan reset password sementara.
-                </p>
-            </div>
-            <div class="flex flex-wrap items-center gap-2">
-                <x-admin.badge tone="gold">
-                    <span class="h-1.5 w-1.5 rounded-full bg-amber-500"></span>
-                    Akses terbatas
-                </x-admin.badge>
-                <x-admin.badge tone="primary">
-                    Total Super Admin Aktif: {{ $totalActiveSuperAdmins }}
-                </x-admin.badge>
-                <button type="button"
-                        wire:click="openCreateModal"
-                        class="inline-flex h-9 items-center gap-2 rounded-lg bg-ista-primary px-3 text-xs font-semibold uppercase tracking-wider text-amber-300 transition hover:bg-stone-800">
-                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 4v16m8-8H4"/>
-                    </svg>
-                    Tambah Akun
-                </button>
-            </div>
+@php
+    $formatInt = fn ($value): string => number_format((float) $value, 0, ',', '.');
+    $summaryTotal = (int) ($accountSummary['total'] ?? 0);
+    $activeAccounts = (int) ($accountSummary['active'] ?? 0);
+    $forcedPasswordAccounts = (int) ($accountSummary['force_password_change'] ?? 0);
+    $activeSuperAdminAccounts = (int) ($accountSummary['active_super_admins'] ?? 0);
+    $accountCards = [
+        [
+            'label' => 'Total Akun Admin',
+            'value' => $summaryTotal,
+            'description' => 'Semua akun admin & super admin',
+            'tone' => 'primary',
+            'icon' => 'M12 11c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v3h16v-3c0-2.66-5.33-4-8-4z',
+        ],
+        [
+            'label' => 'Akun Aktif',
+            'value' => $activeAccounts,
+            'description' => 'Sedang memiliki akses',
+            'tone' => 'success',
+            'icon' => 'M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+        ],
+        [
+            'label' => 'Perlu Reset Password',
+            'value' => $forcedPasswordAccounts,
+            'description' => 'Tindakan keamanan tertunda',
+            'tone' => 'warning',
+            'icon' => 'M15 7.5a3 3 0 11-4.95 2.3L4.5 15.35V18h2.65l5.55-5.55A3 3 0 0015 7.5zM15 7.5h.01M17.5 4.5l2 2m0 0l2-2m-2 2V2.75',
+        ],
+        [
+            'label' => 'Super Admin Aktif',
+            'value' => $activeSuperAdminAccounts,
+            'description' => 'Hak akses tertinggi',
+            'tone' => 'danger',
+            'icon' => 'M12 3l7.5 4.5v5.25c0 4.5-3.075 7.55-7.5 8.25-4.425-.7-7.5-3.75-7.5-8.25V7.5L12 3z',
+        ],
+    ];
+    $roleLabel = fn (?string $role): string => $role === 'super_admin' ? 'Super Admin' : 'Admin';
+    $roleTone = fn (?string $role): string => $role === 'super_admin' ? 'gold' : 'primary';
+    $statusMeta = fn ($account): array => (bool) $account->is_active
+        ? ['label' => 'Aktif', 'tone' => 'success']
+        : ['label' => 'Nonaktif', 'tone' => 'danger'];
+    $initials = function (?string $name): string {
+        $parts = collect(explode(' ', trim((string) $name)))
+            ->filter()
+            ->take(2)
+            ->map(fn ($part) => mb_substr($part, 0, 1));
+
+        return strtoupper($parts->implode('') ?: 'A');
+    };
+@endphp
+
+<div class="admin-accounts-page">
+    <div class="admin-accounts-hero">
+        <div class="max-w-2xl">
+            <p class="admin-accounts-eyebrow">Super Admin</p>
+            <h2 class="admin-accounts-title">Account Management</h2>
+            <p class="admin-accounts-description">
+                Kelola akses admin, role, status akun, dan password sementara.
+            </p>
+        </div>
+        <div class="admin-accounts-hero__actions">
+            <span class="admin-accounts-access-badge">
+                <span></span>
+                Akses terbatas
+            </span>
+            <button type="button" wire:click="openCreateModal" class="admin-accounts-primary-button">
+                <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M12 4v16m8-8H4"/>
+                </svg>
+                Tambah Akun
+            </button>
         </div>
     </div>
 
+    <div class="admin-accounts-kpi-grid">
+        @foreach ($accountCards as $card)
+            <article class="admin-accounts-kpi-card admin-accounts-kpi-card--{{ $card['tone'] }}">
+                <div class="admin-accounts-kpi-card__header">
+                    <span class="admin-accounts-kpi-card__icon" aria-hidden="true">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="{{ $card['icon'] }}"/>
+                        </svg>
+                    </span>
+                    <p class="admin-accounts-kpi-card__label">{{ $card['label'] }}</p>
+                </div>
+                <div class="admin-accounts-kpi-card__body">
+                    <strong>{{ $formatInt($card['value']) }}</strong>
+                    <p class="admin-accounts-kpi-card__description">{{ $card['description'] }}</p>
+                </div>
+            </article>
+        @endforeach
+    </div>
+
     @if ($flashMessage)
-        <div class="mb-4 rounded-lg border border-emerald-200 bg-emerald-50/80 p-3 text-sm text-emerald-800 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-200">
-            <div class="flex items-start justify-between gap-3">
-                <span>{{ $flashMessage }}</span>
-                <button type="button" wire:click="clearFlash" class="text-emerald-700/80 hover:text-emerald-900 dark:text-emerald-200/80 dark:hover:text-emerald-100">
-                    <span class="sr-only">Tutup</span>
-                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M6 18L18 6M6 6l12 12"/></svg>
-                </button>
-            </div>
+        <div class="admin-accounts-alert admin-accounts-alert--success">
+            <span>{{ $flashMessage }}</span>
+            <button type="button" wire:click="clearFlash" aria-label="Tutup pesan">
+                <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M6 6l12 12M18 6L6 18"/>
+                </svg>
+            </button>
         </div>
     @endif
 
     @if ($flashError)
-        <div class="mb-4 rounded-lg border border-rose-200 bg-rose-50/80 p-3 text-sm text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-200">
-            <div class="flex items-start justify-between gap-3">
-                <span>{{ $flashError }}</span>
-                <button type="button" wire:click="clearFlash" class="text-rose-600 hover:text-rose-800 dark:text-rose-200/80 dark:hover:text-rose-100">
-                    <span class="sr-only">Tutup</span>
-                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M6 18L18 6M6 6l12 12"/></svg>
-                </button>
-            </div>
+        <div class="admin-accounts-alert admin-accounts-alert--danger">
+            <span>{{ $flashError }}</span>
+            <button type="button" wire:click="clearFlash" aria-label="Tutup pesan">
+                <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M6 6l12 12M18 6L6 18"/>
+                </svg>
+            </button>
         </div>
     @endif
 
     @if ($generatedTemporaryPassword)
-        <div class="mb-4 rounded-lg border border-amber-200 bg-amber-50/80 p-4 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-200">
-            <div class="flex items-start justify-between gap-3">
-                <div class="min-w-0">
-                    <p class="font-semibold">Password sementara berhasil dibuat</p>
-                    <p class="mt-1 text-xs">Salin password berikut sekarang. Sistem tidak akan menampilkannya kembali.</p>
-                    <code class="mt-2 inline-block rounded bg-white/80 px-3 py-1.5 font-mono text-sm tracking-widest text-stone-900 dark:bg-gray-900 dark:text-amber-200">
-                        {{ $generatedTemporaryPassword }}
-                    </code>
-                </div>
-                <button type="button" wire:click="dismissTemporaryPassword" class="text-amber-800/80 hover:text-amber-900 dark:text-amber-200/80 dark:hover:text-amber-100">
-                    <span class="sr-only">Tutup</span>
-                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M6 18L18 6M6 6l12 12"/></svg>
-                </button>
+        <div class="admin-accounts-temp-password">
+            <div class="min-w-0">
+                <p>Password sementara berhasil dibuat</p>
+                <span>Simpan password ini sekarang. Sistem tidak akan menampilkannya kembali.</span>
+                <code>{{ $generatedTemporaryPassword }}</code>
             </div>
+            <button type="button" wire:click="dismissTemporaryPassword" aria-label="Tutup password sementara">
+                <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M6 6l12 12M18 6L6 18"/>
+                </svg>
+            </button>
         </div>
     @endif
 
-    <x-admin.section
-        title="Daftar Akun Admin"
-        description="Akun admin dan super admin yang terdaftar dalam sistem.">
-        <x-slot name="actions">
-            <div class="flex flex-wrap items-center gap-2">
-                <label class="admin-filter">
-                    <span class="admin-filter__label">Cari</span>
-                    <input type="text"
-                           wire:model.live.debounce.300ms="search"
-                           placeholder="Nama atau email"
-                           class="admin-filter__control">
-                </label>
-                <label class="admin-filter">
-                    <span class="admin-filter__label">Role</span>
-                    <select wire:model.live="roleFilter" class="admin-filter__control">
-                        <option value="all">Semua</option>
-                        <option value="admin">Admin</option>
-                        <option value="super_admin">Super Admin</option>
-                    </select>
-                </label>
-                <label class="admin-filter">
-                    <span class="admin-filter__label">Status</span>
-                    <select wire:model.live="statusFilter" class="admin-filter__control">
-                        <option value="all">Semua</option>
-                        <option value="active">Aktif</option>
-                        <option value="inactive">Nonaktif</option>
-                    </select>
-                </label>
-            </div>
-        </x-slot>
+    <section class="admin-accounts-filter-panel admin-section">
+        <div class="admin-accounts-filter-panel__header">
+            <h3>Filter</h3>
+            <button type="button" wire:click="resetFilters" class="admin-accounts-reset-button">
+                <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M4 4v6h6M20 20v-6h-6M5.5 14a7 7 0 0012 3M18.5 10a7 7 0 00-12-3"/>
+                </svg>
+                Reset
+            </button>
+        </div>
 
-        <x-admin.table :columns="[
-            ['key' => 'name', 'label' => 'Akun'],
-            ['key' => 'role', 'label' => 'Role'],
-            ['key' => 'status', 'label' => 'Status'],
-            ['key' => 'last_login', 'label' => 'Login Terakhir', 'align' => 'right'],
-            ['key' => 'actions', 'label' => 'Aksi', 'align' => 'right'],
-        ]">
-            @forelse ($accounts as $account)
-                <tr>
-                    <td class="admin-table__td">
-                        <div class="flex flex-col">
-                            <span class="text-sm font-semibold text-stone-700 dark:text-gray-200">{{ $account->name }}</span>
-                            <span class="text-[11px] text-stone-400 dark:text-gray-500">{{ $account->email }}</span>
-                            @if ($account->force_password_change)
-                                <span class="mt-1 inline-flex w-fit items-center gap-1 rounded-md bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
-                                    Wajib ganti password
+        <div class="admin-accounts-filter-grid">
+            <label class="admin-accounts-filter">
+                <span>Cari</span>
+                <input type="search"
+                       wire:model.live.debounce.300ms="search"
+                       placeholder="Nama atau email"
+                       class="admin-accounts-control" />
+            </label>
+
+            <label class="admin-accounts-filter">
+                <span>Role</span>
+                <select wire:model.live="roleFilter" class="admin-accounts-control">
+                    @foreach ($roleOptions as $key => $label)
+                        <option value="{{ $key }}">{{ $label }}</option>
+                    @endforeach
+                </select>
+            </label>
+
+            <label class="admin-accounts-filter">
+                <span>Status</span>
+                <select wire:model.live="statusFilter" class="admin-accounts-control">
+                    @foreach ($statusOptions as $key => $label)
+                        <option value="{{ $key }}">{{ $label }}</option>
+                    @endforeach
+                </select>
+            </label>
+        </div>
+    </section>
+
+    <div class="admin-accounts-content-grid">
+        <section class="admin-accounts-table-panel admin-section">
+            <header class="admin-accounts-table-panel__header">
+                <div>
+                    <h3>Daftar Akun Admin</h3>
+                    <p>Menampilkan {{ $accountsPerPage }} akun per halaman pada filter aktif.</p>
+                </div>
+            </header>
+
+            <div class="admin-accounts-table-panel__body">
+                <x-admin.table
+                    class="admin-accounts-table"
+                    :columns="[
+                        ['key' => 'account', 'label' => 'Akun', 'width' => '29%'],
+                        ['key' => 'role', 'label' => 'Role', 'width' => '13%'],
+                        ['key' => 'status', 'label' => 'Status', 'width' => '13%'],
+                        ['key' => 'last_login', 'label' => 'Login Terakhir', 'width' => '18%'],
+                        ['key' => 'actions', 'label' => 'Aksi', 'align' => 'center', 'width' => '27%'],
+                    ]">
+                    @forelse ($accounts as $account)
+                        @php
+                            $accountStatus = $statusMeta($account);
+                        @endphp
+                        <tr>
+                            <td class="admin-table__td">
+                                <div class="admin-users-user-cell">
+                                    <span class="admin-user-avatar" aria-hidden="true">{{ $initials($account->name) }}</span>
+                                    <div class="min-w-0">
+                                        <span class="admin-users-user-cell__name">{{ $account->name }}</span>
+                                        <span class="admin-users-user-cell__email">{{ $account->email }}</span>
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="admin-table__td">
+                                <x-admin.badge :tone="$roleTone($account->role)">
+                                    {{ $roleLabel($account->role) }}
+                                </x-admin.badge>
+                            </td>
+                            <td class="admin-table__td">
+                                <x-admin.badge :tone="$accountStatus['tone']" class="admin-users-status-badge">
+                                    <span @class([
+                                        'admin-users-status-dot',
+                                        'admin-users-status-dot--online' => $account->is_active,
+                                        'admin-users-status-dot--offline' => ! $account->is_active,
+                                    ])></span>
+                                    {{ $accountStatus['label'] }}
+                                </x-admin.badge>
+                            </td>
+                            <td class="admin-table__td">
+                                <span class="admin-accounts-muted" title="{{ $account->last_admin_login_at?->toDateTimeString() ?? '-' }}">
+                                    {{ $account->last_admin_login_at?->diffForHumans() ?? '-' }}
                                 </span>
-                            @endif
-                        </div>
-                    </td>
-                    <td class="admin-table__td">
-                        <x-admin.badge :tone="$account->role === 'super_admin' ? 'gold' : 'primary'">
-                            {{ $account->role === 'super_admin' ? 'Super Admin' : 'Admin' }}
-                        </x-admin.badge>
-                    </td>
-                    <td class="admin-table__td">
-                        @if ($account->is_active)
-                            <x-admin.badge tone="success">Aktif</x-admin.badge>
-                        @else
-                            <x-admin.badge tone="danger">Nonaktif</x-admin.badge>
-                        @endif
-                    </td>
-                    <td class="admin-table__td" data-align="right">
-                        <span class="text-xs text-stone-500 dark:text-gray-400" title="{{ $account->last_admin_login_at?->toDateTimeString() ?? '—' }}">
-                            {{ $account->last_admin_login_at?->diffForHumans() ?? '—' }}
-                        </span>
-                    </td>
-                    <td class="admin-table__td" data-align="right">
-                        <div class="flex flex-wrap items-center justify-end gap-1.5">
-                            <button type="button"
-                                    wire:click="startEdit({{ $account->id }})"
-                                    class="inline-flex h-8 items-center gap-1 rounded-md border border-stone-200 bg-white px-2 text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-ista-primary/40 dark:hover:text-amber-300">
-                                Edit
-                            </button>
+                            </td>
+                            <td class="admin-table__td" data-align="right">
+                                <div class="admin-accounts-action-group">
+                                    <button type="button"
+                                            wire:click="startEdit({{ $account->id }})"
+                                            class="admin-accounts-action-button">
+                                        Edit
+                                    </button>
 
-                            @if ($account->is_active)
-                                <button type="button"
-                                        wire:click="startDeactivate({{ $account->id }})"
-                                        class="inline-flex h-8 items-center gap-1 rounded-md border border-rose-200 bg-rose-50 px-2 text-[11px] font-semibold uppercase tracking-wider text-rose-700 transition hover:bg-rose-100 dark:border-rose-900/40 dark:bg-rose-950/40 dark:text-rose-200">
-                                    Nonaktifkan
-                                </button>
-                            @else
-                                <button type="button"
-                                        wire:click="activate({{ $account->id }})"
-                                        class="inline-flex h-8 items-center gap-1 rounded-md border border-emerald-200 bg-emerald-50 px-2 text-[11px] font-semibold uppercase tracking-wider text-emerald-700 transition hover:bg-emerald-100 dark:border-emerald-900/40 dark:bg-emerald-950/40 dark:text-emerald-200">
-                                    Aktifkan
-                                </button>
-                            @endif
+                                    @if ($account->is_active)
+                                        <button type="button"
+                                                wire:click="startDeactivate({{ $account->id }})"
+                                                class="admin-accounts-toggle admin-accounts-toggle--active"
+                                                aria-label="Nonaktifkan {{ $account->email }}"
+                                                aria-pressed="true">
+                                            <span aria-hidden="true"></span>
+                                        </button>
+                                    @else
+                                        <button type="button"
+                                                wire:click="activate({{ $account->id }})"
+                                                class="admin-accounts-toggle"
+                                                aria-label="Aktifkan {{ $account->email }}"
+                                                aria-pressed="false">
+                                            <span aria-hidden="true"></span>
+                                        </button>
+                                    @endif
 
-                            <button type="button"
-                                    wire:click="startResetPassword({{ $account->id }})"
-                                    wire:confirm="Reset password admin {{ $account->email }}? Password lama tidak dapat dipakai lagi."
-                                    class="inline-flex h-8 items-center gap-1 rounded-md border border-stone-200 bg-white px-2 text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-ista-primary/40 dark:hover:text-amber-300">
-                                Reset Password
-                            </button>
-                        </div>
-                    </td>
-                </tr>
-            @empty
-                <tr>
-                    <td colspan="5" class="admin-table__empty">
-                        <x-admin.empty-state
-                            title="Belum ada akun admin"
-                            description="Tambahkan akun admin atau super admin baru untuk mulai mengelola sistem." />
-                    </td>
-                </tr>
-            @endforelse
-        </x-admin.table>
+                                    <button type="button"
+                                            wire:click="startResetPassword({{ $account->id }})"
+                                            wire:confirm="Reset password admin {{ $account->email }}? Password lama tidak dapat dipakai lagi."
+                                            class="admin-accounts-reset-password-button">
+                                        Reset Password
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="5" class="admin-table__empty">
+                                <x-admin.empty-state
+                                    title="Belum ada akun admin"
+                                    description="Tambahkan akun admin atau super admin baru untuk mulai mengelola sistem." />
+                            </td>
+                        </tr>
+                    @endforelse
+                </x-admin.table>
 
-        @if ($accounts->hasPages())
-            <div class="mt-4">
-                {{ $accounts->links() }}
+                @if ($accounts->hasPages())
+                    <div class="admin-accounts-pagination">
+                        {{ $accounts->links() }}
+                    </div>
+                @endif
             </div>
-        @endif
-    </x-admin.section>
+        </section>
 
-    {{-- Edit drawer --}}
+    </div>
+
     @if ($editingUserId)
-        @php
-            $editingUser = \App\Models\User::query()->find($editingUserId);
-        @endphp
-        <div class="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/40 p-4 backdrop-blur-sm dark:bg-black/60" role="dialog" aria-modal="true">
-            <div class="w-full max-w-md rounded-2xl border border-stone-200 bg-white p-6 shadow-xl dark:border-gray-800 dark:bg-gray-900">
-                <h3 class="text-base font-semibold text-stone-900 dark:text-gray-100">Edit Akun Admin</h3>
-                <p class="mt-1 text-xs text-stone-500 dark:text-gray-400">{{ $editingUser?->email }}</p>
+        <div class="admin-accounts-modal" role="dialog" aria-modal="true" aria-labelledby="admin-edit-account-title">
+            <button type="button" class="admin-accounts-modal__backdrop" wire:click="cancelEdit" aria-label="Tutup edit akun"></button>
+            <section class="admin-accounts-modal__panel">
+                <header class="admin-accounts-modal__header">
+                    <div>
+                        <p class="admin-accounts-modal__eyebrow">Account Update</p>
+                        <h3 id="admin-edit-account-title">Edit Akun Admin</h3>
+                        <span>{{ $editingUser?->email }}</span>
+                    </div>
+                    <button type="button" wire:click="cancelEdit" class="admin-accounts-modal__close" aria-label="Tutup edit akun">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M6 6l12 12M18 6L6 18"/>
+                        </svg>
+                    </button>
+                </header>
 
-                <div class="mt-4 space-y-3">
-                    <div>
-                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Nama</label>
-                        <input type="text" wire:model.defer="editName" class="mt-1 admin-filter__control w-full">
-                        @error('editName') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
-                    </div>
-                    <div>
-                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Email</label>
-                        <input type="email" wire:model.defer="editEmail" class="mt-1 admin-filter__control w-full">
-                        @error('editEmail') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
-                    </div>
-                    <div>
-                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Role</label>
-                        <select wire:model.defer="editRole" class="mt-1 admin-filter__control w-full">
+                <div class="admin-accounts-modal__body">
+                    <label class="admin-accounts-modal__field">
+                        <span>Nama</span>
+                        <input type="text" wire:model.defer="editName" class="admin-accounts-control">
+                        @error('editName') <em>{{ $message }}</em> @enderror
+                    </label>
+                    <label class="admin-accounts-modal__field">
+                        <span>Email</span>
+                        <input type="email" wire:model.defer="editEmail" class="admin-accounts-control">
+                        @error('editEmail') <em>{{ $message }}</em> @enderror
+                    </label>
+                    <label class="admin-accounts-modal__field">
+                        <span>Role</span>
+                        <select wire:model.defer="editRole" class="admin-accounts-control">
                             <option value="admin">Admin</option>
                             <option value="super_admin">Super Admin</option>
                         </select>
-                        @error('editRole') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
-                    </div>
-                    <label class="flex items-center gap-2 text-xs text-stone-600 dark:text-gray-300">
-                        <input type="checkbox" wire:model.defer="editForcePasswordChange" class="h-4 w-4 rounded border-stone-300 text-ista-primary focus:ring-ista-primary/20 dark:border-gray-700">
-                        Wajib ganti password saat login berikutnya
+                        @error('editRole') <em>{{ $message }}</em> @enderror
+                    </label>
+                    <label class="admin-accounts-checkbox">
+                        <input type="checkbox" wire:model.defer="editForcePasswordChange">
+                        <span>Wajib ganti password saat login berikutnya</span>
                     </label>
                 </div>
 
-                <div class="mt-5 flex items-center justify-end gap-2">
-                    <button type="button" wire:click="cancelEdit" class="inline-flex h-9 items-center gap-1 rounded-md border border-stone-200 bg-white px-3 text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
-                        Batal
-                    </button>
-                    <button type="button" wire:click="saveEdit" class="inline-flex h-9 items-center gap-1 rounded-md bg-ista-primary px-3 text-[11px] font-semibold uppercase tracking-wider text-amber-300 transition hover:bg-stone-800">
-                        Simpan Perubahan
-                    </button>
-                </div>
-            </div>
+                <footer class="admin-accounts-modal__footer">
+                    <button type="button" wire:click="cancelEdit" class="admin-accounts-secondary-button">Batal</button>
+                    <button type="button" wire:click="saveEdit" class="admin-accounts-primary-button">Simpan Perubahan</button>
+                </footer>
+            </section>
         </div>
     @endif
 
-    {{-- Deactivate confirmation --}}
     @if ($deactivatingUserId)
-        <div class="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/40 p-4 backdrop-blur-sm dark:bg-black/60" role="dialog" aria-modal="true">
-            <div class="w-full max-w-md rounded-2xl border border-stone-200 bg-white p-6 shadow-xl dark:border-gray-800 dark:bg-gray-900">
-                <h3 class="text-base font-semibold text-stone-900 dark:text-gray-100">Konfirmasi Nonaktifkan Akun</h3>
-                <p class="mt-1 text-xs leading-relaxed text-stone-500 dark:text-gray-400">
-                    Akun yang dinonaktifkan tidak dapat login ke admin meskipun masih memiliki sesi aktif.
-                </p>
-
-                <div class="mt-3">
-                    <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Alasan (opsional)</label>
-                    <textarea wire:model.defer="deactivateReason" rows="2" class="mt-1 admin-filter__control w-full" placeholder="Misal: rotasi tugas, mutasi"></textarea>
-                </div>
-
-                <div class="mt-5 flex items-center justify-end gap-2">
-                    <button type="button" wire:click="cancelDeactivate" class="inline-flex h-9 items-center gap-1 rounded-md border border-stone-200 bg-white px-3 text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
-                        Batal
+        <div class="admin-accounts-modal" role="dialog" aria-modal="true" aria-labelledby="admin-deactivate-account-title">
+            <button type="button" class="admin-accounts-modal__backdrop" wire:click="cancelDeactivate" aria-label="Tutup nonaktifkan akun"></button>
+            <section class="admin-accounts-modal__panel">
+                <header class="admin-accounts-modal__header">
+                    <div>
+                        <p class="admin-accounts-modal__eyebrow">Access Control</p>
+                        <h3 id="admin-deactivate-account-title">Konfirmasi Nonaktifkan Akun</h3>
+                        <span>Akun nonaktif tidak dapat login admin.</span>
+                    </div>
+                    <button type="button" wire:click="cancelDeactivate" class="admin-accounts-modal__close" aria-label="Tutup nonaktifkan akun">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M6 6l12 12M18 6L6 18"/>
+                        </svg>
                     </button>
-                    <button type="button" wire:click="confirmDeactivate" class="inline-flex h-9 items-center gap-1 rounded-md bg-rose-600 px-3 text-[11px] font-semibold uppercase tracking-wider text-white transition hover:bg-rose-700">
-                        Nonaktifkan
-                    </button>
-                </div>
-            </div>
-        </div>
-    @endif
+                </header>
 
-    {{-- Create modal --}}
-    @if ($showCreateModal)
-        <div class="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/40 p-4 backdrop-blur-sm dark:bg-black/60" role="dialog" aria-modal="true">
-            <div class="w-full max-w-md rounded-2xl border border-stone-200 bg-white p-6 shadow-xl dark:border-gray-800 dark:bg-gray-900">
-                <h3 class="text-base font-semibold text-stone-900 dark:text-gray-100">Tambah Akun Admin</h3>
-                <p class="mt-1 text-xs text-stone-500 dark:text-gray-400">Buat akun admin atau super admin baru. Akun otomatis diverifikasi.</p>
-
-                <div class="mt-4 space-y-3">
-                    <div>
-                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Nama</label>
-                        <input type="text" wire:model.defer="newName" class="mt-1 admin-filter__control w-full">
-                        @error('newName') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
-                    </div>
-                    <div>
-                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Email</label>
-                        <input type="email" wire:model.defer="newEmail" class="mt-1 admin-filter__control w-full" placeholder="email@instansi.go.id">
-                        @error('newEmail') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
-                    </div>
-                    <div>
-                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Password Sementara</label>
-                        <div class="mt-1 flex gap-2">
-                            <input type="text" wire:model.defer="newPassword" class="admin-filter__control w-full font-mono">
-                            <button type="button" wire:click="generateNewPassword" class="inline-flex h-10 items-center rounded-md border border-stone-200 bg-white px-3 text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
-                                Generate
-                            </button>
-                        </div>
-                        @error('newPassword') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
-                    </div>
-                    <div>
-                        <label class="block text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Role</label>
-                        <select wire:model.defer="newRole" class="mt-1 admin-filter__control w-full">
-                            <option value="admin">Admin</option>
-                            <option value="super_admin">Super Admin</option>
-                        </select>
-                        @error('newRole') <p class="mt-1 text-[11px] text-rose-600 dark:text-rose-300">{{ $message }}</p> @enderror
-                    </div>
-                    <label class="flex items-center gap-2 text-xs text-stone-600 dark:text-gray-300">
-                        <input type="checkbox" wire:model.defer="newForcePasswordChange" class="h-4 w-4 rounded border-stone-300 text-ista-primary focus:ring-ista-primary/20 dark:border-gray-700">
-                        Wajibkan ganti password setelah login pertama
+                <div class="admin-accounts-modal__body">
+                    <label class="admin-accounts-modal__field">
+                        <span>Alasan</span>
+                        <textarea wire:model.defer="deactivateReason" rows="3" class="admin-accounts-control" placeholder="Opsional"></textarea>
                     </label>
                 </div>
 
-                <div class="mt-5 flex items-center justify-end gap-2">
-                    <button type="button" wire:click="closeCreateModal" class="inline-flex h-9 items-center gap-1 rounded-md border border-stone-200 bg-white px-3 text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
-                        Batal
+                <footer class="admin-accounts-modal__footer">
+                    <button type="button" wire:click="cancelDeactivate" class="admin-accounts-secondary-button">Batal</button>
+                    <button type="button" wire:click="confirmDeactivate" class="admin-accounts-danger-button">Nonaktifkan</button>
+                </footer>
+            </section>
+        </div>
+    @endif
+
+    @if ($showCreateModal)
+        <div class="admin-accounts-modal" role="dialog" aria-modal="true" aria-labelledby="admin-create-account-title">
+            <button type="button" class="admin-accounts-modal__backdrop" wire:click="closeCreateModal" aria-label="Tutup tambah akun"></button>
+            <section class="admin-accounts-modal__panel">
+                <header class="admin-accounts-modal__header">
+                    <div>
+                        <p class="admin-accounts-modal__eyebrow">New Admin</p>
+                        <h3 id="admin-create-account-title">Tambah Akun Admin</h3>
+                        <span>Akun baru otomatis diverifikasi.</span>
+                    </div>
+                    <button type="button" wire:click="closeCreateModal" class="admin-accounts-modal__close" aria-label="Tutup tambah akun">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M6 6l12 12M18 6L6 18"/>
+                        </svg>
                     </button>
-                    <button type="button" wire:click="createAccount" class="inline-flex h-9 items-center gap-1 rounded-md bg-ista-primary px-3 text-[11px] font-semibold uppercase tracking-wider text-amber-300 transition hover:bg-stone-800">
-                        Buat Akun
-                    </button>
+                </header>
+
+                <div class="admin-accounts-modal__body">
+                    <label class="admin-accounts-modal__field">
+                        <span>Nama</span>
+                        <input type="text" wire:model.defer="newName" class="admin-accounts-control">
+                        @error('newName') <em>{{ $message }}</em> @enderror
+                    </label>
+                    <label class="admin-accounts-modal__field">
+                        <span>Email</span>
+                        <input type="email" wire:model.defer="newEmail" class="admin-accounts-control" placeholder="email@instansi.go.id">
+                        @error('newEmail') <em>{{ $message }}</em> @enderror
+                    </label>
+                    <label class="admin-accounts-modal__field">
+                        <span>Password Sementara</span>
+                        <div class="admin-accounts-password-row">
+                            <input type="text" wire:model.defer="newPassword" class="admin-accounts-control font-mono">
+                            <button type="button" wire:click="generateNewPassword" class="admin-accounts-secondary-button">Generate</button>
+                        </div>
+                        @error('newPassword') <em>{{ $message }}</em> @enderror
+                    </label>
+                    <label class="admin-accounts-modal__field">
+                        <span>Role</span>
+                        <select wire:model.defer="newRole" class="admin-accounts-control">
+                            <option value="admin">Admin</option>
+                            <option value="super_admin">Super Admin</option>
+                        </select>
+                        @error('newRole') <em>{{ $message }}</em> @enderror
+                    </label>
+                    <label class="admin-accounts-checkbox">
+                        <input type="checkbox" wire:model.defer="newForcePasswordChange">
+                        <span>Wajibkan ganti password setelah login pertama</span>
+                    </label>
                 </div>
-            </div>
+
+                <footer class="admin-accounts-modal__footer">
+                    <button type="button" wire:click="closeCreateModal" class="admin-accounts-secondary-button">Batal</button>
+                    <button type="button" wire:click="createAccount" class="admin-accounts-primary-button">Buat Akun</button>
+                </footer>
+            </section>
         </div>
     @endif
 </div>

--- a/laravel/resources/views/livewire/admin/admin-dashboard.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-dashboard.blade.php
@@ -1,32 +1,132 @@
-<div>
-    <div class="mb-6">
-        <div class="flex flex-wrap items-end justify-between gap-3">
-            <div class="max-w-2xl">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Selamat datang</p>
-                <h2 class="admin-page-title mt-1">Ringkasan Operasional</h2>
-                <p class="mt-2 text-sm leading-relaxed text-stone-500 dark:text-gray-400">
-                    Pantau aktivitas user, performa AI, dan kesehatan platform dalam satu halaman. Data diambil dari event tracking ISTA AI dan metadata operasional, tanpa menampilkan isi prompt atau jawaban.
-                </p>
-            </div>
-            <div class="flex flex-wrap items-center gap-2">
-                <x-admin.badge tone="primary">
-                    <span class="h-1.5 w-1.5 rounded-full bg-ista-primary"></span>
-                    Live
-                </x-admin.badge>
-                <x-admin.badge tone="neutral">Read-only</x-admin.badge>
-                <button type="button"
-                        wire:click="refreshMetrics"
-                        wire:loading.attr="disabled"
-                        class="inline-flex h-8 items-center gap-1.5 rounded-lg border border-stone-200 bg-white px-3 text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary disabled:opacity-60 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-ista-primary/40 dark:hover:text-amber-300">
-                    <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 4v5h5M20 20v-5h-5M4.5 9A8 8 0 0119 12M19.5 15A8 8 0 015 12"/>
-                    </svg>
-                    Refresh
-                </button>
-            </div>
-        </div>
-    </div>
+@php
+    $formatInt = fn ($value): string => number_format((float) $value, 0, ',', '.');
+    $formatPct = fn ($value): string => number_format((float) $value, 1, ',', '.') . '%';
+    $formatSeconds = fn ($milliseconds): string => number_format(((float) $milliseconds) / 1000, 2, ',', '.') . 's';
+    $trendClass = function (?array $trend): string {
+        return match ($trend['tone'] ?? 'neutral') {
+            'success' => 'text-emerald-600 dark:text-emerald-400',
+            'danger' => 'text-rose-600 dark:text-rose-400',
+            default => 'text-stone-500 dark:text-gray-400',
+        };
+    };
+    $trendLabel = function (?array $trend, string $basis) use ($formatPct, $formatSeconds): ?string {
+        if (empty($trend) || ! ($trend['has_comparison'] ?? false)) {
+            return null;
+        }
 
+        if (($trend['direction'] ?? 'none') === 'flat') {
+            return 'Tidak berubah dari ' . $basis;
+        }
+
+        $icon = ($trend['direction'] ?? 'none') === 'up' ? 'Naik' : 'Turun';
+        $delta = abs((float) ($trend['delta'] ?? 0));
+        $unit = $trend['unit'] ?? 'percent';
+
+        $value = match ($unit) {
+            'percentage_points' => number_format($delta, 1, ',', '.') . ' poin',
+            'milliseconds' => $formatSeconds($delta),
+            default => $formatPct(abs((float) ($trend['delta_percent'] ?? 0))),
+        };
+
+        return $icon . ' ' . $value . ' dari ' . $basis;
+    };
+
+    $requestsToday = (int) ($kpis['ai_requests_today'] ?? 0);
+    $successToday = (int) ($kpis['ai_success_today'] ?? 0);
+    $failedToday = (int) ($kpis['ai_failed_today'] ?? 0);
+    $successRate = $requestsToday > 0 ? ($successToday / $requestsToday) * 100 : 0;
+    $errorRate = $requestsToday > 0 ? ($failedToday / $requestsToday) * 100 : 0;
+    $avgLatencyMs = $kpis['avg_latency_ms_today'] ?? null;
+    $avgLatencyLabel = $avgLatencyMs !== null ? $formatSeconds($avgLatencyMs) : '-';
+    $onlineUsers = (int) ($kpis['online_users'] ?? 0);
+    $activeUsersToday = (int) ($kpis['active_users_today'] ?? 0);
+    $totalErrorsRange = (int) collect($series)->sum('failed');
+    $seriesTotal = (int) collect($series)->sum('total');
+    $chartMax = max(1, (int) ($maxSeriesValue ?? 1));
+    $seriesCount = count($series);
+    $chartPoints = [];
+
+    foreach ($series as $index => $point) {
+        $x = $seriesCount > 1 ? 42 + (($index / ($seriesCount - 1)) * 556) : 320;
+        $y = 180 - (((int) $point['total'] / $chartMax) * 126);
+        $chartPoints[] = [
+            'x' => round($x, 1),
+            'y' => round($y, 1),
+            'total' => (int) $point['total'],
+            'date' => $point['date'],
+            'label' => \Illuminate\Support\Carbon::parse($point['date'])->locale('id')->translatedFormat('j M'),
+        ];
+    }
+
+    $linePath = collect($chartPoints)
+        ->map(fn ($point, $index) => ($index === 0 ? 'M ' : 'L ') . $point['x'] . ' ' . $point['y'])
+        ->implode(' ');
+    $firstPoint = $chartPoints[0] ?? null;
+    $lastPoint = $chartPoints[count($chartPoints) - 1] ?? null;
+    $areaPath = $firstPoint && $lastPoint
+        ? $linePath . ' L ' . $lastPoint['x'] . ' 180 L ' . $firstPoint['x'] . ' 180 Z'
+        : '';
+    $avgSeries = $seriesCount > 0 ? round($seriesTotal / $seriesCount) : 0;
+
+    $requestTrend = $comparisons['ai_requests'] ?? null;
+    $successRateTrend = $comparisons['success_rate'] ?? null;
+    $errorRateTrend = $comparisons['error_rate'] ?? null;
+    $errorsSevenDayTrend = $comparisons['errors_7d'] ?? null;
+    $errorRateSevenDayTrend = $comparisons['error_rate_7d'] ?? null;
+    $totalErrorsRange = (int) ($errorsSevenDayTrend['current'] ?? $totalErrorsRange);
+    $errorRateSevenDay = (float) ($errorRateSevenDayTrend['current'] ?? $errorRate);
+
+    $requestTrendText = $trendLabel($requestTrend, 'kemarin');
+    $successRateTrendText = $trendLabel($successRateTrend, 'kemarin');
+    $errorRateTrendText = $trendLabel($errorRateTrend, 'kemarin');
+    $errorsSevenDayTrendText = $trendLabel($errorsSevenDayTrend, '7 hari lalu');
+    $errorRateSevenDayTrendText = $trendLabel($errorRateSevenDayTrend, '7 hari lalu');
+
+    $overviewCards = [
+        [
+            'title' => 'Users',
+            'value' => $formatInt($kpis['total_users'] ?? 0),
+            'label' => 'Total user',
+            'meta' => $formatInt($onlineUsers) . ' online',
+            'support' => $formatInt($activeUsersToday) . ' aktif hari ini',
+            'tone' => 'primary',
+            'route' => route('admin.users'),
+            'icon' => 'M15.75 7.5a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.5 20.25a7.5 7.5 0 0115 0',
+        ],
+        [
+            'title' => 'AI Usage',
+            'value' => $formatInt($requestsToday),
+            'label' => 'Request hari ini',
+            'meta' => $formatPct($successRate) . ' sukses',
+            'support' => 'Latensi ' . $avgLatencyLabel,
+            'tone' => 'gold',
+            'route' => route('admin.usage'),
+            'icon' => 'M12 3l1.65 4.7L18 9.5l-4.35 1.8L12 16l-1.65-4.7L6 9.5l4.35-1.8L12 3zM19 15l.8 2.2L22 18l-2.2.8L19 21l-.8-2.2L16 18l2.2-.8L19 15z',
+        ],
+        [
+            'title' => 'Documents',
+            'value' => $formatInt($kpis['documents_ready'] ?? 0),
+            'label' => 'Dokumen ready',
+            'meta' => $formatInt($kpis['documents_processing'] ?? 0) . ' processing',
+            'support' => $formatInt($kpis['documents_failed'] ?? 0) . ' failed',
+            'tone' => 'success',
+            'route' => route('admin.documents'),
+            'icon' => 'M8 3.75h6.25L19 8.5v11.75H8A3 3 0 015 17.25V6.75a3 3 0 013-3zM14 3.75V8.5H19M9 13h6M9 16h5',
+        ],
+        [
+            'title' => 'Percakapan & Memo',
+            'value' => $formatInt($kpis['conversations_today'] ?? 0),
+            'label' => 'Percakapan baru',
+            'meta' => $formatInt($kpis['memos_today'] ?? 0) . ' memo hari ini',
+            'support' => $formatInt($kpis['memos_week'] ?? 0) . ' memo / 7 hari',
+            'tone' => 'warning',
+            'route' => route('admin.usage'),
+            'icon' => 'M4.5 6.75A3.75 3.75 0 018.25 3h7.5a3.75 3.75 0 013.75 3.75v5A3.75 3.75 0 0115.75 15H11l-4.5 4.5V15A3.75 3.75 0 014.5 11.25v-4.5z',
+        ],
+    ];
+@endphp
+
+<div class="admin-overview">
     <div wire:loading.flex wire:target="setRange,refreshMetrics" class="mb-4 hidden">
         <x-admin.loading :rows="2" label="Memuat metrik dashboard" class="w-full" />
     </div>
@@ -38,230 +138,250 @@
         </select>
     </label>
 
-    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <x-admin.kpi-card
-            label="Total User"
-            :value="number_format($kpis['total_users'])"
-            tone="primary"
-            description="Jumlah akun terdaftar." />
+    <section class="admin-overview-hero admin-section">
+        <div class="relative z-10 min-w-0">
+            <div class="flex flex-wrap items-center gap-2">
+                <span class="admin-health-pulse" aria-hidden="true">
+                    <span></span>
+                </span>
+                <span class="text-xs font-bold uppercase text-amber-600 dark:text-amber-300">Sistem sehat</span>
+            </div>
+            <div class="mt-3 flex flex-wrap items-center gap-3">
+                <h2 class="admin-overview-title">Ringkasan Operasional</h2>
+                <x-admin.badge tone="success">Live</x-admin.badge>
+            </div>
+            <p class="mt-2 max-w-2xl text-sm leading-relaxed text-stone-600 dark:text-gray-400">
+                Platform berjalan normal. Detail analitik tersedia di tab khusus.
+            </p>
+            <button type="button"
+                    wire:click="refreshMetrics"
+                    wire:loading.attr="disabled"
+                    class="mt-4 inline-flex items-center gap-2 text-xs font-medium text-stone-500 transition hover:text-ista-primary disabled:opacity-60 dark:text-gray-400 dark:hover:text-amber-300">
+                Terakhir diperbarui:
+                {{ $lastUpdatedAt ? $lastUpdatedAt->diffForHumans() : 'Belum ada aktivitas' }}
+                <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 4v5h5M20 20v-5h-5M4.5 9A8 8 0 0119 12M19.5 15A8 8 0 015 12"/>
+                </svg>
+            </button>
+        </div>
 
-        <x-admin.kpi-card
-            label="User Online"
-            :value="number_format($kpis['online_users'])"
-            tone="success"
-            :description="'Aktif <= ' . \App\Services\Admin\AdminMetricsService::PRESENCE_ONLINE_MINUTES . ' menit terakhir.'" />
+        <div class="admin-hero-stats relative z-10">
+            <div class="admin-hero-stat">
+                <span>AI Request Hari Ini</span>
+                <strong>{{ $formatInt($requestsToday) }}</strong>
+                <em class="{{ $requestTrendText ? $trendClass($requestTrend) : 'text-stone-500 dark:text-gray-500' }}">
+                    {{ $requestTrendText ?? 'Hari ini' }}
+                </em>
+            </div>
+            <div class="admin-hero-stat">
+                <span>Success Rate</span>
+                <strong>{{ $formatPct($successRate) }}</strong>
+                <em class="{{ $successRateTrendText ? $trendClass($successRateTrend) : 'text-stone-500 dark:text-gray-500' }}">
+                    {{ $successRateTrendText ?? $formatInt($successToday) . ' sukses' }}
+                </em>
+            </div>
+            <div class="admin-hero-stat">
+                <span>Error Rate</span>
+                <strong>{{ $formatPct($errorRate) }}</strong>
+                <em class="{{ $errorRateTrendText ? $trendClass($errorRateTrend) : 'text-stone-500 dark:text-gray-500' }}">
+                    {{ $errorRateTrendText ?? $formatInt($failedToday) . ' gagal' }}
+                </em>
+            </div>
+        </div>
+    </section>
 
-        <x-admin.kpi-card
-            label="Aktif Hari Ini"
-            :value="number_format($kpis['active_users_today'])"
-            tone="gold"
-            description="User dengan event atau presence hari ini." />
-
-        <x-admin.kpi-card
-            label="Aktif Minggu Ini"
-            :value="number_format($kpis['active_users_week'])"
-            tone="default"
-            description="Aktivitas 7 hari terakhir." />
-    </div>
-
-    <div class="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <x-admin.kpi-card
-            label="Request AI Hari Ini"
-            :value="number_format($kpis['ai_requests_today'])"
-            tone="primary"
-            :description="'Sukses ' . number_format($kpis['ai_success_today']) . ' / Pending ' . number_format($kpis['ai_pending_today'])" />
-
-        <x-admin.kpi-card
-            label="Error AI Hari Ini"
-            :value="number_format($kpis['ai_failed_today'])"
-            tone="danger"
-            description="Status failed pada AI Usage Events." />
-
-        <x-admin.kpi-card
-            label="Latensi Rata-rata"
-            :value="$kpis['avg_latency_ms_today'] !== null ? number_format($kpis['avg_latency_ms_today']) . ' ms' : '—'"
-            tone="success"
-            description="Rata-rata event sukses hari ini." />
-
-        <x-admin.kpi-card
-            label="Pesan User Hari Ini"
-            :value="number_format($kpis['messages_today'])"
-            tone="gold"
-            :description="number_format($kpis['conversations_today']) . ' percakapan baru.'" />
-    </div>
-
-    <div class="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <x-admin.kpi-card
-            label="Dokumen Ready"
-            :value="number_format($kpis['documents_ready'])"
-            tone="success" />
-        <x-admin.kpi-card
-            label="Dokumen Processing"
-            :value="number_format($kpis['documents_processing'])"
-            tone="warning" />
-        <x-admin.kpi-card
-            label="Dokumen Gagal"
-            :value="number_format($kpis['documents_failed'])"
-            tone="danger" />
-        <x-admin.kpi-card
-            label="Memo (Hari/Minggu)"
-            :value="number_format($kpis['memos_today']) . ' / ' . number_format($kpis['memos_week'])"
-            tone="primary"
-            description="Memo dibuat hari ini / 7 hari terakhir." />
-    </div>
-
-    <div class="mt-6 grid gap-4 lg:grid-cols-3">
-        <div class="lg:col-span-2 space-y-4">
-            <x-admin.section
-                title="Aktivitas {{ $rangeDays }} Hari Terakhir"
-                description="Total event AI per hari berdasarkan AI Usage Events.">
-                <x-slot name="actions">
-                    <div class="inline-flex rounded-lg border border-stone-200 bg-white p-1 text-[11px] font-semibold uppercase tracking-wider dark:border-gray-800 dark:bg-gray-900">
-                        @foreach ([7, 14, 30] as $option)
-                            <button type="button"
-                                    wire:click="setRange({{ $option }})"
-                                    @class([
-                                        'rounded-md px-2.5 py-1 transition',
-                                        'bg-ista-primary text-white' => $rangeDays === $option,
-                                        'text-stone-500 hover:text-ista-primary dark:text-gray-400' => $rangeDays !== $option,
-                                    ])>
-                                {{ $option }}h
-                            </button>
-                        @endforeach
+    <div class="admin-summary-grid">
+        @foreach ($overviewCards as $card)
+            <a href="{{ $card['route'] }}" class="admin-summary-card admin-summary-card--{{ $card['tone'] }} admin-kpi admin-section">
+                <div class="admin-summary-card__top">
+                    <span class="admin-summary-card__icon" aria-hidden="true">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="{{ $card['icon'] }}"/>
+                        </svg>
+                    </span>
+                    <h3>{{ $card['title'] }}</h3>
+                </div>
+                <div class="admin-summary-card__body">
+                    <p>{{ $card['label'] }}</p>
+                    <strong>{{ $card['value'] }}</strong>
+                    <div>
+                        <em>{{ $card['meta'] }}</em>
+                        <em>{{ $card['support'] }}</em>
                     </div>
-                </x-slot>
+                </div>
+            </a>
+        @endforeach
+    </div>
 
-                @if (collect($series)->sum('total') === 0)
+    <div class="admin-overview-main-grid">
+        <section class="admin-section admin-panel">
+            <header class="admin-panel-header">
+                <h3>Tren Aktivitas AI ({{ $rangeDays }} Hari Terakhir)</h3>
+                <div class="admin-range-select">
+                    <select wire:change="setRange($event.target.value)" aria-label="Rentang aktivitas AI">
+                        @foreach ([7, 14, 30] as $option)
+                            <option value="{{ $option }}" @selected($rangeDays === $option)>{{ $option }} hari</option>
+                        @endforeach
+                    </select>
+                </div>
+            </header>
+
+            @if ($seriesTotal === 0)
+                <div class="p-5">
                     <x-admin.empty-state
                         title="Belum ada aktivitas"
                         description="Event akan muncul setelah user memakai fitur AI." />
-                @else
-                    <div class="flex h-48 items-end gap-1.5" role="img" aria-label="Grafik aktivitas event AI per hari">
-                        @foreach ($series as $point)
-                            @php
-                                $heightPct = $maxSeriesValue > 0 ? max(2, (int) round(($point['total'] / $maxSeriesValue) * 100)) : 0;
-                                $failedPct = $point['total'] > 0 ? (int) round(($point['failed'] / $point['total']) * $heightPct) : 0;
-                            @endphp
-                            <div class="group flex flex-1 flex-col items-center gap-1.5">
-                                <div class="relative flex w-full flex-col-reverse items-stretch overflow-hidden rounded-t-md bg-stone-100 dark:bg-gray-800" style="height: 100%">
-                                    <div class="w-full bg-ista-primary/80 transition-all" style="height: {{ $heightPct }}%" title="Total: {{ $point['total'] }} (failed: {{ $point['failed'] }})"></div>
-                                    @if ($failedPct > 0)
-                                        <div class="absolute bottom-0 left-0 w-full bg-rose-500/80" style="height: {{ $failedPct }}%"></div>
-                                    @endif
-                                </div>
-                                <span class="text-[9px] font-semibold uppercase tracking-wider text-stone-400 dark:text-gray-500">{{ \Illuminate\Support\Carbon::parse($point['date'])->format('d/m') }}</span>
-                            </div>
+                </div>
+            @else
+                <div class="admin-line-chart" role="img" aria-label="Grafik aktivitas event AI per hari">
+                    <svg viewBox="0 0 640 236" preserveAspectRatio="none">
+                        <defs>
+                            <linearGradient id="adminOverviewArea" x1="0" x2="0" y1="0" y2="1">
+                                <stop offset="0%" stop-color="#a4063a" stop-opacity="0.16" />
+                                <stop offset="100%" stop-color="#a4063a" stop-opacity="0" />
+                            </linearGradient>
+                        </defs>
+                        @foreach ([54, 96, 138, 180] as $gridY)
+                            <line x1="42" y1="{{ $gridY }}" x2="598" y2="{{ $gridY }}" class="admin-chart-grid" />
                         @endforeach
-                    </div>
-                    <div class="mt-3 flex items-center gap-3 text-[10.5px] font-semibold uppercase tracking-wider text-stone-400 dark:text-gray-500">
-                        <span class="inline-flex items-center gap-1.5"><span class="h-2 w-2 rounded-sm bg-ista-primary/80"></span>Total event</span>
-                        <span class="inline-flex items-center gap-1.5"><span class="h-2 w-2 rounded-sm bg-rose-500/80"></span>Failed</span>
-                    </div>
-                @endif
-            </x-admin.section>
-
-            <x-admin.section
-                title="Aktivitas Terbaru"
-                description="10 event AI terakhir dari semua user. Tidak menampilkan isi prompt atau jawaban.">
-                <x-admin.table :columns="[
-                    ['key' => 'user', 'label' => 'User'],
-                    ['key' => 'feature', 'label' => 'Fitur'],
-                    ['key' => 'status', 'label' => 'Status'],
-                    ['key' => 'latency', 'label' => 'Latensi', 'align' => 'right'],
-                    ['key' => 'time', 'label' => 'Waktu', 'align' => 'right'],
-                ]">
-                    @forelse ($recentEvents as $event)
-                        <tr>
-                            <td class="admin-table__td">
-                                <div class="flex flex-col">
-                                    <span class="text-sm font-semibold text-stone-700 dark:text-gray-200">{{ $event->user?->name ?? 'Sistem' }}</span>
-                                    <span class="text-[11px] text-stone-400 dark:text-gray-500">{{ $event->user?->email ?? '—' }}</span>
-                                </div>
-                            </td>
-                            <td class="admin-table__td">
-                                <span class="font-mono text-[11px] uppercase tracking-wider text-stone-500 dark:text-gray-400">{{ $event->feature }}</span>
-                            </td>
-                            <td class="admin-table__td">
-                                @php
-                                    $tone = match ($event->status) {
-                                        'success' => 'success',
-                                        'error' => 'danger',
-                                        'pending' => 'warning',
-                                        'blocked' => 'danger',
-                                        default => 'neutral',
-                                    };
-                                @endphp
-                                <x-admin.badge :tone="$tone">{{ ucfirst($event->status) }}</x-admin.badge>
-                            </td>
-                            <td class="admin-table__td" data-align="right">
-                                <span class="font-mono text-xs text-stone-500 dark:text-gray-400">{{ $event->latency_ms !== null ? number_format($event->latency_ms) . ' ms' : '—' }}</span>
-                            </td>
-                            <td class="admin-table__td" data-align="right">
-                                <span class="text-xs text-stone-500 dark:text-gray-400" title="{{ $event->created_at?->toDateTimeString() }}">{{ $event->created_at?->diffForHumans() }}</span>
-                            </td>
-                        </tr>
-                    @empty
-                        <tr>
-                            <td colspan="5" class="admin-table__empty">
-                                <x-admin.empty-state
-                                    title="Belum ada aktivitas"
-                                    description="Event akan muncul setelah user mengirim chat atau upload dokumen." />
-                            </td>
-                        </tr>
-                    @endforelse
-                </x-admin.table>
-            </x-admin.section>
-        </div>
-
-        <div class="space-y-4">
-            <x-admin.section
-                title="Distribusi Fitur"
-                description="Berdasarkan event AI {{ $rangeDays }} hari terakhir.">
-                @if (empty($distribution))
-                    <x-admin.empty-state title="Belum ada data" description="Tidak ada event pada rentang ini." />
-                @else
-                    @php $totalDist = max(1, collect($distribution)->sum('total')); @endphp
-                    <ul class="space-y-3 text-sm">
-                        @foreach ($distribution as $row)
-                            @php $pct = (int) round(($row['total'] / $totalDist) * 100); @endphp
-                            <li>
-                                <div class="flex items-center justify-between">
-                                    <span class="font-mono text-[11px] uppercase tracking-wider text-stone-500 dark:text-gray-400">{{ $row['feature'] }}</span>
-                                    <span class="text-xs font-semibold text-stone-700 dark:text-gray-200">{{ number_format($row['total']) }}</span>
-                                </div>
-                                <div class="mt-1 h-1.5 overflow-hidden rounded-full bg-stone-100 dark:bg-gray-800">
-                                    <div class="h-full bg-ista-primary/80" style="width: {{ $pct }}%"></div>
-                                </div>
-                                <div class="mt-1 flex items-center justify-between text-[10px] uppercase tracking-wider text-stone-400 dark:text-gray-500">
-                                    <span>Sukses {{ number_format($row['success']) }}</span>
-                                    <span>Gagal {{ number_format($row['failed']) }}</span>
-                                </div>
-                            </li>
+                        @foreach ([0, (int) round($chartMax / 2), $chartMax] as $index => $axisValue)
+                            <text x="0" y="{{ [184, 120, 58][$index] }}" class="admin-chart-axis">{{ $formatInt($axisValue) }}</text>
                         @endforeach
-                    </ul>
-                @endif
-            </x-admin.section>
+                        <path d="{{ $areaPath }}" fill="url(#adminOverviewArea)" />
+                        <path d="{{ $linePath }}" class="admin-chart-line" />
+                        @foreach ($chartPoints as $point)
+                            <circle cx="{{ $point['x'] }}" cy="{{ $point['y'] }}" r="4.2" class="admin-chart-dot" />
+                            <text x="{{ $point['x'] }}" y="{{ max(18, $point['y'] - 13) }}" text-anchor="middle" class="admin-chart-value">{{ $formatInt($point['total']) }}</text>
+                            <text x="{{ $point['x'] }}" y="215" text-anchor="middle" class="admin-chart-label">{{ $point['label'] }}</text>
+                        @endforeach
+                    </svg>
+                </div>
+                <div class="admin-chart-legend">
+                    <span><i class="bg-ista-primary"></i> Request</span>
+                    <span><i class="border border-stone-400 bg-transparent"></i> Rata-rata ({{ $rangeDays }} Hari): {{ $formatInt($avgSeries) }}</span>
+                </div>
+            @endif
+        </section>
 
-            <x-admin.section
-                title="Error Terbaru"
-                description="5 error terakhir untuk korelasi cepat.">
-                @if ($recentErrors->isEmpty())
+        <section class="admin-section admin-panel">
+            <header class="admin-panel-header">
+                <h3>Insiden Terbaru</h3>
+                <a href="{{ route('admin.errors') }}">Lihat semua</a>
+            </header>
+            <div class="admin-incident-summary admin-incident-summary--compact">
+                <div>
+                    <span>Total Error</span>
+                    <strong>{{ $formatInt($totalErrorsRange) }}</strong>
+                    <em class="{{ $errorsSevenDayTrendText ? $trendClass($errorsSevenDayTrend) : 'text-stone-500 dark:text-gray-500' }}">
+                        {{ $errorsSevenDayTrendText ?? '7 hari terakhir' }}
+                    </em>
+                </div>
+                <div>
+                    <span>Error Rate</span>
+                    <strong>{{ $formatPct($errorRateSevenDay) }}</strong>
+                    <em class="{{ $errorRateSevenDayTrendText ? $trendClass($errorRateSevenDayTrend) : 'text-stone-500 dark:text-gray-500' }}">
+                        {{ $errorRateSevenDayTrendText ?? 'Dari seluruh request' }}
+                    </em>
+                </div>
+            </div>
+
+            @if ($recentErrors->isEmpty())
+                <div class="p-5">
                     <x-admin.empty-state title="Tidak ada error" description="Sistem berjalan tanpa kegagalan." />
-                @else
-                    <ul class="space-y-3 text-sm">
-                        @foreach ($recentErrors as $error)
-                            <li class="rounded-lg border border-rose-100 bg-rose-50/60 p-3 dark:border-rose-900/40 dark:bg-rose-950/30">
-                                <div class="flex items-center justify-between gap-2">
-                                    <span class="font-mono text-[11px] uppercase tracking-wider text-rose-700 dark:text-rose-300">{{ $error->feature }}</span>
-                                    <span class="text-[10px] uppercase tracking-wider text-rose-500 dark:text-rose-400">{{ $error->created_at?->diffForHumans() }}</span>
-                                </div>
-                                <p class="mt-1 text-[11px] text-rose-700 dark:text-rose-300">{{ $error->error_code ?? 'unknown_error' }}</p>
-                                <p class="mt-1 truncate font-mono text-[10px] text-rose-500/80 dark:text-rose-400/80" title="{{ $error->request_id }}">req: {{ $error->request_id ?? '—' }}</p>
-                            </li>
-                        @endforeach
-                    </ul>
-                @endif
-            </x-admin.section>
-        </div>
+                </div>
+            @else
+                <ul class="admin-error-list admin-error-list--compact">
+                    @foreach ($recentErrors as $error)
+                        <li>
+                            <span class="admin-error-icon" aria-hidden="true">
+                                <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 8v4m0 4h.01M10.3 4.7L2.8 18a2 2 0 001.74 3h14.92a2 2 0 001.74-3L13.7 4.7a2 2 0 00-3.4 0z" />
+                                </svg>
+                            </span>
+                            <div class="min-w-0 flex-1">
+                                <p title="{{ $error->feature }}">{{ strtoupper(str_replace('_', '.', (string) $error->feature)) }}</p>
+                                <em>{{ $error->created_at?->format('d M Y, H:i') }} WIB</em>
+                                @if ($error->error_code)
+                                    <span class="admin-error-code">{{ $error->error_code }}</span>
+                                @endif
+                            </div>
+                            <x-admin.badge tone="danger">Gagal</x-admin.badge>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        </section>
     </div>
+
+    <section class="admin-section admin-panel admin-activity-panel">
+        <header class="admin-panel-header">
+            <div>
+                <h3>Aktivitas Terbaru</h3>
+                <p>3 event terakhir. Detail lengkap ada di tab Usage.</p>
+            </div>
+            <a href="{{ route('admin.usage') }}">Lihat semua</a>
+        </header>
+        <x-admin.table :columns="[
+            ['key' => 'user', 'label' => 'User'],
+            ['key' => 'feature', 'label' => 'Fitur'],
+            ['key' => 'status', 'label' => 'Status'],
+            ['key' => 'latency', 'label' => 'Latensi', 'align' => 'right'],
+            ['key' => 'time', 'label' => 'Waktu', 'align' => 'right'],
+        ]" class="admin-overview-table">
+            @forelse ($recentEvents as $event)
+                @php
+                    $statusTone = match ($event->status) {
+                        'success' => 'success',
+                        'error' => 'danger',
+                        'pending' => 'warning',
+                        'blocked' => 'danger',
+                        default => 'neutral',
+                    };
+                    $statusLabel = match ($event->status) {
+                        'success' => 'Sukses',
+                        'error' => 'Gagal',
+                        'pending' => 'Pending',
+                        'blocked' => 'Blocked',
+                        default => ucfirst((string) $event->status),
+                    };
+                    $displayFeature = strtoupper(str_replace('_', '.', (string) $event->feature));
+                    $userName = $event->user?->name ?? 'Sistem';
+                    $initial = strtoupper(substr($userName, 0, 1));
+                @endphp
+                <tr>
+                    <td class="admin-table__td">
+                        <div class="flex items-center gap-3">
+                            <span class="admin-row-avatar">{{ $initial }}</span>
+                            <div class="min-w-0">
+                                <span class="block truncate text-sm font-semibold text-stone-800 dark:text-gray-100">{{ $userName }}</span>
+                                <span class="block truncate text-xs text-stone-500 dark:text-gray-500">{{ $event->user?->email ?? '-' }}</span>
+                            </div>
+                        </div>
+                    </td>
+                    <td class="admin-table__td">
+                        <span class="font-mono text-xs font-medium uppercase text-stone-600 dark:text-gray-400" title="{{ $event->feature }}">{{ $displayFeature }}</span>
+                    </td>
+                    <td class="admin-table__td">
+                        <x-admin.badge :tone="$statusTone">{{ $statusLabel }}</x-admin.badge>
+                    </td>
+                    <td class="admin-table__td" data-align="right">
+                        <span class="font-mono text-xs text-stone-600 dark:text-gray-400">
+                            {{ $event->latency_ms !== null ? number_format(((float) $event->latency_ms) / 1000, 2, ',', '.') . 's' : '-' }}
+                        </span>
+                    </td>
+                    <td class="admin-table__td" data-align="right">
+                        <span class="text-xs text-stone-500 dark:text-gray-400" title="{{ $event->created_at?->toDateTimeString() }}">{{ $event->created_at?->diffForHumans() }}</span>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="5" class="admin-table__empty">
+                        <x-admin.empty-state
+                            title="Belum ada aktivitas"
+                            description="Event akan muncul setelah user mengirim chat atau upload dokumen." />
+                    </td>
+                </tr>
+            @endforelse
+        </x-admin.table>
+    </section>
 </div>

--- a/laravel/resources/views/livewire/admin/admin-documents.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-documents.blade.php
@@ -1,145 +1,554 @@
-<div>
-    <div class="mb-6">
-        <div class="flex flex-wrap items-end justify-between gap-3">
-            <div class="max-w-2xl">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Monitoring</p>
-                <h2 class="admin-page-title mt-1">Dokumen User</h2>
-                <p class="mt-2 text-sm leading-relaxed text-stone-500 dark:text-gray-400">
-                    Pantau status pemrosesan dokumen yang di-upload user. Halaman ini hanya menampilkan metadata file (nama, tipe, ukuran, status). Isi dokumen tidak ditampilkan.
-                </p>
-            </div>
-            <x-admin.badge tone="neutral">Read-only</x-admin.badge>
+@php
+    $formatInt = fn ($value): string => number_format((float) $value, 0, ',', '.');
+    $formatPct = function (int $value, int $total): string {
+        if ($total <= 0) {
+            return '0.0%';
+        }
+
+        return number_format(($value / $total) * 100, 1, '.', '') . '%';
+    };
+    $formatBytes = function (int $bytes): string {
+        if ($bytes >= 1073741824) {
+            return number_format($bytes / 1073741824, 2) . ' GB';
+        }
+
+        if ($bytes >= 1048576) {
+            return number_format($bytes / 1048576, 1) . ' MB';
+        }
+
+        if ($bytes >= 1024) {
+            return number_format($bytes / 1024, 1) . ' KB';
+        }
+
+        return $bytes . ' B';
+    };
+    $fileTypeMeta = function ($doc) {
+        $mime = (string) ($doc?->mime_type ?? '');
+        $extension = strtolower((string) pathinfo((string) ($doc?->original_name ?? ''), PATHINFO_EXTENSION));
+        $type = match (true) {
+            $mime === 'application/pdf' || $extension === 'pdf' => 'pdf',
+            in_array($mime, ['text/csv', 'text/plain', 'application/csv'], true) || $extension === 'csv' => 'csv',
+            in_array($mime, ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel'], true) || in_array($extension, ['xls', 'xlsx'], true) => 'xlsx',
+            $mime === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' || $extension === 'docx' => 'docx',
+            default => 'file',
+        };
+
+        return [
+            'key' => $type,
+            'label' => match ($type) {
+                'pdf' => 'PDF',
+                'csv' => 'CSV',
+                'xlsx' => 'XLSX',
+                'docx' => 'DOCX',
+                default => strtoupper($extension ?: 'FILE'),
+            },
+        ];
+    };
+    $statusMeta = function (?string $status): array {
+        return match ($status) {
+            'ready' => ['label' => 'Ready', 'tone' => 'success'],
+            'processing' => ['label' => 'Processing', 'tone' => 'warning'],
+            'pending' => ['label' => 'Pending', 'tone' => 'neutral'],
+            'error' => ['label' => 'Failed', 'tone' => 'danger'],
+            default => ['label' => ucfirst((string) ($status ?: 'Unknown')), 'tone' => 'neutral'],
+        };
+    };
+    $stageState = function (string $status, string $previewStatus, string $stage): string {
+        if ($stage === 'uploaded') {
+            return 'done';
+        }
+
+        if ($status === 'error' || $previewStatus === 'failed') {
+            return 'failed';
+        }
+
+        if ($stage === 'parsed') {
+            if ($status === 'ready' || $previewStatus === 'ready') {
+                return 'done';
+            }
+
+            return $status === 'processing' ? 'active' : 'pending';
+        }
+
+        if ($stage === 'indexed') {
+            if ($status === 'ready') {
+                return 'done';
+            }
+
+            return $status === 'processing' ? 'active' : 'pending';
+        }
+
+        if ($stage === 'ready') {
+            return $status === 'ready' ? 'done' : 'pending';
+        }
+
+        return 'pending';
+    };
+    $pipelineMeta = function ($doc) use ($stageState): array {
+        $status = (string) ($doc?->status ?? 'pending');
+        $previewStatus = (string) ($doc?->preview_status ?? 'pending');
+        $chunks = (int) ($doc?->chunks_count ?? 0);
+        $progress = match ($status) {
+            'ready' => 100,
+            'processing' => $previewStatus === 'ready' ? 72 : 55,
+            'pending' => 25,
+            'error' => 100,
+            default => 15,
+        };
+        $parseStatus = match (true) {
+            $status === 'error' || $previewStatus === 'failed' => 'Failed',
+            $status === 'ready' || $previewStatus === 'ready' => 'Parsed',
+            $status === 'processing' => 'Parsing',
+            default => 'Queued',
+        };
+        $embeddingStatus = match ($status) {
+            'ready' => 'Indexed',
+            'processing' => 'Indexing',
+            'error' => 'Failed',
+            default => 'Waiting',
+        };
+
+        return [
+            'progress' => $progress,
+            'tone' => $status === 'error' ? 'danger' : ($status === 'ready' ? 'success' : 'warning'),
+            'parse_status' => $parseStatus,
+            'embedding_status' => $embeddingStatus,
+            'chunk_count' => $chunks,
+            'stages' => [
+                ['key' => 'uploaded', 'label' => 'Uploaded', 'state' => $stageState($status, $previewStatus, 'uploaded')],
+                ['key' => 'parsed', 'label' => 'Parsed', 'state' => $stageState($status, $previewStatus, 'parsed')],
+                ['key' => 'indexed', 'label' => 'Indexed', 'state' => $stageState($status, $previewStatus, 'indexed')],
+                ['key' => 'ready', 'label' => 'Ready', 'state' => $stageState($status, $previewStatus, 'ready')],
+            ],
+        ];
+    };
+
+    $totalDocs = array_sum($statusCounts);
+    $readyCount = (int) ($statusCounts['ready'] ?? 0);
+    $processingCount = (int) (($statusCounts['pending'] ?? 0) + ($statusCounts['processing'] ?? 0));
+    $failedCount = (int) ($statusCounts['error'] ?? 0);
+    $sizeLabel = $formatBytes((int) $totalSizeBytes);
+
+    $documentCards = [
+        [
+            'label' => 'Total Dokumen',
+            'value' => $totalDocs,
+            'description' => $sizeLabel . ' total ukuran',
+            'tone' => 'primary',
+            'icon' => 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.5L19 9.5V19a2 2 0 01-2 2z',
+        ],
+        [
+            'label' => 'Ready',
+            'value' => $readyCount,
+            'description' => $formatPct($readyCount, $totalDocs) . ' siap dipakai',
+            'tone' => 'success',
+            'icon' => 'M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+        ],
+        [
+            'label' => 'Diproses',
+            'value' => $processingCount,
+            'description' => $formatPct($processingCount, $totalDocs) . ' pending / processing',
+            'tone' => 'warning',
+            'icon' => 'M12 6v6l3 2M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+        ],
+        [
+            'label' => 'Failed',
+            'value' => $failedCount,
+            'description' => $formatPct($failedCount, $totalDocs) . ' perlu dicek',
+            'tone' => 'danger',
+            'icon' => 'M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z',
+        ],
+    ];
+@endphp
+
+<div class="admin-documents-page">
+    <div class="admin-documents-hero">
+        <div class="max-w-2xl">
+            <p class="admin-documents-eyebrow">Monitoring</p>
+            <h2 class="admin-documents-title">Dokumen User</h2>
+            <p class="admin-documents-description">
+                Pantau pipeline dokumen dari upload, parsing, indexing, sampai siap dipakai AI.
+            </p>
         </div>
+        <x-admin.badge tone="neutral" class="admin-documents-readonly">Read-only</x-admin.badge>
     </div>
 
-    @php
-        $totalDocs = array_sum($statusCounts);
-        $readyCount = $statusCounts['ready'] ?? 0;
-        $processingCount = ($statusCounts['pending'] ?? 0) + ($statusCounts['processing'] ?? 0);
-        $failedCount = $statusCounts['error'] ?? 0;
-        $sizeLabel = $totalSizeBytes >= 1073741824
-            ? number_format($totalSizeBytes / 1073741824, 2) . ' GB'
-            : ($totalSizeBytes >= 1048576
-                ? number_format($totalSizeBytes / 1048576, 1) . ' MB'
-                : ($totalSizeBytes >= 1024
-                    ? number_format($totalSizeBytes / 1024, 1) . ' KB'
-                    : $totalSizeBytes . ' B'));
-    @endphp
-
-    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <x-admin.kpi-card label="Total Dokumen" :value="number_format($totalDocs)" tone="primary" />
-        <x-admin.kpi-card label="Ready" :value="number_format($readyCount)" tone="success" />
-        <x-admin.kpi-card label="Processing" :value="number_format($processingCount)" tone="warning" />
-        <x-admin.kpi-card label="Failed" :value="number_format($failedCount)" tone="danger" />
+    <div class="admin-documents-kpi-grid">
+        @foreach ($documentCards as $card)
+            <article class="admin-documents-kpi-card admin-documents-kpi-card--{{ $card['tone'] }}">
+                <div class="admin-documents-kpi-card__header">
+                    <span class="admin-documents-kpi-card__icon" aria-hidden="true">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="{{ $card['icon'] }}"/>
+                        </svg>
+                    </span>
+                    <p class="admin-documents-kpi-card__label">{{ $card['label'] }}</p>
+                </div>
+                <div class="admin-documents-kpi-card__body">
+                    <strong>{{ $formatInt($card['value']) }}</strong>
+                    <p class="admin-documents-kpi-card__description">{{ $card['description'] }}</p>
+                </div>
+            </article>
+        @endforeach
     </div>
 
-    <div class="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <x-admin.kpi-card label="Total Ukuran" :value="$sizeLabel" tone="default" description="Akumulasi file_size_bytes." />
-    </div>
-
-    <div class="mt-6">
-        <x-admin.section title="Filter">
-            <x-slot name="actions">
-                <button type="button" wire:click="resetFilters" class="text-[11px] font-semibold uppercase tracking-wider text-stone-500 transition hover:text-ista-primary dark:text-gray-400 dark:hover:text-amber-300">
+    <section class="admin-documents-filter-panel admin-section">
+        <div class="admin-documents-filter-panel__header">
+            <h3>Filter</h3>
+            <div class="admin-documents-reset-group">
+                <button type="button" wire:click="resetFilters" class="admin-documents-reset-button">
+                    <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M4 4v6h6M20 20v-6h-6M5.5 14a7 7 0 0012 3M18.5 10a7 7 0 00-12-3"/>
+                    </svg>
                     Reset
                 </button>
-            </x-slot>
-            <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                <label class="admin-filter">
-                    <span class="admin-filter__label">Cari nama file</span>
-                    <input type="search"
-                           wire:model.live.debounce.300ms="search"
-                           placeholder="Contoh: laporan.pdf"
-                           class="admin-filter__control" />
-                </label>
-
-                <label class="admin-filter">
-                    <span class="admin-filter__label">Status</span>
-                    <select wire:model.live="status" class="admin-filter__control">
-                        <option value="">Semua</option>
-                        @foreach ($statusOptions as $key => $label)
-                            <option value="{{ $key }}">{{ $label }}</option>
-                        @endforeach
-                    </select>
-                </label>
             </div>
-        </x-admin.section>
-    </div>
+        </div>
 
-    <div class="mt-6 grid gap-4 lg:grid-cols-3">
-        <div class="lg:col-span-2">
-            <x-admin.section
-                title="Dokumen Terbaru"
-                description="Maksimum {{ \App\Services\Admin\AdminMetricsService::RECENT_ROWS_LIMIT }} baris.">
+        <div class="admin-documents-filter-grid">
+            <label class="admin-documents-filter">
+                <span>Cari File</span>
+                <input type="search"
+                       wire:model.live.debounce.300ms="search"
+                       placeholder="Contoh: laporan.pdf"
+                       class="admin-documents-control" />
+            </label>
+
+            <label class="admin-documents-filter">
+                <span>Tipe</span>
+                <select wire:model.live="type" class="admin-documents-control">
+                    <option value="">Semua</option>
+                    @foreach ($typeOptions as $key => $label)
+                        <option value="{{ $key }}">{{ $label }}</option>
+                    @endforeach
+                </select>
+            </label>
+
+            <label class="admin-documents-filter">
+                <span>Status</span>
+                <select wire:model.live="status" class="admin-documents-control">
+                    <option value="">Semua</option>
+                    @foreach ($statusOptions as $key => $label)
+                        <option value="{{ $key }}">{{ $label }}</option>
+                    @endforeach
+                </select>
+            </label>
+
+            <label class="admin-documents-filter">
+                <span>User</span>
+                <select wire:model.live="ownerId" class="admin-documents-control">
+                    <option value="">Semua</option>
+                    @foreach ($ownerOptions as $owner)
+                        <option value="{{ $owner->id }}">{{ $owner->name }} - {{ $owner->email }}</option>
+                    @endforeach
+                </select>
+            </label>
+
+            <label class="admin-documents-filter">
+                <span>Tanggal Mulai</span>
+                <input type="date" wire:model.live="startDate" class="admin-documents-control" />
+            </label>
+
+            <label class="admin-documents-filter">
+                <span>Tanggal Akhir</span>
+                <input type="date" wire:model.live="endDate" class="admin-documents-control" />
+            </label>
+        </div>
+    </section>
+
+    <div class="admin-documents-content-grid">
+        <section class="admin-documents-table-panel admin-section">
+            <header class="admin-documents-table-panel__header">
+                <div>
+                    <h3>Pipeline Dokumen</h3>
+                    <p>Menampilkan {{ $documentsPerPage }} dokumen per halaman pada filter aktif.</p>
+                </div>
+            </header>
+
+            <div class="admin-documents-table-panel__body">
                 @if ($documents->isEmpty())
-                    <x-admin.empty-state title="Belum ada dokumen" description="Tidak ada dokumen yang cocok dengan filter saat ini." />
+                    <x-admin.empty-state
+                        title="Belum ada dokumen"
+                        description="Tidak ada dokumen yang cocok dengan filter saat ini." />
                 @else
-                    <x-admin.table :columns="[
-                        ['key' => 'file', 'label' => 'File'],
-                        ['key' => 'user', 'label' => 'User'],
-                        ['key' => 'mime', 'label' => 'Tipe'],
-                        ['key' => 'size', 'label' => 'Ukuran', 'align' => 'right'],
-                        ['key' => 'status', 'label' => 'Status'],
-                        ['key' => 'time', 'label' => 'Dibuat', 'align' => 'right'],
-                    ]">
+                    <x-admin.table
+                        class="admin-documents-table"
+                        :columns="[
+                            ['key' => 'file', 'label' => 'File', 'width' => '25%'],
+                            ['key' => 'owner', 'label' => 'Owner', 'width' => '17%'],
+                            ['key' => 'status', 'label' => 'Status', 'width' => '12%'],
+                            ['key' => 'pipeline', 'label' => 'Pipeline', 'width' => '20%'],
+                            ['key' => 'size', 'label' => 'Size', 'align' => 'right', 'width' => '8%'],
+                            ['key' => 'uploaded', 'label' => 'Uploaded', 'align' => 'right', 'width' => '10%'],
+                            ['key' => 'action', 'label' => '', 'align' => 'right', 'width' => '8%'],
+                        ]">
                         @foreach ($documents as $doc)
                             @php
-                                $tone = match ($doc->status) {
-                                    'ready' => 'success',
-                                    'pending', 'processing' => 'warning',
-                                    'error' => 'danger',
-                                    default => 'neutral',
-                                };
+                                $typeMeta = $fileTypeMeta($doc);
+                                $status = $statusMeta($doc->status);
+                                $pipeline = $pipelineMeta($doc);
                             @endphp
                             <tr>
                                 <td class="admin-table__td">
-                                    <span class="text-sm font-semibold text-stone-700 dark:text-gray-200">{{ \Illuminate\Support\Str::limit((string) $doc->original_name, 60, '…') }}</span>
-                                </td>
-                                <td class="admin-table__td">
-                                    <div class="flex flex-col">
-                                        <span class="text-xs text-stone-600 dark:text-gray-300">{{ $doc->user?->name ?? '—' }}</span>
-                                        <span class="text-[11px] text-stone-400 dark:text-gray-500">{{ $doc->user?->email ?? '' }}</span>
+                                    <div class="admin-documents-file-cell">
+                                        <span class="admin-documents-file-icon admin-documents-file-icon--{{ $typeMeta['key'] }}" aria-hidden="true">
+                                            {{ $typeMeta['label'] }}
+                                        </span>
+                                        <div class="min-w-0">
+                                            <span class="admin-documents-file-cell__name" title="{{ $doc->original_name }}">
+                                                {{ \Illuminate\Support\Str::limit((string) $doc->original_name, 54, '...') }}
+                                            </span>
+                                            <span class="admin-documents-file-cell__meta">{{ $doc->mime_type ?? 'unknown' }}</span>
+                                        </div>
                                     </div>
                                 </td>
                                 <td class="admin-table__td">
-                                    <span class="font-mono text-[10.5px] uppercase tracking-wider text-stone-500 dark:text-gray-400">{{ $doc->mime_type ?? 'unknown' }}</span>
-                                </td>
-                                <td class="admin-table__td" data-align="right">
-                                    <span class="font-mono text-xs text-stone-500 dark:text-gray-400">{{ $doc->formatted_size }}</span>
+                                    <div class="admin-documents-user-cell">
+                                        <span class="admin-documents-user-cell__name">{{ $doc->user?->name ?? 'Sistem' }}</span>
+                                        <span class="admin-documents-user-cell__email">{{ $doc->user?->email ?? '-' }}</span>
+                                    </div>
                                 </td>
                                 <td class="admin-table__td">
-                                    <x-admin.badge :tone="$tone">{{ ucfirst($doc->status ?? 'unknown') }}</x-admin.badge>
+                                    <span class="admin-documents-status-chip admin-documents-status-chip--{{ $status['tone'] }}">
+                                        {{ $status['label'] }}
+                                    </span>
+                                </td>
+                                <td class="admin-table__td">
+                                    <div class="admin-documents-pipeline">
+                                        <div class="admin-documents-pipeline__track" aria-hidden="true">
+                                            <span class="admin-documents-pipeline__bar admin-documents-pipeline__bar--{{ $pipeline['tone'] }}" style="width: {{ $pipeline['progress'] }}%"></span>
+                                        </div>
+                                        <div class="admin-documents-pipeline__meta">
+                                            <span>{{ $pipeline['parse_status'] }}</span>
+                                            <span>{{ $pipeline['embedding_status'] }}</span>
+                                        </div>
+                                    </div>
                                 </td>
                                 <td class="admin-table__td" data-align="right">
-                                    <span class="text-xs text-stone-500 dark:text-gray-400" title="{{ $doc->created_at?->toDateTimeString() }}">{{ $doc->created_at?->diffForHumans() }}</span>
+                                    <span class="admin-documents-number">{{ $doc->formatted_size }}</span>
+                                </td>
+                                <td class="admin-table__td" data-align="right">
+                                    <span class="admin-documents-muted" title="{{ $doc->created_at?->toDateTimeString() }}">{{ $doc->created_at?->diffForHumans() }}</span>
+                                </td>
+                                <td class="admin-table__td" data-align="right">
+                                    <button type="button" wire:click="showDetail({{ $doc->id }})" class="admin-documents-detail-button">
+                                        Detail
+                                    </button>
                                 </td>
                             </tr>
                         @endforeach
                     </x-admin.table>
-                @endif
-            </x-admin.section>
-        </div>
 
-        <x-admin.section title="Distribusi Tipe" description="Berdasarkan mime_type.">
-            @if (empty($mimeCounts))
-                <x-admin.empty-state title="Tidak ada data" />
-            @else
-                @php $totalMime = max(1, array_sum($mimeCounts)); @endphp
-                <ul class="space-y-3 text-sm">
-                    @foreach ($mimeCounts as $mime => $count)
-                        @php $pct = (int) round(($count / $totalMime) * 100); @endphp
-                        <li>
-                            <div class="flex items-center justify-between">
-                                <span class="font-mono text-[10.5px] uppercase tracking-wider text-stone-500 dark:text-gray-400">{{ $mime }}</span>
-                                <span class="text-xs font-semibold text-stone-700 dark:text-gray-200">{{ number_format($count) }}</span>
-                            </div>
-                            <div class="mt-1 h-1.5 overflow-hidden rounded-full bg-stone-100 dark:bg-gray-800">
-                                <div class="h-full bg-ista-primary/80" style="width: {{ $pct }}%"></div>
-                            </div>
-                        </li>
-                    @endforeach
-                </ul>
-            @endif
-        </x-admin.section>
+                    @if ($documents->hasPages())
+                        <div class="admin-documents-pagination">
+                            {{ $documents->links() }}
+                        </div>
+                    @endif
+                @endif
+            </div>
+        </section>
+
+        <div class="admin-documents-side-grid">
+            <section class="admin-documents-distribution-panel admin-section">
+                <header class="admin-documents-distribution-panel__header">
+                    <div>
+                        <h3>Distribusi Tipe</h3>
+                        <p>Berdasarkan filter aktif.</p>
+                    </div>
+                </header>
+
+                <div class="admin-documents-distribution-panel__body">
+                    @if (empty($mimeCounts))
+                        <x-admin.empty-state title="Tidak ada data" />
+                    @else
+                        @php $totalMime = max(1, array_sum($mimeCounts)); @endphp
+                        <ul class="admin-documents-distribution-list" role="list">
+                            @foreach ($mimeCounts as $mime => $count)
+                                @php
+                                    $mimeMeta = $fileTypeMeta((object) ['mime_type' => $mime, 'original_name' => '']);
+                                    $pct = (int) round(($count / $totalMime) * 100);
+                                @endphp
+                                <li>
+                                    <div class="admin-documents-distribution-list__top">
+                                        <span title="{{ $mime }}">{{ $mimeMeta['label'] }}</span>
+                                        <strong>{{ number_format($count) }}</strong>
+                                    </div>
+                                    <div class="admin-documents-distribution-bar" aria-hidden="true">
+                                        <span style="width: {{ $pct }}%"></span>
+                                    </div>
+                                    <div class="admin-documents-distribution-list__meta">
+                                        <span>{{ $pct }}%</span>
+                                        <span>{{ number_format($count) }} file</span>
+                                    </div>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </div>
+            </section>
+
+            <section class="admin-documents-distribution-panel admin-section">
+                <header class="admin-documents-distribution-panel__header">
+                    <div>
+                        <h3>Status Pipeline</h3>
+                        <p>Uploaded, parsed, indexed, ready.</p>
+                    </div>
+                </header>
+
+                <div class="admin-documents-distribution-panel__body">
+                    @if (empty($statusCounts))
+                        <x-admin.empty-state title="Tidak ada status" />
+                    @else
+                        @php $totalStatus = max(1, array_sum($statusCounts)); @endphp
+                        <ul class="admin-documents-status-list" role="list">
+                            @foreach ($statusCounts as $statusName => $count)
+                                @php
+                                    $pct = (int) round(($count / $totalStatus) * 100);
+                                    $statusItem = $statusMeta($statusName);
+                                @endphp
+                                <li>
+                                    <span class="admin-documents-status-dot admin-documents-status-dot--{{ $statusItem['tone'] }}" aria-hidden="true"></span>
+                                    <div>
+                                        <strong>{{ $statusItem['label'] }}</strong>
+                                        <em>{{ $pct }}% dari dokumen</em>
+                                    </div>
+                                    <b>{{ number_format($count) }}</b>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </div>
+            </section>
+        </div>
     </div>
+
+    @if ($selectedDocument)
+        @php
+            $selectedType = $fileTypeMeta($selectedDocument);
+            $selectedStatus = $statusMeta($selectedDocument->status);
+            $selectedPipeline = $pipelineMeta($selectedDocument);
+        @endphp
+        <div class="admin-documents-drawer" role="dialog" aria-modal="true" aria-labelledby="admin-document-detail-title">
+            <button type="button" class="admin-documents-drawer__backdrop" wire:click="closeDetail" aria-label="Tutup detail dokumen"></button>
+
+            <aside class="admin-documents-drawer__panel">
+                <header class="admin-documents-drawer__header">
+                    <div class="admin-documents-drawer__title-row">
+                        <span class="admin-documents-file-icon admin-documents-file-icon--{{ $selectedType['key'] }}" aria-hidden="true">
+                            {{ $selectedType['label'] }}
+                        </span>
+                        <div class="min-w-0">
+                            <p class="admin-documents-drawer__eyebrow">Document Pipeline</p>
+                            <h3 id="admin-document-detail-title" title="{{ $selectedDocument->original_name }}">
+                                {{ \Illuminate\Support\Str::limit((string) $selectedDocument->original_name, 64, '...') }}
+                            </h3>
+                        </div>
+                    </div>
+                    <button type="button" wire:click="closeDetail" class="admin-documents-drawer__close" aria-label="Tutup detail dokumen">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M6 6l12 12M18 6L6 18"/>
+                        </svg>
+                    </button>
+                </header>
+
+                <div class="admin-documents-drawer__body">
+                    <div class="admin-documents-drawer__summary">
+                        <div>
+                            <span>Status</span>
+                            <strong class="admin-documents-status-chip admin-documents-status-chip--{{ $selectedStatus['tone'] }}">
+                                {{ $selectedStatus['label'] }}
+                            </strong>
+                        </div>
+                        <div>
+                            <span>Owner</span>
+                            <strong>{{ $selectedDocument->user?->name ?? 'Sistem' }}</strong>
+                            <em>{{ $selectedDocument->user?->email ?? '-' }}</em>
+                        </div>
+                        <div>
+                            <span>Size</span>
+                            <strong>{{ $selectedDocument->formatted_size }}</strong>
+                            <em>{{ $selectedDocument->mime_type ?? 'unknown' }}</em>
+                        </div>
+                        <div>
+                            <span>Uploaded</span>
+                            <strong>{{ $selectedDocument->created_at?->diffForHumans() ?? '-' }}</strong>
+                            <em>{{ $selectedDocument->created_at?->toDateTimeString() ?? '-' }}</em>
+                        </div>
+                    </div>
+
+                    <section class="admin-documents-drawer__section">
+                        <div class="admin-documents-drawer__section-heading">
+                            <h4>Pipeline</h4>
+                            <span>{{ $selectedPipeline['progress'] }}%</span>
+                        </div>
+                        <div class="admin-documents-pipeline admin-documents-pipeline--drawer">
+                            <div class="admin-documents-pipeline__track" aria-hidden="true">
+                                <span class="admin-documents-pipeline__bar admin-documents-pipeline__bar--{{ $selectedPipeline['tone'] }}" style="width: {{ $selectedPipeline['progress'] }}%"></span>
+                            </div>
+                        </div>
+                        <ol class="admin-documents-stage-list" role="list">
+                            @foreach ($selectedPipeline['stages'] as $stage)
+                                <li class="admin-documents-stage-list__item admin-documents-stage-list__item--{{ $stage['state'] }}">
+                                    <span aria-hidden="true"></span>
+                                    <strong>{{ $stage['label'] }}</strong>
+                                </li>
+                            @endforeach
+                        </ol>
+                    </section>
+
+                    <section class="admin-documents-drawer__section">
+                        <h4>AI Index Metadata</h4>
+                        <dl class="admin-documents-metadata-grid">
+                            <div>
+                                <dt>Parsing Status</dt>
+                                <dd>{{ $selectedPipeline['parse_status'] }}</dd>
+                            </div>
+                            <div>
+                                <dt>Chunk Count</dt>
+                                <dd>{{ number_format($selectedPipeline['chunk_count']) }}</dd>
+                            </div>
+                            <div>
+                                <dt>Embedding Status</dt>
+                                <dd>{{ $selectedPipeline['embedding_status'] }}</dd>
+                            </div>
+                            <div>
+                                <dt>Preview Status</dt>
+                                <dd>{{ ucfirst((string) ($selectedDocument->preview_status ?? 'pending')) }}</dd>
+                            </div>
+                        </dl>
+                    </section>
+
+                    <section class="admin-documents-drawer__section">
+                        <h4>File Metadata</h4>
+                        <dl class="admin-documents-metadata-grid">
+                            <div>
+                                <dt>File Name</dt>
+                                <dd>{{ $selectedDocument->filename ?? '-' }}</dd>
+                            </div>
+                            <div>
+                                <dt>Original Name</dt>
+                                <dd>{{ $selectedDocument->original_name ?? '-' }}</dd>
+                            </div>
+                            <div>
+                                <dt>Source</dt>
+                                <dd>{{ strtoupper(str_replace('_', ' ', (string) ($selectedDocument->source_provider ?? 'local'))) }}</dd>
+                            </div>
+                            <div>
+                                <dt>External ID</dt>
+                                <dd>{{ $selectedDocument->source_external_id ?? '-' }}</dd>
+                            </div>
+                            <div>
+                                <dt>Synced At</dt>
+                                <dd>{{ $selectedDocument->source_synced_at?->toDateTimeString() ?? '-' }}</dd>
+                            </div>
+                            <div>
+                                <dt>Updated At</dt>
+                                <dd>{{ $selectedDocument->updated_at?->toDateTimeString() ?? '-' }}</dd>
+                            </div>
+                        </dl>
+                    </section>
+                </div>
+            </aside>
+        </div>
+    @endif
 </div>

--- a/laravel/resources/views/livewire/admin/admin-errors.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-errors.blade.php
@@ -1,28 +1,121 @@
-<div>
-    <div class="mb-6">
-        <div class="flex flex-wrap items-end justify-between gap-3">
-            <div class="max-w-2xl">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Monitoring</p>
-                <h2 class="admin-page-title mt-1">Error Operasional AI</h2>
-                <p class="mt-2 text-sm leading-relaxed text-stone-500 dark:text-gray-400">
-                    Lihat event AI dengan status error atau blocked. Ringkasan kategori membantu korelasi cepat dengan log produksi melalui request ID.
-                </p>
-            </div>
-            <x-admin.badge tone="danger">Failed only</x-admin.badge>
+@php
+    $formatInt = fn ($value): string => number_format((float) $value, 0, ',', '.');
+    $formatPct = function (int $value, int $total): string {
+        if ($total <= 0) {
+            return '0.0%';
+        }
+
+        return number_format(($value / $total) * 100, 1, '.', '') . '%';
+    };
+
+    $totalErrors = (int) ($errorSummary['total'] ?? 0);
+    $failedErrors = (int) ($errorSummary['error'] ?? 0);
+    $blockedErrors = (int) ($errorSummary['blocked'] ?? 0);
+    $uniqueCodes = (int) ($errorSummary['unique_codes'] ?? 0);
+
+    $errorCards = [
+        [
+            'label' => 'Total Issue',
+            'value' => $totalErrors,
+            'description' => 'Error dan blocked terfilter',
+            'tone' => 'primary',
+            'icon' => 'M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z',
+        ],
+        [
+            'label' => 'Error',
+            'value' => $failedErrors,
+            'description' => $formatPct($failedErrors, $totalErrors) . ' dari issue',
+            'tone' => 'danger',
+            'icon' => 'M6 18L18 6M6 6l12 12',
+        ],
+        [
+            'label' => 'Blocked',
+            'value' => $blockedErrors,
+            'description' => $formatPct($blockedErrors, $totalErrors) . ' dari issue',
+            'tone' => 'warning',
+            'icon' => 'M12 3l7.5 4.5v5.25c0 4.5-3.075 7.55-7.5 8.25-4.425-.7-7.5-3.75-7.5-8.25V7.5L12 3zm-3.5 9h7',
+        ],
+        [
+            'label' => 'Kode Unik',
+            'value' => $uniqueCodes,
+            'description' => 'Error code tersanitasi',
+            'tone' => 'neutral',
+            'icon' => 'M7 8h10M7 12h10M7 16h7M5 4h14a2 2 0 012 2v12a2 2 0 01-2 2H5a2 2 0 01-2-2V6a2 2 0 012-2z',
+        ],
+    ];
+
+    $featureLabel = fn (?string $feature): string => $featureOptions[$feature] ?? strtoupper(str_replace('_', '.', (string) ($feature ?: '-')));
+    $codeLabel = fn (?string $code): string => strtoupper(str_replace('_', ' ', (string) ($code ?: 'unknown_error')));
+    $modelLabel = function ($event): string {
+        $metadata = is_array($event?->metadata) ? $event->metadata : [];
+
+        return (string) ($metadata['model_label'] ?? $metadata['model_name'] ?? '-');
+    };
+    $metadataValue = function ($value): string {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_array($value)) {
+            return json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '-';
+        }
+
+        if ($value === null || $value === '') {
+            return '-';
+        }
+
+        return (string) $value;
+    };
+@endphp
+
+<div class="admin-errors-page">
+    <div class="admin-errors-hero">
+        <div class="max-w-2xl">
+            <p class="admin-errors-eyebrow">Monitoring</p>
+            <h2 class="admin-errors-title">Error Operasional</h2>
+            <p class="admin-errors-description">
+                Pantau event gagal dan blocked tanpa membuka isi percakapan, dokumen, atau memo.
+            </p>
         </div>
+        <x-admin.badge tone="neutral" class="admin-errors-readonly">Read-only</x-admin.badge>
     </div>
 
-    <x-admin.section title="Filter">
-        <x-slot name="actions">
-            <button type="button" wire:click="resetFilters" class="text-[11px] font-semibold uppercase tracking-wider text-stone-500 transition hover:text-ista-primary dark:text-gray-400 dark:hover:text-amber-300">
-                Reset
-            </button>
-        </x-slot>
+    <div class="admin-errors-kpi-grid">
+        @foreach ($errorCards as $card)
+            <article class="admin-errors-kpi-card admin-errors-kpi-card--{{ $card['tone'] }}">
+                <div class="admin-errors-kpi-card__header">
+                    <span class="admin-errors-kpi-card__icon" aria-hidden="true">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="{{ $card['icon'] }}"/>
+                        </svg>
+                    </span>
+                    <p class="admin-errors-kpi-card__label">{{ $card['label'] }}</p>
+                </div>
+                <div class="admin-errors-kpi-card__body">
+                    <strong>{{ $formatInt($card['value']) }}</strong>
+                    <p class="admin-errors-kpi-card__description">{{ $card['description'] }}</p>
+                </div>
+            </article>
+        @endforeach
+    </div>
 
-        <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            <label class="admin-filter">
-                <span class="admin-filter__label">Fitur</span>
-                <select wire:model.live="feature" class="admin-filter__control">
+    <section class="admin-errors-filter-panel admin-section">
+        <div class="admin-errors-filter-panel__header">
+            <h3>Filter</h3>
+            <div class="admin-errors-reset-group">
+                <button type="button" wire:click="resetFilters" class="admin-errors-reset-button">
+                    <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M4 4v6h6M20 20v-6h-6M5.5 14a7 7 0 0012 3M18.5 10a7 7 0 00-12-3"/>
+                    </svg>
+                    Reset
+                </button>
+            </div>
+        </div>
+
+        <div class="admin-errors-filter-grid">
+            <label class="admin-errors-filter">
+                <span>Fitur</span>
+                <select wire:model.live="feature" class="admin-errors-control">
                     <option value="">Semua</option>
                     @foreach ($featureOptions as $key => $label)
                         <option value="{{ $key }}">{{ $label }}</option>
@@ -30,100 +123,254 @@
                 </select>
             </label>
 
-            <label class="admin-filter">
-                <span class="admin-filter__label">Request ID</span>
+            <label class="admin-errors-filter">
+                <span>Trace</span>
                 <input type="search"
                        wire:model.live.debounce.400ms="requestId"
-                       placeholder="UUID partial…"
-                       class="admin-filter__control" />
+                       placeholder="Cari request ID"
+                       class="admin-errors-control" />
             </label>
 
-            <label class="admin-filter">
-                <span class="admin-filter__label">Tanggal Mulai</span>
-                <input type="date" wire:model.live="startDate" class="admin-filter__control" />
+            <label class="admin-errors-filter">
+                <span>Tanggal Mulai</span>
+                <input type="date" wire:model.live="startDate" class="admin-errors-control" />
             </label>
 
-            <label class="admin-filter">
-                <span class="admin-filter__label">Tanggal Akhir</span>
-                <input type="date" wire:model.live="endDate" class="admin-filter__control" />
+            <label class="admin-errors-filter">
+                <span>Tanggal Akhir</span>
+                <input type="date" wire:model.live="endDate" class="admin-errors-control" />
             </label>
         </div>
-    </x-admin.section>
+    </section>
 
-    <div class="mt-6 grid gap-4 lg:grid-cols-3">
-        <div class="lg:col-span-2">
-            <x-admin.section
-                title="Error Terbaru"
-                description="Maksimum {{ \App\Services\Admin\AdminMetricsService::RECENT_ROWS_LIMIT }} baris.">
+    <div class="admin-errors-content-grid">
+        <section class="admin-errors-table-panel admin-section">
+            <header class="admin-errors-table-panel__header">
+                <div>
+                    <h3>Error Terbaru</h3>
+                    <p>Menampilkan {{ $errorsPerPage }} error per halaman pada filter aktif.</p>
+                </div>
+                @if ($errorSummary['latest_at'] ?? null)
+                    <span class="admin-errors-latest" title="{{ $errorSummary['latest_at']->toDateTimeString() }}">
+                        Terbaru {{ $errorSummary['latest_at']->diffForHumans() }}
+                    </span>
+                @endif
+            </header>
+
+            <div class="admin-errors-table-panel__body">
                 @if ($errors->isEmpty())
                     <x-admin.empty-state
                         title="Tidak ada error"
-                        description="Sistem berjalan tanpa kegagalan untuk filter saat ini." />
+                        description="Tidak ada event gagal atau blocked pada filter saat ini." />
                 @else
-                    <x-admin.table :columns="[
-                        ['key' => 'time', 'label' => 'Waktu'],
-                        ['key' => 'user', 'label' => 'User'],
-                        ['key' => 'feature', 'label' => 'Fitur'],
-                        ['key' => 'error', 'label' => 'Kode Error'],
-                        ['key' => 'request', 'label' => 'Request ID'],
-                    ]">
+                    <x-admin.table
+                        class="admin-errors-table"
+                        :columns="[
+                            ['key' => 'user', 'label' => 'User', 'width' => '24%'],
+                            ['key' => 'feature', 'label' => 'Fitur', 'width' => '14%'],
+                            ['key' => 'code', 'label' => 'Kode Error', 'width' => '22%'],
+                            ['key' => 'severity', 'label' => 'Severity', 'width' => '12%'],
+                            ['key' => 'time', 'label' => 'Waktu', 'align' => 'right', 'width' => '14%'],
+                            ['key' => 'action', 'label' => 'Aksi', 'align' => 'right', 'width' => '14%'],
+                        ]">
                         @foreach ($errors as $error)
                             <tr>
                                 <td class="admin-table__td">
-                                    <span class="text-xs text-stone-500 dark:text-gray-400" title="{{ $error->created_at?->toDateTimeString() }}">{{ $error->created_at?->diffForHumans() }}</span>
-                                </td>
-                                <td class="admin-table__td">
-                                    <div class="flex flex-col">
-                                        <span class="text-sm font-semibold text-stone-700 dark:text-gray-200">{{ $error->user?->name ?? 'Sistem' }}</span>
-                                        <span class="text-[11px] text-stone-400 dark:text-gray-500">{{ $error->user?->email ?? '—' }}</span>
+                                    <div class="admin-errors-user-cell">
+                                        <span class="admin-errors-user-cell__name">{{ $error->user?->name ?? 'Sistem' }}</span>
+                                        <span class="admin-errors-user-cell__email">{{ $error->user?->email ?? '-' }}</span>
                                     </div>
                                 </td>
                                 <td class="admin-table__td">
-                                    <span class="font-mono text-[11px] uppercase tracking-wider text-stone-500 dark:text-gray-400">{{ $error->feature }}</span>
+                                    <span class="admin-errors-feature">{{ $featureLabel($error->feature) }}</span>
                                 </td>
                                 <td class="admin-table__td">
-                                    <x-admin.badge tone="danger">{{ $error->error_code ?? 'unknown_error' }}</x-admin.badge>
+                                    <span class="admin-errors-code" title="{{ $error->error_code ?? 'unknown_error' }}">
+                                        {{ $codeLabel($error->error_code) }}
+                                    </span>
                                 </td>
                                 <td class="admin-table__td">
-                                    <code class="rounded bg-stone-100 px-2 py-0.5 font-mono text-[10px] text-stone-600 dark:bg-gray-800 dark:text-gray-300" title="{{ $error->request_id }}">{{ $error->request_id ?? '—' }}</code>
+                                    <span class="admin-errors-severity admin-errors-severity--{{ $error->getAttribute('severity_level') }}" title="{{ $error->getAttribute('severity_description') }}">
+                                        {{ $error->getAttribute('severity_label') }}
+                                    </span>
+                                </td>
+                                <td class="admin-table__td" data-align="right">
+                                    <span class="admin-errors-muted" title="{{ $error->created_at?->toDateTimeString() }}">{{ $error->created_at?->diffForHumans() }}</span>
+                                </td>
+                                <td class="admin-table__td" data-align="right">
+                                    <button type="button" wire:click="showDetail({{ $error->id }})" class="admin-errors-detail-button">
+                                        Detail
+                                    </button>
                                 </td>
                             </tr>
                         @endforeach
                     </x-admin.table>
-                @endif
-            </x-admin.section>
-        </div>
 
-        <div class="space-y-4">
-            <x-admin.section title="Berdasarkan Fitur" description="Distribusi error pada hasil saat ini.">
-                @if ($byFeature->isEmpty())
-                    <x-admin.empty-state title="Tidak ada error" />
-                @else
-                    <ul class="space-y-2 text-sm">
-                        @foreach ($byFeature as $feature => $count)
-                            <li class="flex items-center justify-between">
-                                <span class="font-mono text-[11px] uppercase tracking-wider text-stone-500 dark:text-gray-400">{{ $feature }}</span>
-                                <span class="font-semibold text-stone-700 dark:text-gray-200">{{ number_format($count) }}</span>
-                            </li>
-                        @endforeach
-                    </ul>
+                    @if ($errors->hasPages())
+                        <div class="admin-errors-pagination">
+                            {{ $errors->links() }}
+                        </div>
+                    @endif
                 @endif
-            </x-admin.section>
+            </div>
+        </section>
 
-            <x-admin.section title="Berdasarkan Kode Error">
-                @if ($byCode->isEmpty())
-                    <x-admin.empty-state title="Tidak ada kode error" description="Belum ada event dengan error_code tersanitasi." />
-                @else
-                    <ul class="space-y-2 text-sm">
-                        @foreach ($byCode as $code => $count)
-                            <li class="flex items-center justify-between">
-                                <span class="font-mono text-[11px] uppercase tracking-wider text-rose-700 dark:text-rose-300">{{ $code }}</span>
-                                <span class="font-semibold text-stone-700 dark:text-gray-200">{{ number_format($count) }}</span>
-                            </li>
-                        @endforeach
-                    </ul>
-                @endif
-            </x-admin.section>
+        <div class="admin-errors-side-grid">
+            <section class="admin-errors-distribution-panel admin-section">
+                <header class="admin-errors-distribution-panel__header">
+                    <div>
+                        <h3>Berdasarkan Fitur</h3>
+                        <p>Distribusi issue pada filter aktif.</p>
+                    </div>
+                </header>
+
+                <div class="admin-errors-distribution-panel__body">
+                    @if (empty($byFeature))
+                        <x-admin.empty-state title="Tidak ada error" />
+                    @else
+                        @php $totalFeature = max(1, collect($byFeature)->sum('total')); @endphp
+                        <ul class="admin-errors-distribution-list" role="list">
+                            @foreach ($byFeature as $row)
+                                @php $pct = (int) round(($row['total'] / $totalFeature) * 100); @endphp
+                                <li>
+                                    <div class="admin-errors-distribution-list__top">
+                                        <span>{{ $featureLabel($row['feature']) }}</span>
+                                        <strong>{{ number_format($row['total']) }}</strong>
+                                    </div>
+                                    <div class="admin-errors-distribution-bar" aria-hidden="true">
+                                        <span style="width: {{ $pct }}%"></span>
+                                    </div>
+                                    <div class="admin-errors-distribution-list__meta">
+                                        <span>{{ $pct }}%</span>
+                                        <span>{{ number_format($row['total']) }} issue</span>
+                                    </div>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </div>
+            </section>
+
+            <section class="admin-errors-distribution-panel admin-section">
+                <header class="admin-errors-distribution-panel__header">
+                    <div>
+                        <h3>Kode Error</h3>
+                        <p>Error code yang paling sering muncul.</p>
+                    </div>
+                </header>
+
+                <div class="admin-errors-distribution-panel__body">
+                    @if (empty($byCode))
+                        <x-admin.empty-state title="Tidak ada kode error" description="Belum ada error code pada filter ini." />
+                    @else
+                        @php $totalCode = max(1, collect($byCode)->sum('total')); @endphp
+                        <ul class="admin-errors-code-list" role="list">
+                            @foreach ($byCode as $row)
+                                @php $pct = (int) round(($row['total'] / $totalCode) * 100); @endphp
+                                <li>
+                                    <div>
+                                        <span>{{ $codeLabel($row['code']) }}</span>
+                                        <em>{{ $pct }}% dari issue</em>
+                                    </div>
+                                    <strong>{{ number_format($row['total']) }}</strong>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </div>
+            </section>
         </div>
     </div>
+
+    @if ($selectedError)
+        <div class="admin-errors-modal" role="dialog" aria-modal="true" aria-labelledby="admin-error-detail-title">
+            <button type="button" class="admin-errors-modal__backdrop" wire:click="closeDetail" aria-label="Tutup detail error"></button>
+
+            <section class="admin-errors-modal__panel">
+                <header class="admin-errors-modal__header">
+                    <div>
+                        <p class="admin-errors-modal__eyebrow">Incident Detail</p>
+                        <h3 id="admin-error-detail-title">Detail Error</h3>
+                        <span class="admin-errors-modal__code">{{ $codeLabel($selectedError->error_code) }}</span>
+                    </div>
+                    <button type="button" wire:click="closeDetail" class="admin-errors-modal__close" aria-label="Tutup detail error">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M6 6l12 12M18 6L6 18"/>
+                        </svg>
+                    </button>
+                </header>
+
+                <div class="admin-errors-modal__body">
+                    <div class="admin-errors-modal__summary-grid">
+                        <div>
+                            <span>Severity</span>
+                            <strong class="admin-errors-severity admin-errors-severity--{{ $selectedError->getAttribute('severity_level') }}">
+                                {{ $selectedError->getAttribute('severity_label') }}
+                            </strong>
+                            <em>{{ $selectedError->getAttribute('severity_description') }}</em>
+                        </div>
+                        <div>
+                            <span>Trace</span>
+                            <strong class="admin-errors-modal__trace">{{ $selectedError->request_id ?? '-' }}</strong>
+                            <em>{{ $selectedError->created_at?->toDateTimeString() ?? '-' }}</em>
+                        </div>
+                        <div>
+                            <span>Fitur</span>
+                            <strong>{{ $featureLabel($selectedError->feature) }}</strong>
+                            <em>{{ ucfirst($selectedError->status) }} · {{ $selectedError->latency_ms !== null ? number_format($selectedError->latency_ms) . ' ms' : 'latensi belum ada' }}</em>
+                        </div>
+                        <div>
+                            <span>User</span>
+                            <strong>{{ $selectedError->user?->name ?? 'Sistem' }}</strong>
+                            <em>{{ $selectedError->user?->email ?? '-' }}</em>
+                        </div>
+                        <div>
+                            <span>Model</span>
+                            <strong>{{ $modelLabel($selectedError) }}</strong>
+                            <em>{{ data_get($selectedError->metadata, 'model_provider', '-') }}</em>
+                        </div>
+                    </div>
+
+                    <section class="admin-errors-modal__section">
+                        <h4>Ringkasan</h4>
+                        <p>{{ $selectedError->getAttribute('handling_summary') }}</p>
+                    </section>
+
+                    <section class="admin-errors-modal__section">
+                        <h4>Kemungkinan Penyebab</h4>
+                        <ul>
+                            @foreach ((array) $selectedError->getAttribute('handling_causes') as $cause)
+                                <li>{{ $cause }}</li>
+                            @endforeach
+                        </ul>
+                    </section>
+
+                    <section class="admin-errors-modal__section">
+                        <h4>Langkah Penanganan</h4>
+                        <ol>
+                            @foreach ((array) $selectedError->getAttribute('handling_steps') as $step)
+                                <li>{{ $step }}</li>
+                            @endforeach
+                        </ol>
+                    </section>
+
+                    <section class="admin-errors-modal__section">
+                        <h4>Metadata Aman</h4>
+                        @if (empty($selectedError->metadata))
+                            <p>Tidak ada metadata tambahan.</p>
+                        @else
+                            <dl class="admin-errors-modal__metadata">
+                                @foreach ($selectedError->metadata as $key => $value)
+                                    <div>
+                                        <dt>{{ strtoupper(str_replace('_', ' ', (string) $key)) }}</dt>
+                                        <dd>{{ $metadataValue($value) }}</dd>
+                                    </div>
+                                @endforeach
+                            </dl>
+                        @endif
+                    </section>
+                </div>
+            </section>
+        </div>
+    @endif
 </div>

--- a/laravel/resources/views/livewire/admin/admin-usage.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-usage.blade.php
@@ -1,153 +1,270 @@
-<div>
-    <div class="mb-6">
-        <div class="flex flex-wrap items-end justify-between gap-3">
-            <div class="max-w-2xl">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Monitoring</p>
-                <h2 class="admin-page-title mt-1">AI Usage Events</h2>
-                <p class="mt-2 text-sm leading-relaxed text-stone-500 dark:text-gray-400">
-                    Lihat event AI per fitur, status, dan rentang tanggal. Hanya metadata operasional yang ditampilkan.
-                </p>
-            </div>
-            <x-admin.badge tone="neutral">Read-only</x-admin.badge>
+@php
+    $formatInt = fn ($value): string => number_format((float) $value, 0, ',', '.');
+    $formatPct = function (int $value, int $total): string {
+        if ($total <= 0) {
+            return '0.0%';
+        }
+
+        return number_format(($value / $total) * 100, 1, '.', '') . '%';
+    };
+
+    $totalEvents = (int) ($totals['total'] ?? 0);
+    $successEvents = (int) ($totals['success'] ?? 0);
+    $pendingEvents = (int) ($totals['pending'] ?? 0);
+    $failedEvents = (int) ($totals['failed'] ?? 0);
+
+    $usageCards = [
+        [
+            'label' => 'Total Event',
+            'value' => $totalEvents,
+            'description' => 'Metadata event terfilter',
+            'tone' => 'primary',
+            'icon' => 'M4 19V10m5 9V5m5 14v-7m5 7V8M3 19h18',
+        ],
+        [
+            'label' => 'Sukses',
+            'value' => $successEvents,
+            'description' => $formatPct($successEvents, $totalEvents) . ' success rate',
+            'tone' => 'success',
+            'icon' => 'M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+        ],
+        [
+            'label' => 'Pending',
+            'value' => $pendingEvents,
+            'description' => $formatPct($pendingEvents, $totalEvents) . ' masih diproses',
+            'tone' => 'warning',
+            'icon' => 'M12 6v6l3 2M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+        ],
+        [
+            'label' => 'Gagal',
+            'value' => $failedEvents,
+            'description' => $formatPct($failedEvents, $totalEvents) . ' error / blocked',
+            'tone' => 'danger',
+            'icon' => 'M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z',
+        ],
+    ];
+
+    $featureLabel = fn (?string $feature): string => $featureOptions[$feature] ?? strtoupper(str_replace('_', '.', (string) ($feature ?: '—')));
+    $formatModelLabel = function ($event): array {
+        $metadata = is_array($event->metadata) ? $event->metadata : [];
+        $label = trim((string) ($metadata['model_label'] ?? $metadata['model_name'] ?? ''));
+        $name = trim((string) ($metadata['model_name'] ?? ''));
+        $provider = trim((string) ($metadata['model_provider'] ?? ''));
+
+        if ($label === '') {
+            return [
+                'label' => '-',
+                'title' => 'Model belum tercatat untuk event ini.',
+                'muted' => true,
+            ];
+        }
+
+        $titleParts = array_filter([
+            $name !== '' ? 'Model: ' . $name : null,
+            $provider !== '' ? 'Provider: ' . $provider : null,
+            $event->request_id ? 'Request ID: ' . $event->request_id : null,
+        ]);
+
+        return [
+            'label' => \Illuminate\Support\Str::limit($label, 22),
+            'title' => implode(' | ', $titleParts) ?: $label,
+            'muted' => false,
+        ];
+    };
+@endphp
+
+<div class="admin-usage-page">
+    <div class="admin-usage-hero">
+        <div class="max-w-2xl">
+            <p class="admin-usage-eyebrow">Monitoring</p>
+            <h2 class="admin-usage-title">Usage Events</h2>
+            <p class="admin-usage-description">
+                Pantau metadata event AI per fitur, status, dan rentang tanggal.
+            </p>
         </div>
+        <x-admin.badge tone="neutral" class="admin-usage-readonly">Read-only</x-admin.badge>
     </div>
 
-    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <x-admin.kpi-card label="Total Event" :value="number_format($totals['total'])" tone="primary" />
-        <x-admin.kpi-card label="Sukses" :value="number_format($totals['success'])" tone="success" />
-        <x-admin.kpi-card label="Pending" :value="number_format($totals['pending'])" tone="warning" />
-        <x-admin.kpi-card label="Gagal" :value="number_format($totals['failed'])" tone="danger" />
+    <div class="admin-usage-kpi-grid">
+        @foreach ($usageCards as $card)
+            <article class="admin-usage-kpi-card admin-usage-kpi-card--{{ $card['tone'] }}">
+                <div class="admin-usage-kpi-card__header">
+                    <span class="admin-usage-kpi-card__icon" aria-hidden="true">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="{{ $card['icon'] }}"/>
+                        </svg>
+                    </span>
+                    <p class="admin-usage-kpi-card__label">{{ $card['label'] }}</p>
+                </div>
+                <div class="admin-usage-kpi-card__body">
+                    <strong>{{ $formatInt($card['value']) }}</strong>
+                    <p class="admin-usage-kpi-card__description">{{ $card['description'] }}</p>
+                </div>
+            </article>
+        @endforeach
     </div>
 
-    <div class="mt-6">
-        <x-admin.section title="Filter">
-            <x-slot name="actions">
-                <button type="button" wire:click="resetFilters" class="text-[11px] font-semibold uppercase tracking-wider text-stone-500 transition hover:text-ista-primary dark:text-gray-400 dark:hover:text-amber-300">
+    <section class="admin-usage-filter-panel admin-section">
+        <div class="admin-usage-filter-panel__header">
+            <h3>Filter</h3>
+            <div class="admin-usage-reset-group">
+                <button type="button" wire:click="resetFilters" class="admin-usage-reset-button">
+                    <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M4 4v6h6M20 20v-6h-6M5.5 14a7 7 0 0012 3M18.5 10a7 7 0 00-12-3"/>
+                    </svg>
                     Reset
                 </button>
-            </x-slot>
-
-            <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                <label class="admin-filter">
-                    <span class="admin-filter__label">Fitur</span>
-                    <select wire:model.live="feature" class="admin-filter__control">
-                        <option value="">Semua</option>
-                        @foreach ($featureOptions as $key => $label)
-                            <option value="{{ $key }}">{{ $label }}</option>
-                        @endforeach
-                    </select>
-                </label>
-
-                <label class="admin-filter">
-                    <span class="admin-filter__label">Status</span>
-                    <select wire:model.live="status" class="admin-filter__control">
-                        <option value="">Semua</option>
-                        @foreach ($statusOptions as $key => $label)
-                            <option value="{{ $key }}">{{ $label }}</option>
-                        @endforeach
-                    </select>
-                </label>
-
-                <label class="admin-filter">
-                    <span class="admin-filter__label">Tanggal Mulai</span>
-                    <input type="date" wire:model.live="startDate" class="admin-filter__control" />
-                </label>
-
-                <label class="admin-filter">
-                    <span class="admin-filter__label">Tanggal Akhir</span>
-                    <input type="date" wire:model.live="endDate" class="admin-filter__control" />
-                </label>
             </div>
-        </x-admin.section>
-    </div>
+        </div>
 
-    <div class="mt-6 grid gap-4 lg:grid-cols-3">
-        <div class="lg:col-span-2">
-            <x-admin.section
-                title="Event Terbaru"
-                description="Maksimum {{ \App\Services\Admin\AdminMetricsService::RECENT_ROWS_LIMIT }} baris pada rentang yang dipilih.">
+        <div class="admin-usage-filter-grid">
+            <label class="admin-usage-filter">
+                <span>Fitur</span>
+                <select wire:model.live="feature" class="admin-usage-control">
+                    <option value="">Semua</option>
+                    @foreach ($featureOptions as $key => $label)
+                        <option value="{{ $key }}">{{ $label }}</option>
+                    @endforeach
+                </select>
+            </label>
+
+            <label class="admin-usage-filter">
+                <span>Status</span>
+                <select wire:model.live="status" class="admin-usage-control">
+                    <option value="">Semua</option>
+                    @foreach ($statusOptions as $key => $label)
+                        <option value="{{ $key }}">{{ $label }}</option>
+                    @endforeach
+                </select>
+            </label>
+
+            <label class="admin-usage-filter">
+                <span>Tanggal Mulai</span>
+                <input type="date" wire:model.live="startDate" class="admin-usage-control" />
+            </label>
+
+            <label class="admin-usage-filter">
+                <span>Tanggal Akhir</span>
+                <input type="date" wire:model.live="endDate" class="admin-usage-control" />
+            </label>
+        </div>
+    </section>
+
+    <div class="admin-usage-content-grid">
+        <section class="admin-usage-table-panel admin-section">
+            <header class="admin-usage-table-panel__header">
+                <div>
+                    <h3>Event Terbaru</h3>
+                    <p>Menampilkan {{ $eventsPerPage }} event per halaman pada filter aktif.</p>
+                </div>
+            </header>
+
+            <div class="admin-usage-table-panel__body">
                 @if ($events->isEmpty())
                     <x-admin.empty-state
                         title="Belum ada event"
                         description="Tidak ada event AI pada rentang dan filter saat ini." />
                 @else
-                    <x-admin.table :columns="[
-                        ['key' => 'user', 'label' => 'User'],
-                        ['key' => 'feature', 'label' => 'Fitur'],
-                        ['key' => 'action', 'label' => 'Action'],
-                        ['key' => 'status', 'label' => 'Status'],
-                        ['key' => 'latency', 'label' => 'Latensi', 'align' => 'right'],
-                        ['key' => 'request_id', 'label' => 'Request'],
-                        ['key' => 'time', 'label' => 'Waktu', 'align' => 'right'],
-                    ]">
+                    <x-admin.table
+                        class="admin-usage-table"
+                        :columns="[
+                            ['key' => 'user', 'label' => 'User', 'width' => '23%'],
+                            ['key' => 'feature', 'label' => 'Fitur', 'width' => '13%'],
+                            ['key' => 'action', 'label' => 'Action', 'width' => '12%'],
+                            ['key' => 'model', 'label' => 'Model', 'width' => '17%'],
+                            ['key' => 'status', 'label' => 'Status', 'width' => '11%'],
+                            ['key' => 'latency', 'label' => 'Latensi', 'align' => 'right', 'width' => '10%'],
+                            ['key' => 'time', 'label' => 'Waktu', 'align' => 'right', 'width' => '14%'],
+                        ]">
                         @foreach ($events as $event)
+                            @php
+                                $statusTone = match ($event->status) {
+                                    'success' => 'success',
+                                    'error', 'blocked' => 'danger',
+                                    'pending' => 'warning',
+                                    default => 'neutral',
+                                };
+                                $model = $formatModelLabel($event);
+                            @endphp
                             <tr>
                                 <td class="admin-table__td">
-                                    <div class="flex flex-col">
-                                        <span class="text-sm font-semibold text-stone-700 dark:text-gray-200">{{ $event->user?->name ?? 'Sistem' }}</span>
-                                        <span class="text-[11px] text-stone-400 dark:text-gray-500">{{ $event->user?->email ?? '—' }}</span>
+                                    <div class="admin-usage-user-cell">
+                                        <span class="admin-usage-user-cell__name">{{ $event->user?->name ?? 'Sistem' }}</span>
+                                        <span class="admin-usage-user-cell__email">{{ $event->user?->email ?? '—' }}</span>
                                     </div>
                                 </td>
                                 <td class="admin-table__td">
-                                    <span class="font-mono text-[11px] uppercase tracking-wider text-stone-500 dark:text-gray-400">{{ $event->feature }}</span>
+                                    <span class="admin-usage-feature">{{ $featureLabel($event->feature) }}</span>
                                 </td>
                                 <td class="admin-table__td">
-                                    <span class="font-mono text-[11px] uppercase tracking-wider text-stone-500 dark:text-gray-400">{{ $event->action }}</span>
+                                    <span class="admin-usage-feature">{{ strtoupper(str_replace('_', '.', $event->action)) }}</span>
                                 </td>
                                 <td class="admin-table__td">
-                                    @php
-                                        $tone = match ($event->status) {
-                                            'success' => 'success',
-                                            'error' => 'danger',
-                                            'pending' => 'warning',
-                                            'blocked' => 'danger',
-                                            default => 'neutral',
-                                        };
-                                    @endphp
-                                    <x-admin.badge :tone="$tone">{{ ucfirst($event->status) }}</x-admin.badge>
+                                    <span @class([
+                                        'admin-usage-model',
+                                        'admin-usage-model--muted' => $model['muted'],
+                                    ]) title="{{ $model['title'] }}">
+                                        {{ $model['label'] }}
+                                    </span>
+                                </td>
+                                <td class="admin-table__td">
+                                    <x-admin.badge :tone="$statusTone" class="admin-usage-status-badge">
+                                        {{ ucfirst($event->status) }}
+                                    </x-admin.badge>
                                 </td>
                                 <td class="admin-table__td" data-align="right">
-                                    <span class="font-mono text-xs text-stone-500 dark:text-gray-400">{{ $event->latency_ms !== null ? number_format($event->latency_ms) . ' ms' : '—' }}</span>
-                                </td>
-                                <td class="admin-table__td">
-                                    <code class="rounded bg-stone-100 px-2 py-0.5 font-mono text-[10px] text-stone-600 dark:bg-gray-800 dark:text-gray-300" title="{{ $event->request_id }}">{{ $event->request_id ?? '—' }}</code>
+                                    <span class="admin-usage-number">{{ $event->latency_ms !== null ? number_format($event->latency_ms) . ' ms' : '—' }}</span>
                                 </td>
                                 <td class="admin-table__td" data-align="right">
-                                    <span class="text-xs text-stone-500 dark:text-gray-400" title="{{ $event->created_at?->toDateTimeString() }}">{{ $event->created_at?->diffForHumans() }}</span>
+                                    <span class="admin-usage-muted" title="{{ $event->created_at?->toDateTimeString() }}">{{ $event->created_at?->diffForHumans() }}</span>
                                 </td>
                             </tr>
                         @endforeach
                     </x-admin.table>
-                @endif
-            </x-admin.section>
-        </div>
 
-        <x-admin.section
-            title="Distribusi Fitur"
-            description="Berdasarkan rentang yang dipilih.">
-            @if (empty($distribution))
-                <x-admin.empty-state title="Belum ada data" description="Tidak ada event pada rentang ini." />
-            @else
-                @php $totalDist = max(1, collect($distribution)->sum('total')); @endphp
-                <ul class="space-y-3 text-sm">
-                    @foreach ($distribution as $row)
-                        @php $pct = (int) round(($row['total'] / $totalDist) * 100); @endphp
-                        <li>
-                            <div class="flex items-center justify-between">
-                                <span class="font-mono text-[11px] uppercase tracking-wider text-stone-500 dark:text-gray-400">{{ $row['feature'] }}</span>
-                                <span class="text-xs font-semibold text-stone-700 dark:text-gray-200">{{ number_format($row['total']) }}</span>
-                            </div>
-                            <div class="mt-1 h-1.5 overflow-hidden rounded-full bg-stone-100 dark:bg-gray-800">
-                                <div class="h-full bg-ista-primary/80" style="width: {{ $pct }}%"></div>
-                            </div>
-                            <div class="mt-1 flex items-center justify-between text-[10px] uppercase tracking-wider text-stone-400 dark:text-gray-500">
-                                <span>Sukses {{ number_format($row['success']) }}</span>
-                                <span>Gagal {{ number_format($row['failed']) }}</span>
-                            </div>
-                        </li>
-                    @endforeach
-                </ul>
-            @endif
-        </x-admin.section>
+                    @if ($events->hasPages())
+                        <div class="admin-usage-pagination">
+                            {{ $events->links() }}
+                        </div>
+                    @endif
+                @endif
+            </div>
+        </section>
+
+        <section class="admin-usage-distribution-panel admin-section">
+            <header class="admin-usage-distribution-panel__header">
+                <div>
+                    <h3>Distribusi Fitur</h3>
+                    <p>Berdasarkan rentang yang dipilih.</p>
+                </div>
+            </header>
+
+            <div class="admin-usage-distribution-panel__body">
+                @if (empty($distribution))
+                    <x-admin.empty-state title="Belum ada data" description="Tidak ada event pada rentang ini." />
+                @else
+                    @php $totalDist = max(1, collect($distribution)->sum('total')); @endphp
+                    <ul class="admin-usage-distribution-list" role="list">
+                        @foreach ($distribution as $row)
+                            @php $pct = (int) round(($row['total'] / $totalDist) * 100); @endphp
+                            <li>
+                                <div class="admin-usage-distribution-list__top">
+                                    <span>{{ $featureLabel($row['feature']) }}</span>
+                                    <strong>{{ number_format($row['total']) }}</strong>
+                                </div>
+                                <div class="admin-usage-distribution-bar" aria-hidden="true">
+                                    <span style="width: {{ $pct }}%"></span>
+                                </div>
+                                <div class="admin-usage-distribution-list__meta">
+                                    <span>{{ $pct }}%</span>
+                                    <span>Sukses {{ number_format($row['success']) }}</span>
+                                    <span>Gagal {{ number_format($row['failed']) }}</span>
+                                </div>
+                            </li>
+                        @endforeach
+                    </ul>
+                @endif
+            </div>
+        </section>
     </div>
 </div>

--- a/laravel/resources/views/livewire/admin/admin-users.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-users.blade.php
@@ -1,36 +1,134 @@
-<div>
-    <div class="mb-6">
-        <div class="flex flex-wrap items-end justify-between gap-3">
-            <div class="max-w-2xl">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Monitoring</p>
-                <h2 class="admin-page-title mt-1">User & Presence</h2>
-                <p class="mt-2 text-sm leading-relaxed text-stone-500 dark:text-gray-400">
-                    Pantau status online/idle/offline user dan ringkasan aktivitas mereka. Halaman ini tidak menampilkan isi percakapan, dokumen, atau memo.
-                </p>
-            </div>
-            <x-admin.badge tone="neutral">Read-only</x-admin.badge>
+@php
+    $formatInt = fn ($value): string => number_format((float) $value, 0, ',', '.');
+    $formatPct = function (int $value, int $total): string {
+        if ($total <= 0) {
+            return '0.0%';
+        }
+
+        return number_format(($value / $total) * 100, 1, '.', '') . '%';
+    };
+
+    $totalUsers = (int) ($presenceSummary['total'] ?? 0);
+    $onlineUsers = (int) ($presenceSummary['online'] ?? 0);
+    $idleUsers = (int) ($presenceSummary['idle'] ?? 0);
+    $offlineUsers = (int) ($presenceSummary['offline'] ?? 0);
+
+    $presenceCards = [
+        [
+            'label' => 'Total User',
+            'value' => $totalUsers,
+            'description' => 'Semua user terdaftar',
+            'tone' => 'primary',
+            'icon' => 'M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87m6-5.13a4 4 0 11-8 0 4 4 0 018 0zm6 0a4 4 0 11-8 0 4 4 0 018 0z',
+        ],
+        [
+            'label' => 'Online',
+            'value' => $onlineUsers,
+            'description' => $formatPct($onlineUsers, $totalUsers) . ' dari total user',
+            'tone' => 'success',
+            'icon' => 'M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+        ],
+        [
+            'label' => 'Idle',
+            'value' => $idleUsers,
+            'description' => $formatPct($idleUsers, $totalUsers) . ' dari total user',
+            'tone' => 'warning',
+            'icon' => 'M12 6v6l3 2M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+        ],
+        [
+            'label' => 'Offline',
+            'value' => $offlineUsers,
+            'description' => $formatPct($offlineUsers, $totalUsers) . ' dari total user',
+            'tone' => 'neutral',
+            'icon' => 'M18.364 18.364A9 9 0 015.636 5.636m12.728 12.728A9 9 0 005.636 5.636m12.728 12.728L5.636 5.636',
+        ],
+    ];
+
+    $avatarInitials = function ($user): string {
+        $name = trim((string) ($user->name ?: $user->email ?: '?'));
+
+        if ($name === '') {
+            return '?';
+        }
+
+        if ($user->role === \App\Models\User::ROLE_SUPER_ADMIN) {
+            return strtoupper(substr($name, 0, 1));
+        }
+
+        $parts = preg_split('/\s+/', $name) ?: [];
+
+        if (count($parts) >= 2) {
+            return strtoupper(substr($parts[0], 0, 1) . substr($parts[1], 0, 1));
+        }
+
+        return strtoupper(substr($name, 0, 2));
+    };
+
+@endphp
+
+<div class="admin-users-page" wire:poll.30s>
+    <div class="admin-users-hero">
+        <div class="max-w-2xl">
+            <p class="admin-users-eyebrow">Monitoring</p>
+            <h2 class="admin-users-title">
+                User <span>&amp;</span> Presence
+            </h2>
+            <p class="admin-users-description">
+                Ringkasan status user tanpa membuka isi percakapan, dokumen, atau memo.
+            </p>
         </div>
+        <x-admin.badge tone="neutral" class="admin-users-readonly">Read-only</x-admin.badge>
     </div>
 
-    <x-admin.section title="Filter">
-        <x-slot name="actions">
-            <button type="button" wire:click="resetFilters" class="text-[11px] font-semibold uppercase tracking-wider text-stone-500 transition hover:text-ista-primary dark:text-gray-400 dark:hover:text-amber-300">
-                Reset
-            </button>
-        </x-slot>
+    <div class="admin-users-kpi-grid">
+        @foreach ($presenceCards as $card)
+            <article class="admin-users-kpi-card admin-users-kpi-card--{{ $card['tone'] }}">
+                <div class="admin-users-kpi-card__header">
+                    <span class="admin-users-kpi-card__icon" aria-hidden="true">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="{{ $card['icon'] }}"/>
+                        </svg>
+                    </span>
+                    <p class="admin-users-kpi-card__label">{{ $card['label'] }}</p>
+                </div>
+                <div class="admin-users-kpi-card__body">
+                    <strong>{{ $formatInt($card['value']) }}</strong>
+                    <p class="admin-users-kpi-card__description">{{ $card['description'] }}</p>
+                </div>
+            </article>
+        @endforeach
+    </div>
 
-        <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            <label class="admin-filter">
-                <span class="admin-filter__label">Cari</span>
-                <input type="search"
-                       wire:model.live.debounce.300ms="search"
-                       placeholder="Nama atau email…"
-                       class="admin-filter__control" />
+    <section class="admin-users-filter-panel admin-section">
+        <div class="admin-users-filter-panel__header">
+            <h3>Filter</h3>
+            <div class="admin-users-reset-group">
+                <button type="button" wire:click="resetFilters" class="admin-users-reset-button">
+                    <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M4 4v6h6M20 20v-6h-6M5.5 14a7 7 0 0012 3M18.5 10a7 7 0 00-12-3"/>
+                    </svg>
+                    Reset
+                </button>
+            </div>
+        </div>
+
+        <div class="admin-users-filter-grid">
+            <label class="admin-users-filter">
+                <span>Cari</span>
+                <div class="admin-users-search-control">
+                    <svg class="h-4 w-4 flex-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 21l-4.35-4.35m1.1-5.15a6.25 6.25 0 11-12.5 0 6.25 6.25 0 0112.5 0z" />
+                    </svg>
+                    <input type="search"
+                           wire:model.live.debounce.300ms="search"
+                           placeholder="Nama atau email..."
+                           class="admin-users-control admin-users-control--search" />
+                </div>
             </label>
 
-            <label class="admin-filter">
-                <span class="admin-filter__label">Status</span>
-                <select wire:model.live="status" class="admin-filter__control">
+            <label class="admin-users-filter">
+                <span>Status</span>
+                <select wire:model.live="status" class="admin-users-control">
                     <option value="">Semua</option>
                     @foreach ($statusOptions as $key => $label)
                         <option value="{{ $key }}">{{ $label }}</option>
@@ -38,9 +136,9 @@
                 </select>
             </label>
 
-            <label class="admin-filter">
-                <span class="admin-filter__label">Role</span>
-                <select wire:model.live="role" class="admin-filter__control">
+            <label class="admin-users-filter">
+                <span>Role</span>
+                <select wire:model.live="role" class="admin-users-control">
                     <option value="">Semua</option>
                     @foreach ($roleOptions as $key => $label)
                         <option value="{{ $key }}">{{ $label }}</option>
@@ -48,27 +146,34 @@
                 </select>
             </label>
         </div>
-    </x-admin.section>
+    </section>
 
-    <div class="mt-6">
-        <x-admin.section
-            title="Daftar User"
-            description="Maksimum {{ \App\Services\Admin\AdminMetricsService::RECENT_ROWS_LIMIT }} baris ditampilkan.">
+    <section class="admin-users-table-panel admin-section">
+        <header class="admin-users-table-panel__header">
+            <div>
+                <h3>Daftar User</h3>
+                <p>Menampilkan {{ $usersPerPage }} user per halaman.</p>
+            </div>
+        </header>
+
+        <div class="admin-users-table-panel__body">
             @if ($users->isEmpty())
                 <x-admin.empty-state
                     title="Tidak ada user"
                     description="Tidak ada user yang cocok dengan filter saat ini." />
             @else
-                <x-admin.table :columns="[
-                    ['key' => 'user', 'label' => 'User'],
-                    ['key' => 'role', 'label' => 'Role'],
-                    ['key' => 'status', 'label' => 'Status'],
-                    ['key' => 'last_seen', 'label' => 'Last Seen'],
-                    ['key' => 'last_feature', 'label' => 'Aktivitas Terakhir'],
-                    ['key' => 'events_today', 'label' => 'Event Hari Ini', 'align' => 'right'],
-                    ['key' => 'events_week', 'label' => 'Event 7 Hari', 'align' => 'right'],
-                    ['key' => 'totals', 'label' => 'Total', 'align' => 'right'],
-                ]">
+                <x-admin.table
+                    class="admin-users-table"
+                    :columns="[
+                        ['key' => 'user', 'label' => 'User', 'width' => '21%'],
+                        ['key' => 'role', 'label' => 'Role', 'width' => '9%'],
+                        ['key' => 'status', 'label' => 'Status', 'width' => '10%'],
+                        ['key' => 'last_seen', 'label' => 'Last Seen', 'width' => '11%'],
+                        ['key' => 'last_feature', 'label' => 'Aktivitas Terakhir', 'width' => '20%'],
+                        ['key' => 'events_today', 'label' => 'Event Hari Ini', 'align' => 'right', 'width' => '9%'],
+                        ['key' => 'events_week', 'label' => 'Event 7 Hari', 'align' => 'right', 'width' => '9%'],
+                        ['key' => 'totals', 'label' => 'Total', 'align' => 'right', 'width' => '11%'],
+                    ]">
                     @foreach ($users as $user)
                         @php
                             $statusKey = $user->getAttribute('presence_status') ?? 'offline';
@@ -77,54 +182,72 @@
                                 'idle' => 'warning',
                                 default => 'neutral',
                             };
+                            $roleTone = match ($user->role) {
+                                \App\Models\User::ROLE_SUPER_ADMIN => 'gold',
+                                \App\Models\User::ROLE_ADMIN => 'primary',
+                                default => 'neutral',
+                            };
+                            $lastFeature = $user->last_active_feature
+                                ? strtoupper(str_replace('_', '.', $user->last_active_feature))
+                                : '—';
                         @endphp
-                        <tr>
+                        <tr class="admin-users-table-row">
                             <td class="admin-table__td">
-                                <div class="flex flex-col">
-                                    <span class="text-sm font-semibold text-stone-700 dark:text-gray-200">{{ $user->name }}</span>
-                                    <span class="text-[11px] text-stone-400 dark:text-gray-500">{{ $user->email }}</span>
+                                <div class="admin-users-user-cell">
+                                    <span class="admin-user-avatar" aria-hidden="true">{{ $avatarInitials($user) }}</span>
+                                    <div class="min-w-0">
+                                        <span class="admin-users-user-cell__name">{{ $user->name }}</span>
+                                        <span class="admin-users-user-cell__email">{{ $user->email }}</span>
+                                    </div>
                                 </div>
                             </td>
                             <td class="admin-table__td">
-                                <x-admin.badge :tone="$user->role === 'super_admin' ? 'gold' : ($user->role === 'admin' ? 'primary' : 'neutral')">
+                                <x-admin.badge :tone="$roleTone">
                                     {{ $roleOptions[$user->role] ?? $user->role }}
                                 </x-admin.badge>
                             </td>
                             <td class="admin-table__td">
-                                <x-admin.badge :tone="$statusTone">
+                                <x-admin.badge :tone="$statusTone" class="admin-users-status-badge">
                                     <span @class([
-                                        'h-1.5 w-1.5 rounded-full',
-                                        'bg-emerald-500' => $statusKey === 'online',
-                                        'bg-amber-500' => $statusKey === 'idle',
-                                        'bg-stone-400' => $statusKey === 'offline',
+                                        'admin-users-status-dot',
+                                        'admin-users-status-dot--online' => $statusKey === 'online',
+                                        'admin-users-status-dot--idle' => $statusKey === 'idle',
+                                        'admin-users-status-dot--offline' => $statusKey === 'offline',
                                     ])></span>
                                     {{ ucfirst($statusKey) }}
                                 </x-admin.badge>
                             </td>
                             <td class="admin-table__td">
-                                <span class="text-xs text-stone-500 dark:text-gray-400" title="{{ $user->last_seen_at?->toDateTimeString() }}">
+                                <span class="admin-users-muted" title="{{ $user->last_seen_at?->toDateTimeString() }}">
                                     {{ $user->last_seen_at ? $user->last_seen_at->diffForHumans() : 'Belum pernah' }}
                                 </span>
                             </td>
                             <td class="admin-table__td">
-                                <span class="font-mono text-[11px] uppercase tracking-wider text-stone-500 dark:text-gray-400">{{ $user->last_active_feature ?? '—' }}</span>
+                                <span class="admin-users-feature">{{ $lastFeature }}</span>
                             </td>
                             <td class="admin-table__td" data-align="right">
-                                <span class="font-mono text-xs text-stone-700 dark:text-gray-200">{{ number_format($user->getAttribute('events_today') ?? 0) }}</span>
+                                <span class="admin-users-number">{{ number_format($user->getAttribute('events_today') ?? 0) }}</span>
                             </td>
                             <td class="admin-table__td" data-align="right">
-                                <span class="font-mono text-xs text-stone-500 dark:text-gray-400">{{ number_format($user->getAttribute('events_week') ?? 0) }}</span>
+                                <span class="admin-users-number">{{ number_format($user->getAttribute('events_week') ?? 0) }}</span>
                             </td>
                             <td class="admin-table__td" data-align="right">
-                                <div class="flex flex-col items-end text-[11px] text-stone-500 dark:text-gray-400">
-                                    <span>{{ number_format($user->getAttribute('conversation_count') ?? 0) }} conv</span>
-                                    <span>{{ number_format($user->getAttribute('document_count') ?? 0) }} doc · {{ number_format($user->getAttribute('memo_count') ?? 0) }} memo</span>
+                                <div class="admin-users-total-cell">
+                                    <span class="admin-users-total-cell__primary">{{ number_format($user->getAttribute('conversation_count') ?? 0) }} conv</span>
+                                    <span class="admin-users-total-cell__meta">{{ number_format($user->getAttribute('document_count') ?? 0) }} doc</span>
+                                    <span class="admin-users-total-cell__meta">{{ number_format($user->getAttribute('memo_count') ?? 0) }} memo</span>
                                 </div>
                             </td>
                         </tr>
                     @endforeach
                 </x-admin.table>
+
+                @if ($users->hasPages())
+                    <div class="admin-users-pagination">
+                        {{ $users->links() }}
+                    </div>
+                @endif
             @endif
-        </x-admin.section>
-    </div>
+        </div>
+    </section>
 </div>

--- a/laravel/resources/views/livewire/dashboard-nav-profile.blade.php
+++ b/laravel/resources/views/livewire/dashboard-nav-profile.blade.php
@@ -41,12 +41,8 @@ new class extends Component {
             <p class="truncate text-xs text-stone-500 dark:text-gray-400">{{ auth()->user()->email }}</p>
         </div>
 
-        <a href="{{ route('profile') }}" class="block px-4 py-2 text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-amber-300" role="menuitem">
-            Profil
-        </a>
-
         @if (auth()->user() && method_exists(auth()->user(), 'canAccessAdmin') && auth()->user()->canAccessAdmin())
-            <a href="{{ route('admin.dashboard') }}" class="flex items-center gap-2 border-t border-stone-100 px-4 py-2 text-sm font-medium text-ista-primary transition hover:bg-stone-50 dark:border-gray-800 dark:text-amber-300 dark:hover:bg-gray-800" role="menuitem">
+            <a href="{{ route('admin.dashboard') }}" class="flex items-center gap-2 px-4 py-2 text-sm font-medium text-ista-primary transition hover:bg-stone-50 dark:text-amber-300 dark:hover:bg-gray-800" role="menuitem">
                 <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
                 </svg>
@@ -54,7 +50,11 @@ new class extends Component {
             </a>
         @endif
 
-        <button wire:click="logout" class="block w-full px-4 py-2 text-left text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-amber-300" role="menuitem">
+        <a href="{{ route('profile') }}" class="block px-4 py-2 text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-amber-300" role="menuitem">
+            Profil
+        </a>
+
+        <button wire:click="logout" class="block w-full border-t border-stone-100 px-4 py-2 text-left text-sm text-stone-700 transition hover:bg-stone-50 hover:text-ista-primary dark:border-gray-800 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-amber-300" role="menuitem">
             Keluar
         </button>
     </div>

--- a/laravel/tests/Feature/Admin/AIUsageEventTrackingTest.php
+++ b/laravel/tests/Feature/Admin/AIUsageEventTrackingTest.php
@@ -79,6 +79,7 @@ class AIUsageEventTrackingTest extends TestCase
                 ?array $document_ids = null,
                 ?string $request_id = null,
             ): \Generator {
+                yield "[MODEL:GPT-4.1 (Primary)]\n";
                 yield 'OK';
             }
         });
@@ -128,6 +129,8 @@ class AIUsageEventTrackingTest extends TestCase
         $this->assertSame(AIUsageEvent::ACTION_STARTED, $events[0]->action);
         $this->assertSame(AIUsageEvent::ACTION_COMPLETED, $events[1]->action);
         $this->assertSame('stream', $events[1]->metadata['channel'] ?? null);
+        $this->assertSame('GPT-4.1 (Primary)', $events[1]->metadata['model_label'] ?? null);
+        $this->assertSame('openai/gpt-4.1', $events[1]->metadata['model_name'] ?? null);
         $this->assertSame((int) $conversation->id, (int) ($events[1]->metadata['conversation_id'] ?? 0));
     }
 
@@ -156,6 +159,7 @@ class AIUsageEventTrackingTest extends TestCase
                 ?array $document_ids = null,
                 ?string $request_id = null,
             ): \Generator {
+                yield "[MODEL:GPT-4o (Primary)]\n";
                 yield AIService::ERROR_SENTINEL.'AI tidak tersedia';
             }
         });
@@ -204,6 +208,7 @@ class AIUsageEventTrackingTest extends TestCase
         $this->assertSame(AIUsageEvent::ACTION_FAILED, $events[1]->action);
         $this->assertSame('error_sentinel', $events[1]->error_code);
         $this->assertSame('stream', $events[1]->metadata['channel'] ?? null);
+        $this->assertSame('GPT-4o (Primary)', $events[1]->metadata['model_label'] ?? null);
     }
 
     public function test_stream_controller_rejects_malformed_request_id_query_param(): void
@@ -383,6 +388,7 @@ class AIUsageEventTrackingTest extends TestCase
         {
             public function sendChat(array $messages, ?array $document_filenames = null, ?string $user_id = null, bool $force_web_search = false, ?string $source_policy = null, bool $allow_auto_realtime_web = true, ?array $document_ids = null, ?string $request_id = null): \Generator
             {
+                yield "[MODEL:GPT-4.1 Mini (Primary)]\n";
                 yield 'Halo juga ';
                 yield 'pengguna ';
             }
@@ -413,6 +419,8 @@ class AIUsageEventTrackingTest extends TestCase
         $this->assertNotNull($event);
         $this->assertSame(AIUsageEvent::STATUS_SUCCESS, $event->status);
         $this->assertNotNull($event->metadata['response_length'] ?? null);
+        $this->assertSame('GPT-4.1 Mini (Primary)', $event->metadata['model_label'] ?? null);
+        $this->assertSame('openai/gpt-4.1-mini', $event->metadata['model_name'] ?? null);
         $this->assertNotNull($event->subject_id);
         $this->assertSame(Message::class, $event->subject_type);
     }
@@ -434,6 +442,7 @@ class AIUsageEventTrackingTest extends TestCase
         {
             public function sendChat(array $messages, ?array $document_filenames = null, ?string $user_id = null, bool $force_web_search = false, ?string $source_policy = null, bool $allow_auto_realtime_web = true, ?array $document_ids = null, ?string $request_id = null): \Generator
             {
+                yield "[MODEL:Llama 3.3 70B (Groq)]\n";
                 yield AIService::ERROR_SENTINEL.'AI tidak tersedia';
             }
         });
@@ -461,6 +470,8 @@ class AIUsageEventTrackingTest extends TestCase
         $this->assertNotNull($event);
         $this->assertSame(AIUsageEvent::STATUS_ERROR, $event->status);
         $this->assertSame('error_sentinel', $event->error_code);
+        $this->assertSame('Llama 3.3 70B (Groq)', $event->metadata['model_label'] ?? null);
+        $this->assertSame('groq/llama-3.3-70b-versatile', $event->metadata['model_name'] ?? null);
     }
 
     public function test_document_upload_records_completed_event(): void

--- a/laravel/tests/Feature/Admin/AdminAccessTest.php
+++ b/laravel/tests/Feature/Admin/AdminAccessTest.php
@@ -75,6 +75,9 @@ class AdminAccessTest extends TestCase
         $response->assertStatus(200);
         $response->assertSee('AI Configuration', false);
         $response->assertSee('Akses terbatas', false);
+        $response->assertSee('Model Routing', false);
+        $response->assertSee('Prompt Profiles', false);
+        $response->assertDontSee('Placeholder', false);
     }
 
     public function test_unverified_user_is_redirected_for_admin_routes(): void

--- a/laravel/tests/Feature/Admin/AdminAccountManagementTest.php
+++ b/laravel/tests/Feature/Admin/AdminAccountManagementTest.php
@@ -26,6 +26,11 @@ class AdminAccountManagementTest extends TestCase
         $response->assertOk();
         $response->assertSee('Account Management');
         $response->assertSee('Daftar Akun Admin');
+        $response->assertSee('Super Admin Aktif');
+        $response->assertSee('admin-accounts-kpi-card__icon', false);
+        $response->assertDontSee('Ringkasan Keamanan');
+        $response->assertSee('Reset Password');
+        $response->assertSee('Menampilkan 15 akun per halaman');
     }
 
     public function test_admin_cannot_access_account_management_page(): void

--- a/laravel/tests/Feature/Admin/AdminLayoutTest.php
+++ b/laravel/tests/Feature/Admin/AdminLayoutTest.php
@@ -23,6 +23,7 @@ class AdminLayoutTest extends TestCase
         // Sidebar branding & nav.
         $response->assertSee('admin-sidebar', false);
         $response->assertSee('admin-nav-link', false);
+        $response->assertSee('admin-sidebar-profile-menu', false);
         $response->assertSee('Overview', false);
 
         // Topbar.
@@ -106,7 +107,7 @@ class AdminLayoutTest extends TestCase
         $response->assertSee('ista-shell', false);
     }
 
-    public function test_admin_layout_provides_link_back_to_chat(): void
+    public function test_admin_layout_provides_link_to_enter_chat(): void
     {
         $admin = User::factory()->create([
             'role' => User::ROLE_ADMIN,
@@ -116,6 +117,24 @@ class AdminLayoutTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSee(route('chat'), false);
-        $response->assertSee('Kembali ke Chat', false);
+        $response->assertSee('Masuk ke Chat', false);
+        $response->assertDontSee('Kembali ke Chat', false);
+        $response->assertDontSee('Logout', false);
+    }
+
+    public function test_ai_configuration_renders_consistent_admin_surface(): void
+    {
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+        ]);
+
+        $response = $this->actingAs($superAdmin)->get('/admin/ai-config');
+
+        $response->assertStatus(200);
+        $response->assertSee('admin-ai-config-page', false);
+        $response->assertSee('admin-ai-config-kpi-card', false);
+        $response->assertSee('admin-ai-config-kpi-card__icon', false);
+        $response->assertSee('Parameter Runtime', false);
+        $response->assertSee('Service Endpoints', false);
     }
 }

--- a/laravel/tests/Feature/Admin/AdminLoginTest.php
+++ b/laravel/tests/Feature/Admin/AdminLoginTest.php
@@ -18,7 +18,8 @@ class AdminLoginTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('Login Admin');
-        $response->assertSee('Admin Console');
+        $response->assertDontSee('Admin Console');
+        $response->assertSee('data-admin-theme-toggle', false);
         $response->assertDontSee('Daftar', false);
         $response->assertDontSee('Lupa Password', false);
         $response->assertDontSee('Guest Chat', false);

--- a/laravel/tests/Feature/Admin/AdminMonitoringDashboardTest.php
+++ b/laravel/tests/Feature/Admin/AdminMonitoringDashboardTest.php
@@ -2,11 +2,14 @@
 
 namespace Tests\Feature\Admin;
 
+use App\Livewire\Admin\AdminErrors;
+use App\Livewire\Admin\AdminDocuments;
 use App\Livewire\Admin\AdminUsage;
 use App\Livewire\Admin\AdminUsers;
 use App\Models\AIUsageEvent;
 use App\Models\Conversation;
 use App\Models\Document;
+use App\Models\DocumentChunk;
 use App\Models\Memo;
 use App\Models\Message;
 use App\Models\User;
@@ -41,12 +44,18 @@ class AdminMonitoringDashboardTest extends TestCase
         $response->assertOk();
         $response->assertSee('Ringkasan Operasional', false);
         $response->assertSee('Aktivitas Terbaru', false);
-        $response->assertSee('Distribusi Fitur', false);
-        $response->assertSee('Error Terbaru', false);
+        $response->assertSee('Insiden Terbaru', false);
+        $response->assertSee('Detail lengkap ada di tab Usage.', false);
+        $response->assertDontSee('Distribusi Fitur', false);
+        $response->assertDontSee('Error Terbaru', false);
         $response->assertSee('chat', false);
         $response->assertSee('document_rag', false);
         $response->assertSee('rag_timeout', false);
         $response->assertSee('admin-kpi', false);
+        $response->assertDontSee('Belum ada pembanding', false);
+        $response->assertSee('Terakhir diperbarui:', false);
+        $response->assertDontSee('↑ 18% dari kemarin', false);
+        $response->assertDontSee('↓ 33% dari 7 hari lalu', false);
 
         Carbon::setTestNow();
     }
@@ -76,7 +85,16 @@ class AdminMonitoringDashboardTest extends TestCase
 
         $response = $this->actingAs($admin)->get('/admin/users');
         $response->assertOk();
-        $response->assertSee('User & Presence', false);
+        $response->assertSeeText('User & Presence');
+        $response->assertDontSeeText('User dan Presence');
+        $response->assertSee('wire:poll.30s', false);
+        $response->assertSee('Ringkasan status user tanpa membuka isi percakapan', false);
+        $response->assertDontSee('Pantau status online/idle/offline user dan ringkasan aktivitas mereka.', false);
+        $response->assertSee('Menampilkan 15 user per halaman.', false);
+        $response->assertSee('Total User', false);
+        $response->assertSee('admin-users-kpi-card', false);
+        $response->assertSee('admin-users-kpi-card__icon', false);
+        $response->assertSee('admin-user-avatar', false);
         $response->assertSee('Admin Aktif', false);
         $response->assertSee('User Idle', false);
         $response->assertSee('User Offline', false);
@@ -122,15 +140,65 @@ class AdminMonitoringDashboardTest extends TestCase
         $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
         $user = User::factory()->create(['role' => User::ROLE_USER]);
 
-        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subHour(), 'req-chat');
-        $this->makeEvent($user->id, AIUsageEvent::FEATURE_DOCUMENT_RAG, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subMinutes(30), 'req-rag');
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subHour(), 'req-chat', null, null, [
+            'model_label' => 'GPT-4.1 (Primary)',
+            'model_name' => 'openai/gpt-4.1',
+            'model_provider' => 'github_models',
+        ]);
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_DOCUMENT_RAG, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subMinutes(30), 'req-rag', null, null, [
+            'model_label' => 'RAG Model',
+            'model_name' => 'internal/rag',
+            'model_provider' => 'internal',
+        ]);
 
         $this->actingAs($admin);
 
         Livewire::test(AdminUsage::class)
             ->set('feature', AIUsageEvent::FEATURE_CHAT)
-            ->assertSee('req-chat', false)
-            ->assertDontSee('req-rag', false);
+            ->assertSee('Usage Events')
+            ->assertSee('admin-usage-kpi-card', false)
+            ->assertSee('admin-usage-kpi-card__icon', false)
+            ->assertSee('Distribusi Fitur')
+            ->assertSee('Event Terbaru')
+            ->assertSee('Model')
+            ->assertSee('GPT-4.1 (Primary)', false)
+            ->assertDontSee('Detail')
+            ->assertDontSee('RAG Model', false);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_admin_usage_paginates_event_table_at_five_rows(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        for ($index = 1; $index <= 6; $index++) {
+            $rowUser = User::factory()->create([
+                'role' => User::ROLE_USER,
+                'email' => 'usage-row-' . $index . '@example.test',
+            ]);
+
+            $this->makeEvent(
+                $rowUser->id,
+                AIUsageEvent::FEATURE_CHAT,
+                AIUsageEvent::ACTION_COMPLETED,
+                AIUsageEvent::STATUS_SUCCESS,
+                $now->copy()->subMinutes($index),
+                'req-page-' . $index,
+            );
+        }
+
+        $this->actingAs($admin);
+
+        Livewire::test(AdminUsage::class)
+            ->assertSee('Menampilkan 5 event per halaman')
+            ->assertSee('usage-row-1@example.test', false)
+            ->assertDontSee('usage-row-6@example.test', false)
+            ->call('gotoPage', 2)
+            ->assertSee('usage-row-6@example.test', false)
+            ->assertDontSee('usage-row-1@example.test', false);
 
         Carbon::setTestNow();
     }
@@ -141,18 +209,25 @@ class AdminMonitoringDashboardTest extends TestCase
         Carbon::setTestNow($now);
 
         $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
-        $user = User::factory()->create(['role' => User::ROLE_USER]);
+        $includedUser = User::factory()->create([
+            'role' => User::ROLE_USER,
+            'email' => 'usage-end-day@example.test',
+        ]);
+        $excludedUser = User::factory()->create([
+            'role' => User::ROLE_USER,
+            'email' => 'usage-next-day@example.test',
+        ]);
 
-        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, Carbon::parse('2026-05-18 23:45:00'), 'req-end-day');
-        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, Carbon::parse('2026-05-19 00:01:00'), 'req-next-day');
+        $this->makeEvent($includedUser->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, Carbon::parse('2026-05-18 23:45:00'), 'req-end-day');
+        $this->makeEvent($excludedUser->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, Carbon::parse('2026-05-19 00:01:00'), 'req-next-day');
 
         $this->actingAs($admin);
 
         Livewire::test(AdminUsage::class)
             ->set('startDate', '2026-05-18')
             ->set('endDate', '2026-05-18')
-            ->assertSee('req-end-day', false)
-            ->assertDontSee('req-next-day', false);
+            ->assertSee('usage-end-day@example.test', false)
+            ->assertDontSee('usage-next-day@example.test', false);
 
         Carbon::setTestNow();
     }
@@ -166,12 +241,90 @@ class AdminMonitoringDashboardTest extends TestCase
         $user = User::factory()->create(['role' => User::ROLE_USER]);
 
         $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subHour(), 'req-success');
-        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_FAILED, AIUsageEvent::STATUS_ERROR, $now->copy()->subMinutes(30), 'req-fail', null, 'rate_limited');
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_FAILED, AIUsageEvent::STATUS_ERROR, $now->copy()->subMinutes(30), 'req-fail', null, 'error_sentinel', [
+            'model_label' => 'GPT-4o (Primary)',
+            'model_name' => 'openai/gpt-4o',
+            'model_provider' => 'github_models',
+        ]);
 
         $response = $this->actingAs($admin)->get('/admin/errors');
         $response->assertOk();
-        $response->assertSee('rate_limited', false);
+        $response->assertSee('Error Operasional', false);
+        $response->assertSee('admin-errors-kpi-card', false);
+        $response->assertSee('admin-errors-kpi-card__icon', false);
+        $response->assertSee('Menampilkan 5 error per halaman', false);
+        $response->assertSee('ERROR SENTINEL', false);
+        $response->assertSee('Severity', false);
+        $response->assertSee('High', false);
+        $response->assertSee('Detail', false);
         $response->assertDontSee('req-success', false);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_admin_errors_detail_modal_shows_guidance_and_safe_metadata(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $user = User::factory()->create(['role' => User::ROLE_USER]);
+
+        $event = $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_FAILED, AIUsageEvent::STATUS_ERROR, $now->copy()->subMinutes(10), 'req-detail', 1200, 'error_sentinel', [
+            'conversation_id' => 99,
+            'channel' => 'stream',
+            'model_label' => 'GPT-4o (Primary)',
+            'model_name' => 'openai/gpt-4o',
+            'model_provider' => 'github_models',
+        ]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(AdminErrors::class)
+            ->call('showDetail', $event->id)
+            ->assertSee('Detail Error')
+            ->assertSee('Langkah Penanganan')
+            ->assertSee('Kemungkinan Penyebab')
+            ->assertSee('GPT-4o (Primary)', false)
+            ->assertSee('req-detail', false)
+            ->assertSee('Cari request ID di log Laravel dan Python AI.');
+
+        Carbon::setTestNow();
+    }
+
+    public function test_admin_errors_paginates_error_table_at_five_rows(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        for ($index = 1; $index <= 6; $index++) {
+            $rowUser = User::factory()->create([
+                'role' => User::ROLE_USER,
+                'email' => 'error-row-' . $index . '@example.test',
+            ]);
+
+            $this->makeEvent(
+                $rowUser->id,
+                AIUsageEvent::FEATURE_CHAT,
+                AIUsageEvent::ACTION_FAILED,
+                AIUsageEvent::STATUS_ERROR,
+                $now->copy()->subMinutes($index),
+                'req-error-' . $index,
+                null,
+                'error_code_' . $index,
+            );
+        }
+
+        $this->actingAs($admin);
+
+        Livewire::test(AdminErrors::class)
+            ->assertSee('Menampilkan 5 error per halaman')
+            ->assertSee('error-row-1@example.test', false)
+            ->assertDontSee('error-row-6@example.test', false)
+            ->call('gotoPage', 2)
+            ->assertSee('error-row-6@example.test', false)
+            ->assertDontSee('error-row-1@example.test', false);
 
         Carbon::setTestNow();
     }
@@ -204,10 +357,170 @@ class AdminMonitoringDashboardTest extends TestCase
         $response = $this->actingAs($admin)->get('/admin/documents');
         $response->assertOk();
         $response->assertSee('Dokumen User', false);
+        $response->assertSee('admin-documents-kpi-card', false);
+        $response->assertSee('admin-documents-kpi-card__icon', false);
+        $response->assertSee('Menampilkan 10 dokumen per halaman', false);
+        $response->assertSee('Distribusi Tipe', false);
+        $response->assertSee('Status Pipeline', false);
+        $response->assertSee('PDF', false);
+        $response->assertSee('Pipeline Dokumen', false);
+        $response->assertSee('Detail', false);
         $response->assertSee('a.pdf', false);
         $response->assertSee('b.pdf', false);
         $response->assertSee('Ready', false);
-        $response->assertSee('Error', false);
+        $response->assertSee('Failed', false);
+    }
+
+    public function test_admin_documents_filters_by_type_owner_and_date(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $includedOwner = User::factory()->create([
+            'role' => User::ROLE_USER,
+            'email' => 'included-owner@example.test',
+        ]);
+        $otherOwner = User::factory()->create([
+            'role' => User::ROLE_USER,
+            'email' => 'other-owner@example.test',
+        ]);
+
+        $included = Document::create([
+            'user_id' => $includedOwner->id,
+            'filename' => 'finance.csv',
+            'original_name' => 'finance.csv',
+            'file_path' => 'docs/finance.csv',
+            'status' => 'ready',
+            'mime_type' => 'text/csv',
+            'file_size_bytes' => 1024,
+        ]);
+        $included->timestamps = false;
+        $included->created_at = Carbon::parse('2026-05-18 09:00:00');
+        $included->updated_at = Carbon::parse('2026-05-18 09:00:00');
+        $included->save();
+
+        $excludedByType = Document::create([
+            'user_id' => $includedOwner->id,
+            'filename' => 'finance.pdf',
+            'original_name' => 'finance.pdf',
+            'file_path' => 'docs/finance.pdf',
+            'status' => 'ready',
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 2048,
+        ]);
+        $excludedByType->timestamps = false;
+        $excludedByType->created_at = Carbon::parse('2026-05-18 10:00:00');
+        $excludedByType->updated_at = Carbon::parse('2026-05-18 10:00:00');
+        $excludedByType->save();
+
+        $excludedByOwner = Document::create([
+            'user_id' => $otherOwner->id,
+            'filename' => 'other.csv',
+            'original_name' => 'other.csv',
+            'file_path' => 'docs/other.csv',
+            'status' => 'ready',
+            'mime_type' => 'text/csv',
+            'file_size_bytes' => 1024,
+        ]);
+        $excludedByOwner->timestamps = false;
+        $excludedByOwner->created_at = Carbon::parse('2026-05-18 11:00:00');
+        $excludedByOwner->updated_at = Carbon::parse('2026-05-18 11:00:00');
+        $excludedByOwner->save();
+
+        $this->actingAs($admin);
+
+        Livewire::test(AdminDocuments::class)
+            ->set('type', 'csv')
+            ->set('ownerId', (string) $includedOwner->id)
+            ->set('startDate', '2026-05-18')
+            ->set('endDate', '2026-05-18')
+            ->assertSee('finance.csv', false)
+            ->assertDontSee('finance.pdf', false)
+            ->assertDontSee('other.csv', false);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_admin_documents_detail_drawer_shows_pipeline_metadata(): void
+    {
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $owner = User::factory()->create(['role' => User::ROLE_USER]);
+
+        $document = Document::create([
+            'user_id' => $owner->id,
+            'filename' => 'ai-policy.pdf',
+            'original_name' => 'ai-policy.pdf',
+            'file_path' => 'docs/ai-policy.pdf',
+            'status' => 'ready',
+            'preview_status' => Document::PREVIEW_STATUS_READY,
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 4096,
+            'source_provider' => 'google_drive',
+            'source_external_id' => 'drive-document-id',
+            'source_synced_at' => Carbon::parse('2026-05-18 08:00:00'),
+        ]);
+
+        DocumentChunk::create([
+            'document_id' => $document->id,
+            'page_number' => 1,
+            'text_content' => 'Hidden chunk content must not be rendered.',
+        ]);
+        DocumentChunk::create([
+            'document_id' => $document->id,
+            'page_number' => 2,
+            'text_content' => 'Another hidden chunk.',
+        ]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(AdminDocuments::class)
+            ->call('showDetail', $document->id)
+            ->assertSee('Document Pipeline')
+            ->assertSee('AI Index Metadata')
+            ->assertSee('Chunk Count')
+            ->assertSee('2')
+            ->assertSee('Indexed')
+            ->assertSee('GOOGLE DRIVE', false)
+            ->assertDontSee('Hidden chunk content must not be rendered.', false);
+    }
+
+    public function test_admin_documents_paginates_document_table_at_ten_rows(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $owner = User::factory()->create(['role' => User::ROLE_USER]);
+
+        for ($index = 1; $index <= 11; $index++) {
+            $document = Document::create([
+                'user_id' => $owner->id,
+                'filename' => 'document-row-' . $index . '.pdf',
+                'original_name' => 'document-row-' . $index . '.pdf',
+                'file_path' => 'docs/document-row-' . $index . '.pdf',
+                'status' => 'ready',
+                'mime_type' => 'application/pdf',
+                'file_size_bytes' => 1024,
+            ]);
+
+            $document->timestamps = false;
+            $document->created_at = $now->copy()->subMinutes($index);
+            $document->updated_at = $now->copy()->subMinutes($index);
+            $document->save();
+        }
+
+        $this->actingAs($admin);
+
+        Livewire::test(AdminDocuments::class)
+            ->assertSee('Menampilkan 10 dokumen per halaman')
+            ->assertSee('document-row-1.pdf', false)
+            ->assertDontSee('document-row-11.pdf', false)
+            ->call('gotoPage', 2)
+            ->assertSee('document-row-11.pdf', false)
+            ->assertDontSee('document-row-1.pdf', false);
+
+        Carbon::setTestNow();
     }
 
     public function test_regular_user_cannot_access_monitoring_pages(): void
@@ -283,6 +596,7 @@ class AdminMonitoringDashboardTest extends TestCase
         $response->assertOk();
         $response->assertSee(route('admin.users'), false);
         $response->assertSee(route('admin.usage'), false);
+        $response->assertSee('M4 19V10m5 9V5m5 14v-7m5 7V8M3 19h18', false);
         $response->assertSee(route('admin.errors'), false);
         $response->assertSee(route('admin.documents'), false);
     }
@@ -296,12 +610,12 @@ class AdminMonitoringDashboardTest extends TestCase
         // values rather than passing them into Carbon::parse().
         $response = $this->actingAs($admin)->get('/admin/usage?startDate=not-a-date&endDate=also-bad');
         $response->assertOk();
-        $response->assertSee('AI Usage Events', false);
+        $response->assertSee('Usage Events', false);
 
         // Empty values must also be tolerated.
         $response = $this->actingAs($admin)->get('/admin/usage?startDate=&endDate=');
         $response->assertOk();
-        $response->assertSee('AI Usage Events', false);
+        $response->assertSee('Usage Events', false);
     }
 
     public function test_admin_usage_livewire_component_handles_invalid_date_input(): void
@@ -313,10 +627,10 @@ class AdminMonitoringDashboardTest extends TestCase
             ->set('startDate', 'banana')
             ->set('endDate', 'pineapple')
             ->assertOk()
-            ->assertSee('AI Usage Events');
+            ->assertSee('Usage Events');
     }
 
-    private function makeEvent(int $userId, string $feature, string $action, string $status, Carbon $createdAt, ?string $requestId = null, ?int $latencyMs = null, ?string $errorCode = null): AIUsageEvent
+    private function makeEvent(int $userId, string $feature, string $action, string $status, Carbon $createdAt, ?string $requestId = null, ?int $latencyMs = null, ?string $errorCode = null, ?array $metadata = null): AIUsageEvent
     {
         $event = new AIUsageEvent([
             'user_id' => $userId,
@@ -326,6 +640,7 @@ class AdminMonitoringDashboardTest extends TestCase
             'request_id' => $requestId,
             'latency_ms' => $latencyMs,
             'error_code' => $errorCode,
+            'metadata' => $metadata,
         ]);
         $event->timestamps = false;
         $event->created_at = $createdAt;

--- a/laravel/tests/Unit/Services/Admin/AIUsageEventServiceTest.php
+++ b/laravel/tests/Unit/Services/Admin/AIUsageEventServiceTest.php
@@ -148,6 +148,18 @@ class AIUsageEventServiceTest extends TestCase
         $this->assertLessThanOrEqual(AIUsageEventService::MAX_LIST_ITEMS, count($clean['document_ids']));
     }
 
+    public function test_model_metadata_is_allowed_and_inferred_from_stream_label(): void
+    {
+        $service = app(AIUsageEventService::class);
+
+        $metadata = $service->modelMetadata('GPT-4.1 Mini (Primary)');
+        $clean = $service->sanitizeMetadata($metadata);
+
+        $this->assertSame('GPT-4.1 Mini (Primary)', $clean['model_label']);
+        $this->assertSame('openai/gpt-4.1-mini', $clean['model_name']);
+        $this->assertSame('github_models', $clean['model_provider']);
+    }
+
     public function test_record_is_best_effort_when_database_throws(): void
     {
         Log::spy();

--- a/laravel/tests/Unit/Services/Admin/AdminMetricsServiceTest.php
+++ b/laravel/tests/Unit/Services/Admin/AdminMetricsServiceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Services\Admin;
 use App\Models\AIUsageEvent;
 use App\Models\Conversation;
 use App\Models\Document;
+use App\Models\DocumentChunk;
 use App\Models\Memo;
 use App\Models\Message;
 use App\Models\User;
@@ -124,7 +125,103 @@ class AdminMetricsServiceTest extends TestCase
         Carbon::setTestNow();
     }
 
-    private function makeEvent(int $userId, string $feature, string $action, string $status, Carbon $createdAt, ?int $latencyMs = null, ?string $errorCode = null): AIUsageEvent
+    public function test_overview_comparisons_use_real_previous_periods(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        $user = User::factory()->create();
+
+        // Today: 4 requests, 3 successes, 1 failure, avg latency 2s.
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subHours(3), 1000);
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subHours(2), 2000);
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_DOCUMENT_RAG, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subHour(), 3000);
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_FAILED, AIUsageEvent::STATUS_ERROR, $now->copy()->subMinutes(30));
+
+        // Yesterday: 2 requests, 1 success, 1 failure, avg latency 4s.
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subDay()->setTime(10, 0), 4000);
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_FAILED, AIUsageEvent::STATUS_ERROR, $now->copy()->subDay()->setTime(11, 0));
+
+        // Previous 7-day window: 8 requests, 4 failures.
+        foreach ([8, 9, 10, 11] as $daysAgo) {
+            $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_FAILED, AIUsageEvent::STATUS_ERROR, $now->copy()->subDays($daysAgo));
+            $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subDays($daysAgo), 5000);
+        }
+
+        $comparisons = $this->metrics->overviewComparisons($now);
+
+        $this->assertTrue($comparisons['ai_requests']['has_comparison']);
+        $this->assertSame(4, $comparisons['ai_requests']['current']);
+        $this->assertSame(2, $comparisons['ai_requests']['previous']);
+        $this->assertSame('up', $comparisons['ai_requests']['direction']);
+        $this->assertSame('success', $comparisons['ai_requests']['tone']);
+        $this->assertEqualsWithDelta(100.0, $comparisons['ai_requests']['delta_percent'], 0.001);
+
+        $this->assertEqualsWithDelta(75.0, $comparisons['success_rate']['current'], 0.001);
+        $this->assertEqualsWithDelta(50.0, $comparisons['success_rate']['previous'], 0.001);
+        $this->assertEqualsWithDelta(25.0, $comparisons['success_rate']['delta'], 0.001);
+        $this->assertSame('success', $comparisons['success_rate']['tone']);
+
+        $this->assertSame(2000, $comparisons['avg_latency_ms']['current']);
+        $this->assertSame(4000, $comparisons['avg_latency_ms']['previous']);
+        $this->assertSame('down', $comparisons['avg_latency_ms']['direction']);
+        $this->assertSame('success', $comparisons['avg_latency_ms']['tone']);
+
+        $this->assertEqualsWithDelta(25.0, $comparisons['error_rate']['current'], 0.001);
+        $this->assertEqualsWithDelta(50.0, $comparisons['error_rate']['previous'], 0.001);
+        $this->assertSame('down', $comparisons['error_rate']['direction']);
+        $this->assertSame('success', $comparisons['error_rate']['tone']);
+
+        $this->assertSame(2, $comparisons['errors_7d']['current']);
+        $this->assertSame(4, $comparisons['errors_7d']['previous']);
+        $this->assertSame('down', $comparisons['errors_7d']['direction']);
+        $this->assertEqualsWithDelta(-50.0, $comparisons['errors_7d']['delta_percent'], 0.001);
+
+        $this->assertEqualsWithDelta(33.333, $comparisons['error_rate_7d']['current'], 0.01);
+        $this->assertEqualsWithDelta(50.0, $comparisons['error_rate_7d']['previous'], 0.001);
+        $this->assertSame('success', $comparisons['error_rate_7d']['tone']);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_overview_comparisons_do_not_fake_trends_without_previous_data(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        $user = User::factory()->create();
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subHour(), 1000);
+
+        $comparisons = $this->metrics->overviewComparisons($now);
+
+        $this->assertFalse($comparisons['ai_requests']['has_comparison']);
+        $this->assertSame('none', $comparisons['ai_requests']['direction']);
+        $this->assertNull($comparisons['ai_requests']['delta_percent']);
+        $this->assertFalse($comparisons['avg_latency_ms']['has_comparison']);
+        $this->assertFalse($comparisons['errors_7d']['has_comparison']);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_last_overview_activity_uses_operational_data_not_dashboard_render_time(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        $user = User::factory()->create(['last_seen_at' => $now]);
+        $this->assertNull($this->metrics->lastOverviewActivityAt());
+
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subMinutes(20));
+
+        $this->assertSame(
+            $now->copy()->subMinutes(20)->toDateTimeString(),
+            $this->metrics->lastOverviewActivityAt()?->toDateTimeString(),
+        );
+
+        Carbon::setTestNow();
+    }
+
+    private function makeEvent(int $userId, string $feature, string $action, string $status, Carbon $createdAt, ?int $latencyMs = null, ?string $errorCode = null, ?array $metadata = null): AIUsageEvent
     {
         $event = new AIUsageEvent([
             'user_id' => $userId,
@@ -133,6 +230,7 @@ class AdminMetricsServiceTest extends TestCase
             'status' => $status,
             'latency_ms' => $latencyMs,
             'error_code' => $errorCode,
+            'metadata' => $metadata,
         ]);
         $event->timestamps = false;
         $event->created_at = $createdAt;
@@ -161,6 +259,28 @@ class AdminMetricsServiceTest extends TestCase
         $this->assertSame('idle', $this->metrics->presenceStatus($idle, $now));
         $this->assertSame('offline', $this->metrics->presenceStatus($offline, $now));
         $this->assertSame('offline', $this->metrics->presenceStatus($never, $now));
+    }
+
+    public function test_user_presence_summary_returns_presence_counts(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        User::factory()->create(['last_seen_at' => $now->copy()->subSeconds(30)]);
+        User::factory()->create(['last_seen_at' => $now->copy()->subMinutes(8)]);
+        User::factory()->create(['last_seen_at' => $now->copy()->subDay()]);
+        User::factory()->create(['last_seen_at' => null]);
+
+        $summary = $this->metrics->userPresenceSummary($now);
+
+        $this->assertSame([
+            'total' => 4,
+            'online' => 1,
+            'idle' => 1,
+            'offline' => 2,
+        ], $summary);
+
+        Carbon::setTestNow();
     }
 
     public function test_daily_activity_series_returns_window_with_zeroed_days(): void
@@ -205,6 +325,122 @@ class AdminMetricsServiceTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_error_event_summary_counts_filtered_failed_and_blocked_events(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        $user = User::factory()->create();
+
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_FAILED, AIUsageEvent::STATUS_ERROR, $now->copy()->subMinutes(30), null, 'rate_limited');
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_FAILED, AIUsageEvent::STATUS_BLOCKED, $now->copy()->subMinutes(20));
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_DOCUMENT_RAG, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subMinutes(10));
+
+        $summary = $this->metrics->errorEventSummary([
+            'feature' => AIUsageEvent::FEATURE_CHAT,
+        ]);
+
+        $this->assertSame(2, $summary['total']);
+        $this->assertSame(1, $summary['error']);
+        $this->assertSame(1, $summary['blocked']);
+        $this->assertSame(2, $summary['unique_codes']);
+        $this->assertSame($now->copy()->subMinutes(20)->toDateTimeString(), $summary['latest_at']?->toDateTimeString());
+        $this->assertSame(AIUsageEvent::FEATURE_CHAT, $summary['by_feature'][0]['feature']);
+        $this->assertSame(2, $summary['by_feature'][0]['total']);
+        $this->assertContains('rate_limited', collect($summary['by_code'])->pluck('code')->all());
+        $this->assertContains('unknown_error', collect($summary['by_code'])->pluck('code')->all());
+
+        Carbon::setTestNow();
+    }
+
+    public function test_error_events_listing_paginates_failed_and_blocked_events(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        $user = User::factory()->create();
+
+        for ($index = 1; $index <= 6; $index++) {
+            $this->makeEvent(
+                $user->id,
+                AIUsageEvent::FEATURE_CHAT,
+                AIUsageEvent::ACTION_FAILED,
+                AIUsageEvent::STATUS_ERROR,
+                $now->copy()->subMinutes($index),
+            );
+        }
+
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now);
+
+        $firstPage = $this->metrics->errorEventsListing([], 5, 1);
+        $secondPage = $this->metrics->errorEventsListing([], 5, 2);
+
+        $this->assertSame(6, $firstPage->total());
+        $this->assertSame(5, $firstPage->count());
+        $this->assertTrue($firstPage->hasPages());
+        $this->assertSame(1, $secondPage->count());
+        $this->assertSame(AIUsageEvent::STATUS_ERROR, $firstPage->first()->status);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_error_severity_and_guidance_are_derived_from_error_code(): void
+    {
+        $user = User::factory()->create();
+
+        $event = $this->makeEvent(
+            $user->id,
+            AIUsageEvent::FEATURE_CHAT,
+            AIUsageEvent::ACTION_FAILED,
+            AIUsageEvent::STATUS_ERROR,
+            Carbon::parse('2026-05-18 12:00:00'),
+            null,
+            'error_sentinel',
+            [
+                'model_label' => 'GPT-4o (Primary)',
+                'model_name' => 'openai/gpt-4o',
+            ],
+        );
+
+        $severity = $this->metrics->errorSeverity($event);
+        $guidance = $this->metrics->errorHandlingGuidance($event);
+        $detail = $this->metrics->errorEventDetail($event->id);
+
+        $this->assertSame('high', $severity['level']);
+        $this->assertSame('High', $severity['label']);
+        $this->assertStringContainsString('sentinel', $guidance['summary']);
+        $this->assertNotEmpty($guidance['steps']);
+        $this->assertSame('High', $detail?->getAttribute('severity_label'));
+        $this->assertSame('GPT-4o (Primary)', $detail?->metadata['model_label'] ?? null);
+    }
+
+    public function test_usage_event_summary_counts_filtered_statuses(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        $user = User::factory()->create();
+
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subHours(1));
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_STARTED, AIUsageEvent::STATUS_PENDING, $now->copy()->subMinutes(50));
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_FAILED, AIUsageEvent::STATUS_ERROR, $now->copy()->subMinutes(40));
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_CHAT, AIUsageEvent::ACTION_FAILED, AIUsageEvent::STATUS_BLOCKED, $now->copy()->subMinutes(30));
+        $this->makeEvent($user->id, AIUsageEvent::FEATURE_DOCUMENT_RAG, AIUsageEvent::ACTION_COMPLETED, AIUsageEvent::STATUS_SUCCESS, $now->copy()->subMinutes(20));
+
+        $summary = $this->metrics->usageEventSummary([
+            'feature' => AIUsageEvent::FEATURE_CHAT,
+        ]);
+
+        $this->assertSame([
+            'total' => 4,
+            'success' => 1,
+            'pending' => 1,
+            'failed' => 2,
+        ], $summary);
+
+        Carbon::setTestNow();
+    }
+
     public function test_recent_events_end_date_filter_includes_the_full_selected_day(): void
     {
         $now = Carbon::parse('2026-05-20 12:00:00');
@@ -222,6 +458,38 @@ class AdminMetricsServiceTest extends TestCase
 
         $this->assertCount(1, $rows);
         $this->assertSame('2026-05-18 23:59:59', $rows->first()->created_at->toDateTimeString());
+
+        Carbon::setTestNow();
+    }
+
+    public function test_usage_events_listing_paginates_recent_events(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        $user = User::factory()->create();
+
+        for ($index = 1; $index <= 6; $index++) {
+            $this->makeEvent(
+                $user->id,
+                AIUsageEvent::FEATURE_CHAT,
+                AIUsageEvent::ACTION_COMPLETED,
+                AIUsageEvent::STATUS_SUCCESS,
+                $now->copy()->subMinutes($index),
+            );
+        }
+
+        $firstPage = $this->metrics->usageEventsListing([], 5, 1);
+        $secondPage = $this->metrics->usageEventsListing([], 5, 2);
+
+        $this->assertSame(6, $firstPage->total());
+        $this->assertSame(5, $firstPage->count());
+        $this->assertTrue($firstPage->hasPages());
+        $this->assertSame(1, $secondPage->count());
+        $this->assertSame(
+            $now->copy()->subMinute()->toDateTimeString(),
+            $firstPage->first()->created_at->toDateTimeString(),
+        );
 
         Carbon::setTestNow();
     }
@@ -251,11 +519,34 @@ class AdminMetricsServiceTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_user_presence_listing_paginates_user_rows(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        for ($index = 1; $index <= 16; $index++) {
+            User::factory()->create([
+                'name' => sprintf('Paginated User %02d', $index),
+                'last_seen_at' => $now->copy()->subMinutes($index + 20),
+            ]);
+        }
+
+        $firstPage = $this->metrics->userPresenceListing([], 15, $now, 1);
+        $secondPage = $this->metrics->userPresenceListing([], 15, $now, 2);
+
+        $this->assertSame(16, $firstPage->total());
+        $this->assertSame(15, $firstPage->count());
+        $this->assertTrue($firstPage->hasPages());
+        $this->assertSame(1, $secondPage->count());
+
+        Carbon::setTestNow();
+    }
+
     public function test_document_listing_returns_status_counts(): void
     {
         $user = User::factory()->create();
 
-        Document::create([
+        $readyDocument = Document::create([
             'user_id' => $user->id,
             'filename' => 'a.pdf',
             'original_name' => 'a.pdf',
@@ -263,6 +554,12 @@ class AdminMetricsServiceTest extends TestCase
             'status' => 'ready',
             'mime_type' => 'application/pdf',
             'file_size_bytes' => 1024,
+        ]);
+
+        DocumentChunk::create([
+            'document_id' => $readyDocument->id,
+            'page_number' => 1,
+            'text_content' => 'Internal chunk text.',
         ]);
 
         Document::create([
@@ -281,5 +578,14 @@ class AdminMetricsServiceTest extends TestCase
         $this->assertSame(1, $payload['status_counts']['error'] ?? 0);
         $this->assertSame(3072, $payload['total_size_bytes']);
         $this->assertSame(2, $payload['rows']->count());
+
+        $readyPayload = $this->metrics->documentListing([
+            'status' => 'ready',
+            'type' => 'pdf',
+            'user_id' => $user->id,
+        ]);
+
+        $this->assertSame(1, $readyPayload['rows']->count());
+        $this->assertSame(1, $readyPayload['rows']->getCollection()->first()->chunks_count);
     }
 }


### PR DESCRIPTION
## Summary
- Refresh admin overview, users, usage, errors, documents, account management, and AI configuration pages with the finalized ISTA admin style.
- Wire dynamic admin metrics for presence, usage model metadata, error severity/detail guidance, document pipeline state, and paginated admin tables.
- Add/adjust admin feature and service tests for the redesigned monitoring surfaces.

## Verification
- `cd laravel && php artisan test tests/Feature/Admin/AdminMonitoringDashboardTest.php tests/Feature/Admin/AdminAccountManagementTest.php tests/Feature/Admin/AdminLayoutTest.php tests/Feature/Admin/AdminLoginTest.php tests/Feature/Admin/AIUsageEventTrackingTest.php tests/Unit/Services/Admin/AdminMetricsServiceTest.php tests/Unit/Services/Admin/AIUsageEventServiceTest.php`
- `cd laravel && npm run build`
- `git diff --check origin/main...HEAD`
- `cd laravel && php -d memory_limit=-1 vendor/bin/phpunit`
- `cd python-ai && source venv/bin/activate && pytest`