### PR TITLE
[codex] Fix production migration deploy command

### DIFF
--- a/docs/deploy-digitalocean-checklist-demo.md
+++ b/docs/deploy-digitalocean-checklist-demo.md
@@ -76,8 +76,8 @@ docker compose --env-file .env.droplet -f docker-compose.production.yml up -d --
 
 ```bash
 cd /opt/ista-ai
-docker compose --env-file .env.droplet -f docker-compose.production.yml run --rm artisan migrate --force
-docker compose --env-file .env.droplet -f docker-compose.production.yml restart laravel horizon
+docker compose --env-file .env.droplet -f docker-compose.production.yml exec -T laravel php artisan migrate --force
+docker compose --env-file .env.droplet -f docker-compose.production.yml restart laravel horizon scheduler
 ```
 
 ## 7. Cek Status Container
@@ -149,8 +149,8 @@ Update berikutnya cukup:
 cd /opt/ista-ai
 git pull origin main
 docker compose --env-file .env.droplet -f docker-compose.production.yml up -d --build
-docker compose --env-file .env.droplet -f docker-compose.production.yml run --rm artisan migrate --force
-docker compose --env-file .env.droplet -f docker-compose.production.yml restart laravel horizon
+docker compose --env-file .env.droplet -f docker-compose.production.yml exec -T laravel php artisan migrate --force
+docker compose --env-file .env.droplet -f docker-compose.production.yml restart laravel horizon scheduler
 ```
 
 ## Catatan

--- a/docs/deploy-digitalocean.md
+++ b/docs/deploy-digitalocean.md
@@ -107,7 +107,7 @@ docker compose --env-file .env.droplet -f docker-compose.production.yml ps
 ## 7. Jalankan Migrasi
 
 ```bash
-docker compose --env-file .env.droplet -f docker-compose.production.yml run --rm artisan migrate --force
+docker compose --env-file .env.droplet -f docker-compose.production.yml exec -T laravel php artisan migrate --force
 ```
 
 Jika Anda butuh akun awal atau data dummy, jalankan seed secara terpisah sesuai kebutuhan aplikasi.
@@ -115,7 +115,7 @@ Jika Anda butuh akun awal atau data dummy, jalankan seed secara terpisah sesuai 
 ## 8. Restart Aplikasi Setelah Migrasi Pertama
 
 ```bash
-docker compose --env-file .env.droplet -f docker-compose.production.yml restart laravel horizon
+docker compose --env-file .env.droplet -f docker-compose.production.yml restart laravel horizon scheduler
 ```
 
 ## 9. Verifikasi Deploy
@@ -177,8 +177,8 @@ docker compose --env-file .env.droplet -f docker-compose.production.yml logs -f
 cd /opt/ista-ai
 git pull origin main
 docker compose --env-file .env.droplet -f docker-compose.production.yml up -d --build
-docker compose --env-file .env.droplet -f docker-compose.production.yml run --rm artisan migrate --force
-docker compose --env-file .env.droplet -f docker-compose.production.yml restart laravel horizon
+docker compose --env-file .env.droplet -f docker-compose.production.yml exec -T laravel php artisan migrate --force
+docker compose --env-file .env.droplet -f docker-compose.production.yml restart laravel horizon scheduler
 ```
 
 ## 12. Backup Minimum

--- a/docs/production-config-guide.md
+++ b/docs/production-config-guide.md
@@ -90,8 +90,10 @@ Gunakan `--env-file .env.droplet` agar variable interpolation seperti `ONLYOFFIC
 ```bash
 docker compose --env-file .env.droplet -f docker-compose.production.yml ps
 docker compose --env-file .env.droplet -f docker-compose.production.yml up -d --build
-docker compose --env-file .env.droplet -f docker-compose.production.yml run --rm artisan migrate --force
+docker compose --env-file .env.droplet -f docker-compose.production.yml exec -T laravel php artisan migrate --force
 ```
+
+Jalankan migration dari service `laravel` yang aktif karena service profile `artisan` tidak selalu ikut rebuild saat `up -d --build`.
 
 ## Checklist Sebelum Deploy Config
 


### PR DESCRIPTION
## Summary
- Update production deploy docs to run migrations from the rebuilt `laravel` container.
- Restart scheduler together with Laravel and Horizon after production deploys.
- Document why the profile-only `artisan` service should not be the default migration path.

## Verification
- `git diff --check`
- Verified the corrected command in production with `docker compose exec -T laravel php artisan migrate --force` and `migrate:status`.