### PR TITLE
Polish admin documents and knowledge UI

### DIFF
--- a/issue/issue-admin-documents-knowledge-production-hotfix-2026-05-19.md
+++ b/issue/issue-admin-documents-knowledge-production-hotfix-2026-05-19.md
@@ -1,0 +1,34 @@
+# Issue: Admin Documents & Knowledge production hotfix
+
+## Tujuan
+- Rapikan tabel `/admin/documents` agar mengikuti contoh: kolom file, user, tipe, size, status, chunks, waktu, aksi.
+- Hilangkan kolom pipeline dari tabel dokumen dan pindahkan konteks pipeline ke detail modal yang lebih ringkas.
+- Ubah detail dokumen dari drawer ramai menjadi modal yang serasi dengan modal detail error.
+- Selaraskan tampilan `/admin/knowledge` dengan tab admin lain.
+
+## Scope
+- Blade admin documents dan knowledge.
+- CSS admin documents/knowledge.
+- Test feature admin yang memverifikasi copy, kolom, modal, dan konsistensi class.
+
+## Di luar scope
+- Mengubah pipeline ingest dokumen atau knowledge.
+- Mengubah isi data production.
+- Menambahkan fitur retrieval knowledge baru.
+
+## Risiko
+- Table overflow pada viewport sempit.
+- Modal bisa terlalu padat jika metadata panjang.
+- Knowledge action buttons tetap harus aman dan tidak berubah perilaku.
+
+## Verifikasi
+- Targeted Laravel admin tests.
+- `npm run build`.
+- `git diff --check`.
+- Setelah merge, deploy production dan smoke check `/up`, `/admin/login`, `/admin/documents`, `/admin/knowledge`.
+
+## Catatan implementasi
+- Tabel documents dibuat full-width agar kolom file, user, tipe, size, status, chunks, waktu, dan aksi tidak sesak.
+- Kolom pipeline dihapus dari tabel; status pipeline tetap tersedia di konteks panel samping dan detail modal ringkas.
+- Detail dokumen diubah menjadi modal centered yang mengikuti pola modal detail error.
+- Knowledge dipoles menjadi layout admin konsisten: hero, KPI cards, filter, tabel, upload, dan status panel.

--- a/laravel/resources/css/app.css
+++ b/laravel/resources/css/app.css
@@ -909,11 +909,11 @@
     }
 
     .admin-documents-content-grid {
-        @apply mt-3 grid gap-3 xl:grid-cols-[minmax(0,1.85fr)_minmax(18rem,0.7fr)];
+        @apply mt-3 grid gap-3;
     }
 
     .admin-documents-side-grid {
-        @apply grid gap-3 content-start;
+        @apply grid gap-3 content-start lg:grid-cols-2;
     }
 
     .admin-documents-table-panel,
@@ -947,36 +947,74 @@
     }
 
     .admin-documents-file-cell {
-        @apply flex min-w-[12rem] items-center gap-2.5;
+        @apply flex min-w-[10rem] items-center gap-3;
+    }
+
+    .admin-documents-user-row {
+        @apply flex min-w-[9rem] items-center gap-2.5;
+    }
+
+    .admin-documents-avatar {
+        @apply inline-flex h-8 w-8 flex-none items-center justify-center rounded-full bg-ista-primary text-[0.64rem] font-bold text-amber-200 ring-2 ring-white dark:bg-rose-900 dark:text-amber-200 dark:ring-gray-900;
+        letter-spacing: 0;
     }
 
     .admin-documents-user-cell {
-        @apply flex min-w-[9rem] flex-col;
+        @apply flex min-w-0 flex-col;
     }
 
     .admin-documents-file-icon {
-        @apply inline-flex h-8 w-8 flex-none items-center justify-center rounded-lg font-mono text-[0.58rem] font-bold ring-1;
+        @apply relative inline-flex h-9 w-8 flex-none items-center justify-center font-mono text-[0.52rem] font-black;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-file-icon svg {
+        @apply absolute inset-0 h-full w-full;
+    }
+
+    .admin-documents-file-icon > span {
+        @apply absolute bottom-1 left-1/2 z-10 -translate-x-1/2 rounded-[0.16rem] px-0.5 py-px text-[0.43rem] font-black leading-none text-white shadow-sm;
         letter-spacing: 0;
     }
 
     .admin-documents-file-icon--pdf {
-        @apply bg-rose-50 text-rose-600 ring-rose-100 dark:bg-rose-500/10 dark:text-rose-300 dark:ring-rose-400/20;
+        @apply text-red-500 dark:text-red-300;
+    }
+
+    .admin-documents-file-icon--pdf > span {
+        @apply bg-red-600 dark:bg-red-500;
     }
 
     .admin-documents-file-icon--csv {
-        @apply bg-emerald-50 text-emerald-700 ring-emerald-100 dark:bg-emerald-400/10 dark:text-emerald-300 dark:ring-emerald-300/20;
+        @apply text-emerald-600 dark:text-emerald-300;
+    }
+
+    .admin-documents-file-icon--csv > span {
+        @apply bg-emerald-700 dark:bg-emerald-500;
     }
 
     .admin-documents-file-icon--xlsx {
-        @apply bg-teal-50 text-teal-700 ring-teal-100 dark:bg-teal-400/10 dark:text-teal-300 dark:ring-teal-300/20;
+        @apply text-green-700 dark:text-green-300;
+    }
+
+    .admin-documents-file-icon--xlsx > span {
+        @apply bg-green-700 dark:bg-green-500;
     }
 
     .admin-documents-file-icon--docx {
-        @apply bg-sky-50 text-sky-700 ring-sky-100 dark:bg-sky-400/10 dark:text-sky-300 dark:ring-sky-300/20;
+        @apply text-sky-600 dark:text-sky-300;
+    }
+
+    .admin-documents-file-icon--docx > span {
+        @apply bg-sky-600 dark:bg-sky-500;
     }
 
     .admin-documents-file-icon--file {
-        @apply bg-stone-100 text-stone-600 ring-stone-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700;
+        @apply text-stone-500 dark:text-gray-300;
+    }
+
+    .admin-documents-file-icon--file > span {
+        @apply bg-stone-600 dark:bg-gray-500;
     }
 
     .admin-documents-file-cell__name,
@@ -989,26 +1027,43 @@
         @apply block truncate text-[0.68rem] text-stone-500 dark:text-gray-500;
     }
 
-    .admin-documents-status-chip {
-        @apply inline-flex min-w-[4.6rem] items-center justify-center rounded-full px-2 py-0.5 text-[0.64rem] font-bold uppercase ring-1;
+    .admin-documents-type-label {
+        @apply font-mono text-[0.68rem] font-medium uppercase text-stone-500 dark:text-gray-400;
         letter-spacing: 0;
+    }
+
+    .admin-documents-status-chip {
+        @apply inline-flex min-w-[4.8rem] items-center justify-center gap-1.5 rounded-full px-2 py-1 text-[0.64rem] font-bold ring-1;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-status-chip > span {
+        @apply h-1.5 w-1.5 rounded-full;
     }
 
     .admin-documents-status-chip--success {
         @apply bg-emerald-50 text-emerald-700 ring-emerald-100 dark:bg-emerald-400/10 dark:text-emerald-300 dark:ring-emerald-300/20;
     }
 
+    .admin-documents-status-chip--success > span { @apply bg-emerald-500; }
+
     .admin-documents-status-chip--warning {
         @apply bg-amber-50 text-amber-700 ring-amber-100 dark:bg-amber-400/10 dark:text-amber-300 dark:ring-amber-300/20;
     }
+
+    .admin-documents-status-chip--warning > span { @apply bg-amber-500; }
 
     .admin-documents-status-chip--danger {
         @apply bg-rose-50 text-rose-700 ring-rose-100 dark:bg-rose-500/10 dark:text-rose-300 dark:ring-rose-400/20;
     }
 
+    .admin-documents-status-chip--danger > span { @apply bg-rose-500; }
+
     .admin-documents-status-chip--neutral {
         @apply bg-stone-100 text-stone-600 ring-stone-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700;
     }
+
+    .admin-documents-status-chip--neutral > span { @apply bg-stone-400; }
 
     .admin-documents-number {
         @apply whitespace-nowrap font-mono text-[0.72rem] font-medium text-stone-800 dark:text-gray-200;
@@ -1049,11 +1104,15 @@
     }
 
     .admin-documents-detail-button {
-        @apply inline-flex h-7 items-center justify-center rounded-md border border-stone-200 bg-white px-2.5 text-[0.68rem] font-semibold text-stone-700 transition hover:border-ista-primary/30 hover:text-ista-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-200 dark:hover:border-amber-300/30 dark:hover:text-amber-300;
+        @apply inline-flex h-7 items-center justify-center gap-1.5 rounded-md border border-stone-200 bg-white px-2.5 text-[0.68rem] font-semibold text-stone-700 transition hover:border-ista-primary/30 hover:text-ista-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-200 dark:hover:border-amber-300/30 dark:hover:text-amber-300;
+    }
+
+    .admin-documents-table-footer {
+        @apply flex flex-wrap items-center justify-center gap-3 border-t border-stone-100 px-3 py-3 text-center text-[0.74rem] text-stone-500 dark:border-gray-800 dark:text-gray-400;
     }
 
     .admin-documents-pagination {
-        @apply mt-3 border-t border-stone-100 pt-3 dark:border-gray-800;
+        @apply w-full;
     }
 
     .admin-documents-distribution-list {
@@ -1120,6 +1179,107 @@
     .admin-documents-status-dot--warning { @apply bg-amber-500; }
     .admin-documents-status-dot--danger { @apply bg-rose-500; }
     .admin-documents-status-dot--neutral { @apply bg-stone-400 dark:bg-gray-500; }
+
+    .admin-documents-modal {
+        @apply fixed inset-0 z-50 flex items-center justify-center p-4;
+    }
+
+    .admin-documents-modal__backdrop {
+        @apply absolute inset-0 bg-stone-950/35 backdrop-blur-sm dark:bg-black/60;
+    }
+
+    .admin-documents-modal__panel {
+        @apply relative flex max-h-[86vh] w-full max-w-4xl flex-col overflow-hidden rounded-xl border border-stone-200 bg-white shadow-[0_24px_80px_rgba(28,25,23,0.24)] dark:border-gray-800 dark:bg-gray-950;
+    }
+
+    .admin-documents-modal__header {
+        @apply flex flex-none items-start justify-between gap-4 border-b border-stone-100 px-5 py-4 dark:border-gray-800;
+    }
+
+    .admin-documents-modal__title-row {
+        @apply flex min-w-0 items-center gap-3;
+    }
+
+    .admin-documents-modal__eyebrow {
+        @apply text-[0.6rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-modal__header h3 {
+        @apply mt-1 truncate text-lg font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-documents-modal__code {
+        @apply mt-2 inline-block rounded-md bg-stone-50 px-2 py-0.5 font-mono text-[0.68rem] font-semibold uppercase text-stone-600 ring-1 ring-stone-100 dark:bg-gray-900 dark:text-gray-300 dark:ring-gray-800;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-modal__close {
+        @apply inline-flex h-8 w-8 flex-none items-center justify-center rounded-lg text-stone-500 transition hover:bg-stone-100 hover:text-stone-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-gray-100;
+    }
+
+    .admin-documents-modal__body {
+        @apply min-h-0 flex-1 overflow-y-auto px-5 pb-5 pt-4;
+    }
+
+    .admin-documents-modal__summary-grid {
+        @apply grid gap-3 md:grid-cols-2 xl:grid-cols-3;
+    }
+
+    .admin-documents-modal__summary-grid > div {
+        @apply rounded-lg border border-stone-100 bg-stone-50/50 p-3 dark:border-gray-800 dark:bg-gray-900/50;
+    }
+
+    .admin-documents-modal__summary-grid span,
+    .admin-documents-modal__metadata dt {
+        @apply block text-[0.6rem] font-bold uppercase text-stone-400 dark:text-gray-500;
+        letter-spacing: 0;
+    }
+
+    .admin-documents-modal__summary-grid strong {
+        @apply mt-1 block truncate text-xs font-semibold text-stone-900 dark:text-gray-100;
+    }
+
+    .admin-documents-modal__summary-grid strong.admin-documents-status-chip {
+        @apply inline-flex;
+    }
+
+    .admin-documents-modal__summary-grid em {
+        @apply mt-1 block truncate text-[0.68rem] not-italic text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-documents-modal__section {
+        @apply mt-4 rounded-lg border border-stone-100 bg-white p-3.5 dark:border-gray-800 dark:bg-gray-900/40;
+    }
+
+    .admin-documents-modal__section-heading {
+        @apply flex items-center justify-between gap-3;
+    }
+
+    .admin-documents-modal__section h4 {
+        @apply text-[0.82rem] font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-documents-modal__section-heading span {
+        @apply text-xs font-semibold text-stone-500 dark:text-gray-400;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-documents-modal__section p {
+        @apply mt-2 text-[0.76rem] leading-relaxed text-stone-600 dark:text-gray-300;
+    }
+
+    .admin-documents-modal__metadata {
+        @apply mt-2 grid gap-2 md:grid-cols-2;
+    }
+
+    .admin-documents-modal__metadata div {
+        @apply min-w-0 rounded-md bg-stone-50 px-2.5 py-2 dark:bg-gray-950/70;
+    }
+
+    .admin-documents-modal__metadata dd {
+        @apply mt-1 truncate font-mono text-[0.68rem] text-stone-700 dark:text-gray-300;
+    }
 
     .admin-documents-drawer {
         @apply fixed inset-0 z-50 flex justify-end;
@@ -1235,6 +1395,215 @@
 
     .admin-documents-metadata-grid dd {
         @apply mt-1 break-words text-[0.74rem] font-semibold text-stone-700 dark:text-gray-200;
+    }
+
+    .admin-knowledge-page {
+        @apply pb-6 text-stone-900 dark:text-gray-100;
+    }
+
+    .admin-knowledge-hero {
+        @apply mb-4 flex flex-wrap items-start justify-between gap-4;
+    }
+
+    .admin-knowledge-eyebrow {
+        @apply text-[0.64rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-knowledge-title {
+        font-family: "Fraunces", serif;
+        @apply mt-1 text-[1.38rem] font-semibold leading-tight text-stone-950 dark:text-gray-100;
+        letter-spacing: 0;
+    }
+
+    .admin-knowledge-description {
+        @apply mt-2 max-w-xl text-[0.82rem] leading-relaxed text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-knowledge-readonly {
+        @apply px-3.5 py-1.5 text-[0.72rem] font-medium;
+    }
+
+    .admin-knowledge-alert {
+        @apply mb-4 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800 dark:border-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200;
+    }
+
+    .admin-knowledge-kpi-grid {
+        @apply grid gap-3 sm:grid-cols-2 xl:grid-cols-4;
+    }
+
+    .admin-knowledge-kpi-card {
+        @apply block min-h-[5.75rem] overflow-hidden rounded-lg border border-stone-200/80 bg-white p-0 shadow-[0_8px_24px_rgba(28,25,23,0.04)] transition-colors dark:border-gray-800 dark:bg-gray-900/80;
+    }
+
+    .admin-knowledge-kpi-card__header {
+        @apply flex items-center gap-2.5 border-b border-stone-200/80 px-4 py-2.5 text-ista-primary dark:border-gray-800 dark:text-amber-300;
+    }
+
+    .admin-knowledge-kpi-card__icon {
+        @apply inline-flex h-4 w-4 flex-none items-center justify-center;
+    }
+
+    .admin-knowledge-kpi-card__label {
+        @apply truncate text-[0.72rem] font-bold uppercase text-ista-primary dark:text-amber-300;
+        letter-spacing: 0;
+    }
+
+    .admin-knowledge-kpi-card__body {
+        @apply min-w-0 px-4 py-3;
+    }
+
+    .admin-knowledge-kpi-card__body strong {
+        @apply block text-2xl font-semibold leading-none text-stone-950 dark:text-gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-knowledge-kpi-card__description {
+        @apply mt-1.5 text-[0.7rem] font-medium text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-knowledge-kpi-card--success .admin-knowledge-kpi-card__description { @apply text-emerald-600 dark:text-emerald-400; }
+    .admin-knowledge-kpi-card--warning .admin-knowledge-kpi-card__description { @apply text-amber-600 dark:text-amber-400; }
+    .admin-knowledge-kpi-card--danger .admin-knowledge-kpi-card__description { @apply text-rose-600 dark:text-rose-400; }
+
+    .admin-knowledge-content-grid {
+        @apply mt-3 grid gap-3 xl:grid-cols-[minmax(0,1.72fr)_minmax(18rem,0.72fr)];
+    }
+
+    .admin-knowledge-main-stack,
+    .admin-knowledge-side-grid {
+        @apply grid content-start gap-3;
+    }
+
+    .admin-knowledge-filter-panel,
+    .admin-knowledge-table-panel,
+    .admin-knowledge-upload-panel,
+    .admin-knowledge-status-panel {
+        @apply overflow-hidden rounded-lg;
+    }
+
+    .admin-knowledge-filter-panel__header,
+    .admin-knowledge-table-panel__header,
+    .admin-knowledge-upload-panel__header,
+    .admin-knowledge-status-panel__header {
+        @apply flex flex-wrap items-start justify-between gap-3 px-4 pt-3.5;
+    }
+
+    .admin-knowledge-filter-panel__header h3,
+    .admin-knowledge-table-panel__header h3,
+    .admin-knowledge-upload-panel__header h3,
+    .admin-knowledge-status-panel__header h3 {
+        @apply text-[0.95rem] font-semibold text-stone-950 dark:text-gray-100;
+    }
+
+    .admin-knowledge-table-panel__header p,
+    .admin-knowledge-upload-panel__header p,
+    .admin-knowledge-status-panel__header p {
+        @apply mt-1 text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-knowledge-reset-button {
+        @apply inline-flex items-center gap-1.5 text-[0.72rem] font-semibold text-ista-primary transition hover:text-rose-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/30 dark:text-rose-300 dark:hover:text-rose-200;
+    }
+
+    .admin-knowledge-filter-grid {
+        @apply grid gap-3 px-4 pb-3.5 pt-3 md:grid-cols-3;
+    }
+
+    .admin-knowledge-filter {
+        @apply flex flex-col gap-1.5;
+    }
+
+    .admin-knowledge-filter span {
+        @apply text-[0.6rem] font-bold uppercase text-stone-500 dark:text-gray-400;
+        letter-spacing: 0;
+    }
+
+    .admin-knowledge-control {
+        @apply h-9 w-full rounded-lg border border-stone-200 bg-white px-3 text-xs text-stone-800 shadow-[inset_0_1px_0_rgba(28,25,23,0.02)] transition placeholder:text-stone-400 focus:border-ista-primary focus:outline-none focus:ring-2 focus:ring-ista-primary/15 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500;
+    }
+
+    .admin-knowledge-control--textarea {
+        @apply min-h-20 py-2;
+    }
+
+    .admin-knowledge-control--file {
+        @apply h-auto py-2;
+    }
+
+    .admin-knowledge-table-panel__body,
+    .admin-knowledge-status-panel__body {
+        @apply px-3.5 pb-3.5 pt-3;
+    }
+
+    .admin-knowledge-table {
+        @apply rounded-lg;
+    }
+
+    .admin-knowledge-table .admin-table__th {
+        @apply bg-white px-3 py-2.5 text-[0.61rem] text-stone-500 dark:bg-gray-900/80 dark:text-gray-400;
+    }
+
+    .admin-knowledge-table .admin-table__td {
+        @apply px-3 py-2;
+    }
+
+    .admin-knowledge-table tbody tr {
+        @apply transition hover:bg-stone-50/80 dark:hover:bg-gray-800/50;
+    }
+
+    .admin-knowledge-file-name {
+        @apply block truncate text-xs font-semibold text-stone-800 dark:text-gray-100;
+    }
+
+    .admin-knowledge-file-meta {
+        @apply block truncate text-[0.68rem] text-stone-500 dark:text-gray-500;
+    }
+
+    .admin-knowledge-source {
+        @apply inline-flex max-w-[9rem] truncate rounded-md bg-stone-50 px-2 py-1 text-[0.68rem] font-semibold text-stone-600 ring-1 ring-stone-100 dark:bg-gray-950 dark:text-gray-300 dark:ring-gray-800;
+    }
+
+    .admin-knowledge-error-code,
+    .admin-knowledge-error {
+        @apply text-[0.66rem] font-medium text-rose-500 dark:text-rose-300;
+    }
+
+    .admin-knowledge-error-code {
+        @apply mt-1;
+    }
+
+    .admin-knowledge-action-group {
+        @apply flex flex-wrap items-center justify-end gap-1.5;
+    }
+
+    .admin-knowledge-action {
+        @apply inline-flex h-7 items-center justify-center rounded-md border border-stone-200 bg-white px-2 text-[0.64rem] font-semibold text-stone-600 transition hover:border-ista-primary/30 hover:text-ista-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-300 dark:hover:border-amber-300/30 dark:hover:text-amber-300;
+    }
+
+    .admin-knowledge-action--success {
+        @apply text-emerald-700 hover:border-emerald-200 hover:text-emerald-600 dark:text-emerald-300 dark:hover:border-emerald-300/30 dark:hover:text-emerald-200;
+    }
+
+    .admin-knowledge-action--warning {
+        @apply text-amber-700 hover:border-amber-200 hover:text-amber-600 dark:text-amber-300 dark:hover:border-amber-300/30 dark:hover:text-amber-200;
+    }
+
+    .admin-knowledge-action--danger {
+        @apply text-rose-700 hover:border-rose-200 hover:text-rose-600 dark:text-rose-300 dark:hover:border-rose-300/30 dark:hover:text-rose-200;
+    }
+
+    .admin-knowledge-upload-form {
+        @apply space-y-3 px-4 pb-4 pt-3;
+    }
+
+    .admin-knowledge-upload-note {
+        @apply text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-knowledge-upload-button {
+        @apply inline-flex h-10 w-full items-center justify-center rounded-lg bg-ista-primary px-4 text-xs font-semibold uppercase text-amber-200 transition hover:bg-ista-primary/90 disabled:opacity-50;
+        letter-spacing: 0;
     }
 
     .admin-accounts-page {

--- a/laravel/resources/views/livewire/admin/admin-documents.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-documents.blade.php
@@ -42,7 +42,30 @@
                 'docx' => 'DOCX',
                 default => strtoupper($extension ?: 'FILE'),
             },
+            'type_label' => match ($type) {
+                'pdf' => 'APPLICATION/PDF',
+                'csv' => 'TEXT/CSV',
+                'xlsx' => 'XLSX',
+                'docx' => 'DOCX',
+                default => strtoupper($mime ?: ($extension ?: 'UNKNOWN')),
+            },
         ];
+    };
+    $initials = function (?string $name, ?string $email = null): string {
+        $base = trim((string) ($name ?: $email ?: 'Sistem'));
+        $parts = preg_split('/\s+/', $base) ?: [];
+        $letters = '';
+
+        foreach (array_slice($parts, 0, 2) as $part) {
+            $letters .= mb_substr($part, 0, 1);
+        }
+
+        return mb_strtoupper($letters ?: 'S');
+    };
+    $sourceLabel = function (?string $provider): string {
+        $provider = trim((string) $provider);
+
+        return $provider === '' ? 'LOCAL' : strtoupper(str_replace('_', ' ', $provider));
     };
     $statusMeta = function (?string $status): array {
         return match ($status) {
@@ -260,8 +283,8 @@
         <section class="admin-documents-table-panel admin-section">
             <header class="admin-documents-table-panel__header">
                 <div>
-                    <h3>Pipeline Dokumen</h3>
-                    <p>Menampilkan {{ $documentsPerPage }} dokumen per halaman pada filter aktif.</p>
+                    <h3>Dokumen Terbaru</h3>
+                    <p>Maksimum {{ $documentsPerPage }} baris pada filter aktif.</p>
                 </div>
             </header>
 
@@ -274,64 +297,70 @@
                     <x-admin.table
                         class="admin-documents-table"
                         :columns="[
-                            ['key' => 'file', 'label' => 'File', 'width' => '25%'],
-                            ['key' => 'owner', 'label' => 'Owner', 'width' => '17%'],
-                            ['key' => 'status', 'label' => 'Status', 'width' => '12%'],
-                            ['key' => 'pipeline', 'label' => 'Pipeline', 'width' => '20%'],
-                            ['key' => 'size', 'label' => 'Size', 'align' => 'right', 'width' => '8%'],
-                            ['key' => 'uploaded', 'label' => 'Uploaded', 'align' => 'right', 'width' => '10%'],
-                            ['key' => 'action', 'label' => '', 'align' => 'right', 'width' => '8%'],
+                            ['key' => 'file', 'label' => 'File', 'width' => '26%'],
+                            ['key' => 'owner', 'label' => 'User', 'width' => '18%'],
+                            ['key' => 'type', 'label' => 'Tipe', 'width' => '12%'],
+                            ['key' => 'size', 'label' => 'Size', 'align' => 'right', 'width' => '9%'],
+                            ['key' => 'status', 'label' => 'Status', 'width' => '11%'],
+                            ['key' => 'chunks', 'label' => 'Chunks', 'align' => 'center', 'width' => '8%'],
+                            ['key' => 'uploaded', 'label' => 'Waktu', 'align' => 'right', 'width' => '9%'],
+                            ['key' => 'action', 'label' => 'Aksi', 'align' => 'right', 'width' => '7%'],
                         ]">
                         @foreach ($documents as $doc)
                             @php
                                 $typeMeta = $fileTypeMeta($doc);
                                 $status = $statusMeta($doc->status);
-                                $pipeline = $pipelineMeta($doc);
                             @endphp
                             <tr>
                                 <td class="admin-table__td">
                                     <div class="admin-documents-file-cell">
                                         <span class="admin-documents-file-icon admin-documents-file-icon--{{ $typeMeta['key'] }}" aria-hidden="true">
-                                            {{ $typeMeta['label'] }}
+                                            <svg viewBox="0 0 32 38" fill="none" aria-hidden="true">
+                                                <path d="M7 1.75h12.6L29.25 11.4V33A3.25 3.25 0 0 1 26 36.25H7A3.25 3.25 0 0 1 3.75 33V5A3.25 3.25 0 0 1 7 1.75Z" stroke="currentColor" stroke-width="2"/>
+                                                <path d="M19.5 2.5V10a2 2 0 0 0 2 2H29" stroke="currentColor" stroke-width="2"/>
+                                            </svg>
+                                            <span>{{ $typeMeta['label'] }}</span>
                                         </span>
                                         <div class="min-w-0">
                                             <span class="admin-documents-file-cell__name" title="{{ $doc->original_name }}">
                                                 {{ \Illuminate\Support\Str::limit((string) $doc->original_name, 54, '...') }}
                                             </span>
-                                            <span class="admin-documents-file-cell__meta">{{ $doc->mime_type ?? 'unknown' }}</span>
                                         </div>
                                     </div>
                                 </td>
                                 <td class="admin-table__td">
-                                    <div class="admin-documents-user-cell">
-                                        <span class="admin-documents-user-cell__name">{{ $doc->user?->name ?? 'Sistem' }}</span>
-                                        <span class="admin-documents-user-cell__email">{{ $doc->user?->email ?? '-' }}</span>
+                                    <div class="admin-documents-user-row">
+                                        <span class="admin-documents-avatar" aria-hidden="true">{{ $initials($doc->user?->name, $doc->user?->email) }}</span>
+                                        <div class="admin-documents-user-cell">
+                                            <span class="admin-documents-user-cell__name">{{ $doc->user?->name ?? 'Sistem' }}</span>
+                                            <span class="admin-documents-user-cell__email">{{ $doc->user?->email ?? '-' }}</span>
+                                        </div>
                                     </div>
                                 </td>
                                 <td class="admin-table__td">
-                                    <span class="admin-documents-status-chip admin-documents-status-chip--{{ $status['tone'] }}">
-                                        {{ $status['label'] }}
-                                    </span>
-                                </td>
-                                <td class="admin-table__td">
-                                    <div class="admin-documents-pipeline">
-                                        <div class="admin-documents-pipeline__track" aria-hidden="true">
-                                            <span class="admin-documents-pipeline__bar admin-documents-pipeline__bar--{{ $pipeline['tone'] }}" style="width: {{ $pipeline['progress'] }}%"></span>
-                                        </div>
-                                        <div class="admin-documents-pipeline__meta">
-                                            <span>{{ $pipeline['parse_status'] }}</span>
-                                            <span>{{ $pipeline['embedding_status'] }}</span>
-                                        </div>
-                                    </div>
+                                    <span class="admin-documents-type-label">{{ $typeMeta['type_label'] }}</span>
                                 </td>
                                 <td class="admin-table__td" data-align="right">
                                     <span class="admin-documents-number">{{ $doc->formatted_size }}</span>
+                                </td>
+                                <td class="admin-table__td">
+                                    <span class="admin-documents-status-chip admin-documents-status-chip--{{ $status['tone'] }}">
+                                        <span aria-hidden="true"></span>
+                                        {{ $status['label'] }}
+                                    </span>
+                                </td>
+                                <td class="admin-table__td" data-align="center">
+                                    <span class="admin-documents-number">{{ number_format((int) ($doc->chunks_count ?? 0)) }}</span>
                                 </td>
                                 <td class="admin-table__td" data-align="right">
                                     <span class="admin-documents-muted" title="{{ $doc->created_at?->toDateTimeString() }}">{{ $doc->created_at?->diffForHumans() }}</span>
                                 </td>
                                 <td class="admin-table__td" data-align="right">
                                     <button type="button" wire:click="showDetail({{ $doc->id }})" class="admin-documents-detail-button">
+                                        <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M2.25 12s3.75-6.75 9.75-6.75S21.75 12 21.75 12 18 18.75 12 18.75 2.25 12 2.25 12z"/>
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 9.25a2.75 2.75 0 110 5.5 2.75 2.75 0 010-5.5z"/>
+                                        </svg>
                                         Detail
                                     </button>
                                 </td>
@@ -339,11 +368,14 @@
                         @endforeach
                     </x-admin.table>
 
-                    @if ($documents->hasPages())
-                        <div class="admin-documents-pagination">
-                            {{ $documents->links() }}
-                        </div>
-                    @endif
+                    <div class="admin-documents-table-footer">
+                        <span>Menampilkan {{ number_format($documents->firstItem() ?? 0) }}-{{ number_format($documents->lastItem() ?? 0) }} dari {{ number_format($documents->total()) }} dokumen</span>
+                        @if ($documents->hasPages())
+                            <div class="admin-documents-pagination">
+                                {{ $documents->links() }}
+                            </div>
+                        @endif
+                    </div>
                 @endif
             </div>
         </section>
@@ -427,35 +459,42 @@
             $selectedType = $fileTypeMeta($selectedDocument);
             $selectedStatus = $statusMeta($selectedDocument->status);
             $selectedPipeline = $pipelineMeta($selectedDocument);
+            $selectedSource = $sourceLabel($selectedDocument->source_provider);
         @endphp
-        <div class="admin-documents-drawer" role="dialog" aria-modal="true" aria-labelledby="admin-document-detail-title">
-            <button type="button" class="admin-documents-drawer__backdrop" wire:click="closeDetail" aria-label="Tutup detail dokumen"></button>
+        <div class="admin-documents-modal" role="dialog" aria-modal="true" aria-labelledby="admin-document-detail-title">
+            <button type="button" class="admin-documents-modal__backdrop" wire:click="closeDetail" aria-label="Tutup detail dokumen"></button>
 
-            <aside class="admin-documents-drawer__panel">
-                <header class="admin-documents-drawer__header">
-                    <div class="admin-documents-drawer__title-row">
+            <section class="admin-documents-modal__panel">
+                <header class="admin-documents-modal__header">
+                    <div class="admin-documents-modal__title-row">
                         <span class="admin-documents-file-icon admin-documents-file-icon--{{ $selectedType['key'] }}" aria-hidden="true">
-                            {{ $selectedType['label'] }}
+                            <svg viewBox="0 0 32 38" fill="none" aria-hidden="true">
+                                <path d="M7 1.75h12.6L29.25 11.4V33A3.25 3.25 0 0 1 26 36.25H7A3.25 3.25 0 0 1 3.75 33V5A3.25 3.25 0 0 1 7 1.75Z" stroke="currentColor" stroke-width="2"/>
+                                <path d="M19.5 2.5V10a2 2 0 0 0 2 2H29" stroke="currentColor" stroke-width="2"/>
+                            </svg>
+                            <span>{{ $selectedType['label'] }}</span>
                         </span>
                         <div class="min-w-0">
-                            <p class="admin-documents-drawer__eyebrow">Document Pipeline</p>
+                            <p class="admin-documents-modal__eyebrow">Document Detail</p>
                             <h3 id="admin-document-detail-title" title="{{ $selectedDocument->original_name }}">
                                 {{ \Illuminate\Support\Str::limit((string) $selectedDocument->original_name, 64, '...') }}
                             </h3>
+                            <span class="admin-documents-modal__code">{{ $selectedType['type_label'] }}</span>
                         </div>
                     </div>
-                    <button type="button" wire:click="closeDetail" class="admin-documents-drawer__close" aria-label="Tutup detail dokumen">
+                    <button type="button" wire:click="closeDetail" class="admin-documents-modal__close" aria-label="Tutup detail dokumen">
                         <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M6 6l12 12M18 6L6 18"/>
                         </svg>
                     </button>
                 </header>
 
-                <div class="admin-documents-drawer__body">
-                    <div class="admin-documents-drawer__summary">
+                <div class="admin-documents-modal__body">
+                    <div class="admin-documents-modal__summary-grid">
                         <div>
                             <span>Status</span>
                             <strong class="admin-documents-status-chip admin-documents-status-chip--{{ $selectedStatus['tone'] }}">
+                                <span aria-hidden="true"></span>
                                 {{ $selectedStatus['label'] }}
                             </strong>
                         </div>
@@ -470,15 +509,25 @@
                             <em>{{ $selectedDocument->mime_type ?? 'unknown' }}</em>
                         </div>
                         <div>
+                            <span>Chunks</span>
+                            <strong>{{ number_format((int) ($selectedDocument->chunks_count ?? 0)) }}</strong>
+                            <em>{{ $selectedPipeline['embedding_status'] }}</em>
+                        </div>
+                        <div>
                             <span>Uploaded</span>
                             <strong>{{ $selectedDocument->created_at?->diffForHumans() ?? '-' }}</strong>
                             <em>{{ $selectedDocument->created_at?->toDateTimeString() ?? '-' }}</em>
                         </div>
+                        <div>
+                            <span>Source</span>
+                            <strong>{{ $selectedSource }}</strong>
+                            <em>{{ $selectedDocument->source_synced_at?->toDateTimeString() ?? 'Local upload' }}</em>
+                        </div>
                     </div>
 
-                    <section class="admin-documents-drawer__section">
-                        <div class="admin-documents-drawer__section-heading">
-                            <h4>Pipeline</h4>
+                    <section class="admin-documents-modal__section">
+                        <div class="admin-documents-modal__section-heading">
+                            <h4>Status AI</h4>
                             <span>{{ $selectedPipeline['progress'] }}%</span>
                         </div>
                         <div class="admin-documents-pipeline admin-documents-pipeline--drawer">
@@ -486,69 +535,34 @@
                                 <span class="admin-documents-pipeline__bar admin-documents-pipeline__bar--{{ $selectedPipeline['tone'] }}" style="width: {{ $selectedPipeline['progress'] }}%"></span>
                             </div>
                         </div>
-                        <ol class="admin-documents-stage-list" role="list">
-                            @foreach ($selectedPipeline['stages'] as $stage)
-                                <li class="admin-documents-stage-list__item admin-documents-stage-list__item--{{ $stage['state'] }}">
-                                    <span aria-hidden="true"></span>
-                                    <strong>{{ $stage['label'] }}</strong>
-                                </li>
-                            @endforeach
-                        </ol>
+                        <p>{{ $selectedPipeline['parse_status'] }} · {{ $selectedPipeline['embedding_status'] }} · preview {{ ucfirst((string) ($selectedDocument->preview_status ?? 'pending')) }}.</p>
                     </section>
 
-                    <section class="admin-documents-drawer__section">
-                        <h4>AI Index Metadata</h4>
-                        <dl class="admin-documents-metadata-grid">
+                    <section class="admin-documents-modal__section">
+                        <h4>Metadata ringkas</h4>
+                        <dl class="admin-documents-modal__metadata">
                             <div>
-                                <dt>Parsing Status</dt>
-                                <dd>{{ $selectedPipeline['parse_status'] }}</dd>
-                            </div>
-                            <div>
-                                <dt>Chunk Count</dt>
-                                <dd>{{ number_format($selectedPipeline['chunk_count']) }}</dd>
-                            </div>
-                            <div>
-                                <dt>Embedding Status</dt>
-                                <dd>{{ $selectedPipeline['embedding_status'] }}</dd>
-                            </div>
-                            <div>
-                                <dt>Preview Status</dt>
-                                <dd>{{ ucfirst((string) ($selectedDocument->preview_status ?? 'pending')) }}</dd>
-                            </div>
-                        </dl>
-                    </section>
-
-                    <section class="admin-documents-drawer__section">
-                        <h4>File Metadata</h4>
-                        <dl class="admin-documents-metadata-grid">
-                            <div>
-                                <dt>File Name</dt>
+                                <dt>Stored file</dt>
                                 <dd>{{ $selectedDocument->filename ?? '-' }}</dd>
                             </div>
                             <div>
-                                <dt>Original Name</dt>
+                                <dt>Original file</dt>
                                 <dd>{{ $selectedDocument->original_name ?? '-' }}</dd>
                             </div>
+                            @if ($selectedDocument->source_external_id)
+                                <div>
+                                    <dt>External ID</dt>
+                                    <dd>{{ $selectedDocument->source_external_id }}</dd>
+                                </div>
+                            @endif
                             <div>
-                                <dt>Source</dt>
-                                <dd>{{ strtoupper(str_replace('_', ' ', (string) ($selectedDocument->source_provider ?? 'local'))) }}</dd>
-                            </div>
-                            <div>
-                                <dt>External ID</dt>
-                                <dd>{{ $selectedDocument->source_external_id ?? '-' }}</dd>
-                            </div>
-                            <div>
-                                <dt>Synced At</dt>
-                                <dd>{{ $selectedDocument->source_synced_at?->toDateTimeString() ?? '-' }}</dd>
-                            </div>
-                            <div>
-                                <dt>Updated At</dt>
+                                <dt>Updated</dt>
                                 <dd>{{ $selectedDocument->updated_at?->toDateTimeString() ?? '-' }}</dd>
                             </div>
                         </dl>
                     </section>
                 </div>
-            </aside>
+            </section>
         </div>
     @endif
 </div>

--- a/laravel/resources/views/livewire/admin/admin-knowledge.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-knowledge.blade.php
@@ -1,64 +1,163 @@
-<div>
-    <div class="mb-6">
-        <div class="flex flex-wrap items-end justify-between gap-3">
-            <div class="max-w-2xl">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400 dark:text-gray-500">Knowledge</p>
-                <h2 class="admin-page-title mt-1">Knowledge Base Internal</h2>
-                <p class="mt-2 text-sm leading-relaxed text-stone-500 dark:text-gray-400">
-                    Kelola dokumen knowledge internal global. Dokumen di-upload admin akan diproses menjadi vector dengan metadata <code class="font-mono text-[11px]">scope=global_internal</code> dan <code class="font-mono text-[11px]">audience=all_users</code>. Halaman ini hanya menampilkan metadata file, bukan isinya.
-                </p>
-            </div>
-            <x-admin.badge tone="primary">Admin only</x-admin.badge>
+@php
+    $formatInt = fn ($value): string => number_format((float) $value, 0, ',', '.');
+    $formatPct = function (int $value, int $total): string {
+        if ($total <= 0) {
+            return '0.0%';
+        }
+
+        return number_format(($value / $total) * 100, 1, '.', '') . '%';
+    };
+    $fileTypeMeta = function ($doc): array {
+        $mime = (string) ($doc?->mime_type ?? '');
+        $extension = strtolower((string) pathinfo((string) ($doc?->original_name ?? ''), PATHINFO_EXTENSION));
+        $type = match (true) {
+            $mime === 'application/pdf' || $extension === 'pdf' => 'pdf',
+            in_array($mime, ['text/csv', 'text/plain', 'application/csv'], true) || $extension === 'csv' => 'csv',
+            in_array($mime, ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel'], true) || in_array($extension, ['xls', 'xlsx'], true) => 'xlsx',
+            $mime === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' || $extension === 'docx' => 'docx',
+            default => 'file',
+        };
+
+        return [
+            'key' => $type,
+            'label' => match ($type) {
+                'pdf' => 'PDF',
+                'csv' => 'CSV',
+                'xlsx' => 'XLSX',
+                'docx' => 'DOCX',
+                default => strtoupper($extension ?: 'FILE'),
+            },
+            'type_label' => match ($type) {
+                'pdf' => 'APPLICATION/PDF',
+                'csv' => 'TEXT/CSV',
+                'xlsx' => 'XLSX',
+                'docx' => 'DOCX',
+                default => strtoupper($mime ?: ($extension ?: 'UNKNOWN')),
+            },
+        ];
+    };
+    $statusMeta = function (?string $status): array {
+        return match ($status) {
+            'active' => ['label' => 'Active', 'tone' => 'success'],
+            'processing' => ['label' => 'Processing', 'tone' => 'warning'],
+            'draft' => ['label' => 'Draft', 'tone' => 'neutral'],
+            'error' => ['label' => 'Failed', 'tone' => 'danger'],
+            'archived' => ['label' => 'Archived', 'tone' => 'neutral'],
+            default => ['label' => ucfirst((string) ($status ?: 'Unknown')), 'tone' => 'neutral'],
+        };
+    };
+    $initials = function (?string $name, ?string $email = null): string {
+        $base = trim((string) ($name ?: $email ?: 'Admin'));
+        $parts = preg_split('/\s+/', $base) ?: [];
+        $letters = '';
+
+        foreach (array_slice($parts, 0, 2) as $part) {
+            $letters .= mb_substr($part, 0, 1);
+        }
+
+        return mb_strtoupper($letters ?: 'A');
+    };
+
+    $totalDocs = array_sum($statusCounts);
+    $activeCount = (int) ($statusCounts['active'] ?? 0);
+    $processingCount = (int) (($statusCounts['draft'] ?? 0) + ($statusCounts['processing'] ?? 0));
+    $errorCount = (int) ($statusCounts['error'] ?? 0);
+    $archivedCount = (int) ($statusCounts['archived'] ?? 0);
+
+    $knowledgeCards = [
+        [
+            'label' => 'Total Knowledge',
+            'value' => $totalDocs,
+            'description' => $formatInt($archivedCount) . ' archived',
+            'tone' => 'primary',
+            'icon' => 'M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5s3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18s-3.332.477-4.5 1.253',
+        ],
+        [
+            'label' => 'Active',
+            'value' => $activeCount,
+            'description' => $formatPct($activeCount, $totalDocs) . ' siap dipakai',
+            'tone' => 'success',
+            'icon' => 'M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+        ],
+        [
+            'label' => 'Draft / Processing',
+            'value' => $processingCount,
+            'description' => $formatPct($processingCount, $totalDocs) . ' sedang disiapkan',
+            'tone' => 'warning',
+            'icon' => 'M12 6v6l3 2M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+        ],
+        [
+            'label' => 'Failed',
+            'value' => $errorCount,
+            'description' => $formatPct($errorCount, $totalDocs) . ' perlu dicek',
+            'tone' => 'danger',
+            'icon' => 'M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z',
+        ],
+    ];
+@endphp
+
+<div class="admin-knowledge-page">
+    <div class="admin-knowledge-hero">
+        <div class="max-w-2xl">
+            <p class="admin-knowledge-eyebrow">Knowledge</p>
+            <h2 class="admin-knowledge-title">Knowledge Base Internal</h2>
+            <p class="admin-knowledge-description">
+                Kelola dokumen internal global untuk referensi AI tanpa menampilkan isi dokumen.
+            </p>
         </div>
+        <x-admin.badge tone="neutral" class="admin-knowledge-readonly">Admin only</x-admin.badge>
     </div>
 
     @if (session('knowledge_status'))
-        <div class="mb-4 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800 dark:border-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200">
+        <div class="admin-knowledge-alert">
             {{ session('knowledge_status') }}
         </div>
     @endif
 
-    @php
-        $totalDocs = array_sum($statusCounts);
-        $activeCount = $statusCounts['active'] ?? 0;
-        $processingCount = ($statusCounts['draft'] ?? 0) + ($statusCounts['processing'] ?? 0);
-        $errorCount = $statusCounts['error'] ?? 0;
-        $archivedCount = $statusCounts['archived'] ?? 0;
-    @endphp
-
-    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <x-admin.kpi-card label="Total Knowledge" :value="number_format($totalDocs)" tone="primary" />
-        <x-admin.kpi-card label="Active" :value="number_format($activeCount)" tone="success" />
-        <x-admin.kpi-card label="Draft / Processing" :value="number_format($processingCount)" tone="warning" />
-        <x-admin.kpi-card label="Error" :value="number_format($errorCount)" tone="danger" />
+    <div class="admin-knowledge-kpi-grid">
+        @foreach ($knowledgeCards as $card)
+            <article class="admin-knowledge-kpi-card admin-knowledge-kpi-card--{{ $card['tone'] }}">
+                <div class="admin-knowledge-kpi-card__header">
+                    <span class="admin-knowledge-kpi-card__icon" aria-hidden="true">
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="{{ $card['icon'] }}"/>
+                        </svg>
+                    </span>
+                    <p class="admin-knowledge-kpi-card__label">{{ $card['label'] }}</p>
+                </div>
+                <div class="admin-knowledge-kpi-card__body">
+                    <strong>{{ $formatInt($card['value']) }}</strong>
+                    <p class="admin-knowledge-kpi-card__description">{{ $card['description'] }}</p>
+                </div>
+            </article>
+        @endforeach
     </div>
 
-    <div class="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <x-admin.kpi-card label="Archived" :value="number_format($archivedCount)" tone="default" description="Dokumen yang dinonaktifkan." />
-    </div>
-
-    <div class="mt-6 grid gap-4 lg:grid-cols-3">
-        <div class="lg:col-span-2">
-            <x-admin.section title="Filter">
-                <x-slot name="actions">
-                    <button type="button"
-                            wire:click="resetFilters"
-                            class="text-[11px] font-semibold uppercase tracking-wider text-stone-500 transition hover:text-ista-primary dark:text-gray-400 dark:hover:text-amber-300">
+    <div class="admin-knowledge-content-grid">
+        <div class="admin-knowledge-main-stack">
+            <section class="admin-knowledge-filter-panel admin-section">
+                <div class="admin-knowledge-filter-panel__header">
+                    <h3>Filter</h3>
+                    <button type="button" wire:click="resetFilters" class="admin-knowledge-reset-button">
+                        <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M4 4v6h6M20 20v-6h-6M5.5 14a7 7 0 0012 3M18.5 10a7 7 0 00-12-3"/>
+                        </svg>
                         Reset
                     </button>
-                </x-slot>
-                <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                    <label class="admin-filter">
-                        <span class="admin-filter__label">Cari judul / nama file</span>
+                </div>
+
+                <div class="admin-knowledge-filter-grid">
+                    <label class="admin-knowledge-filter">
+                        <span>Cari knowledge</span>
                         <input type="search"
                                wire:model.live.debounce.300ms="search"
                                placeholder="Contoh: SOP HR"
-                               class="admin-filter__control" />
+                               class="admin-knowledge-control" />
                     </label>
 
-                    <label class="admin-filter">
-                        <span class="admin-filter__label">Status</span>
-                        <select wire:model.live="status" class="admin-filter__control">
+                    <label class="admin-knowledge-filter">
+                        <span>Status</span>
+                        <select wire:model.live="status" class="admin-knowledge-control">
                             <option value="">Semua</option>
                             @foreach ($statusOptions as $key => $label)
                                 <option value="{{ $key }}">{{ $label }}</option>
@@ -66,9 +165,9 @@
                         </select>
                     </label>
 
-                    <label class="admin-filter">
-                        <span class="admin-filter__label">Source</span>
-                        <select wire:model.live="sourceFilter" class="admin-filter__control">
+                    <label class="admin-knowledge-filter">
+                        <span>Source</span>
+                        <select wire:model.live="sourceFilter" class="admin-knowledge-control">
                             <option value="">Semua</option>
                             @foreach ($sources as $source)
                                 <option value="{{ $source->id }}">{{ $source->name }}</option>
@@ -76,155 +175,197 @@
                         </select>
                     </label>
                 </div>
-            </x-admin.section>
+            </section>
+
+            <section class="admin-knowledge-table-panel admin-section">
+                <header class="admin-knowledge-table-panel__header">
+                    <div>
+                        <h3>Dokumen Knowledge</h3>
+                        <p>Maksimum 100 baris pada filter aktif.</p>
+                    </div>
+                </header>
+
+                <div class="admin-knowledge-table-panel__body">
+                    @if ($documents->isEmpty())
+                        <x-admin.empty-state title="Belum ada knowledge" description="Belum ada dokumen knowledge yang cocok dengan filter saat ini." />
+                    @else
+                        <x-admin.table
+                            class="admin-knowledge-table"
+                            :columns="[
+                                ['key' => 'file', 'label' => 'File', 'width' => '29%'],
+                                ['key' => 'source', 'label' => 'Source', 'width' => '16%'],
+                                ['key' => 'admin', 'label' => 'Admin', 'width' => '19%'],
+                                ['key' => 'type', 'label' => 'Tipe', 'width' => '12%'],
+                                ['key' => 'size', 'label' => 'Size', 'align' => 'right', 'width' => '9%'],
+                                ['key' => 'status', 'label' => 'Status', 'width' => '11%'],
+                                ['key' => 'time', 'label' => 'Dibuat', 'align' => 'right', 'width' => '10%'],
+                                ['key' => 'actions', 'label' => 'Aksi', 'align' => 'right', 'width' => '14%'],
+                            ]">
+                            @foreach ($documents as $doc)
+                                @php
+                                    $typeMeta = $fileTypeMeta($doc);
+                                    $status = $statusMeta($doc->status);
+                                @endphp
+                                <tr>
+                                    <td class="admin-table__td">
+                                        <div class="admin-documents-file-cell">
+                                            <span class="admin-documents-file-icon admin-documents-file-icon--{{ $typeMeta['key'] }}" aria-hidden="true">
+                                                <svg viewBox="0 0 32 38" fill="none" aria-hidden="true">
+                                                    <path d="M7 1.75h12.6L29.25 11.4V33A3.25 3.25 0 0 1 26 36.25H7A3.25 3.25 0 0 1 3.75 33V5A3.25 3.25 0 0 1 7 1.75Z" stroke="currentColor" stroke-width="2"/>
+                                                    <path d="M19.5 2.5V10a2 2 0 0 0 2 2H29" stroke="currentColor" stroke-width="2"/>
+                                                </svg>
+                                                <span>{{ $typeMeta['label'] }}</span>
+                                            </span>
+                                            <div class="min-w-0">
+                                                <span class="admin-knowledge-file-name" title="{{ $doc->title }}">{{ \Illuminate\Support\Str::limit((string) $doc->title, 52, '...') }}</span>
+                                                <span class="admin-knowledge-file-meta">{{ \Illuminate\Support\Str::limit((string) $doc->original_name, 52, '...') }}</span>
+                                            </div>
+                                        </div>
+                                    </td>
+                                    <td class="admin-table__td">
+                                        <span class="admin-knowledge-source">{{ $doc->source?->name ?? 'Default' }}</span>
+                                    </td>
+                                    <td class="admin-table__td">
+                                        <div class="admin-documents-user-row">
+                                            <span class="admin-documents-avatar" aria-hidden="true">{{ $initials($doc->uploader?->name, $doc->uploader?->email) }}</span>
+                                            <div class="admin-documents-user-cell">
+                                                <span class="admin-documents-user-cell__name">{{ $doc->uploader?->name ?? 'Sistem' }}</span>
+                                                <span class="admin-documents-user-cell__email">{{ $doc->uploader?->email ?? '-' }}</span>
+                                            </div>
+                                        </div>
+                                    </td>
+                                    <td class="admin-table__td">
+                                        <span class="admin-documents-type-label">{{ $typeMeta['type_label'] }}</span>
+                                    </td>
+                                    <td class="admin-table__td" data-align="right">
+                                        <span class="admin-documents-number">{{ $doc->formatted_size }}</span>
+                                    </td>
+                                    <td class="admin-table__td">
+                                        <span class="admin-documents-status-chip admin-documents-status-chip--{{ $status['tone'] }}">
+                                            <span aria-hidden="true"></span>
+                                            {{ $status['label'] }}
+                                        </span>
+                                        @if ($doc->error_code)
+                                            <p class="admin-knowledge-error-code">{{ $doc->error_code }}</p>
+                                        @endif
+                                    </td>
+                                    <td class="admin-table__td" data-align="right">
+                                        <span class="admin-documents-muted" title="{{ $doc->created_at?->toDateTimeString() }}">{{ $doc->created_at?->diffForHumans() }}</span>
+                                    </td>
+                                    <td class="admin-table__td" data-align="right">
+                                        <div class="admin-knowledge-action-group">
+                                            @if ($doc->status !== 'active')
+                                                <button type="button" wire:click="activate({{ $doc->id }})" class="admin-knowledge-action admin-knowledge-action--success">Aktifkan</button>
+                                            @endif
+                                            @if ($doc->status !== 'archived')
+                                                <button type="button" wire:click="archive({{ $doc->id }})" class="admin-knowledge-action admin-knowledge-action--warning">Arsip</button>
+                                            @endif
+                                            <button type="button" wire:click="reprocess({{ $doc->id }})" class="admin-knowledge-action">Proses ulang</button>
+                                            <button type="button"
+                                                    wire:click="delete({{ $doc->id }})"
+                                                    wire:confirm="Yakin hapus knowledge ini? Vector akan dihapus juga."
+                                                    class="admin-knowledge-action admin-knowledge-action--danger">
+                                                Hapus
+                                            </button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </x-admin.table>
+                    @endif
+                </div>
+            </section>
         </div>
 
-        <x-admin.section title="Upload Dokumen Knowledge" description="Format yang diterima: {{ implode(', ', $allowedExtensions) }}.">
-            <form wire:submit.prevent="upload" class="space-y-3">
-                <label class="admin-filter">
-                    <span class="admin-filter__label">Judul (opsional)</span>
-                    <input type="text"
-                           wire:model.defer="title"
-                           placeholder="Contoh: SOP Penerimaan Tamu"
-                           class="admin-filter__control" />
-                    @error('title') <span class="text-xs text-rose-500">{{ $message }}</span> @enderror
-                </label>
+        <aside class="admin-knowledge-side-grid">
+            <section class="admin-knowledge-upload-panel admin-section">
+                <header class="admin-knowledge-upload-panel__header">
+                    <div>
+                        <h3>Upload Knowledge</h3>
+                        <p>Format: {{ implode(', ', $allowedExtensions) }}.</p>
+                    </div>
+                </header>
 
-                <label class="admin-filter">
-                    <span class="admin-filter__label">Source (existing)</span>
-                    <select wire:model.defer="sourceId" class="admin-filter__control">
-                        <option value="">— Pilih source —</option>
-                        @foreach ($sources as $source)
-                            <option value="{{ $source->id }}">{{ $source->name }}</option>
-                        @endforeach
-                    </select>
-                    @error('sourceId') <span class="text-xs text-rose-500">{{ $message }}</span> @enderror
-                </label>
+                <form wire:submit.prevent="upload" class="admin-knowledge-upload-form">
+                    <label class="admin-knowledge-filter">
+                        <span>Judul opsional</span>
+                        <input type="text" wire:model.defer="title" placeholder="Contoh: SOP Penerimaan Tamu" class="admin-knowledge-control" />
+                        @error('title') <span class="admin-knowledge-error">{{ $message }}</span> @enderror
+                    </label>
 
-                <label class="admin-filter">
-                    <span class="admin-filter__label">Atau buat source baru</span>
-                    <input type="text"
-                           wire:model.defer="newSourceName"
-                           placeholder="Contoh: Aturan ISTANA"
-                           class="admin-filter__control" />
-                    @error('newSourceName') <span class="text-xs text-rose-500">{{ $message }}</span> @enderror
-                </label>
+                    <label class="admin-knowledge-filter">
+                        <span>Source existing</span>
+                        <select wire:model.defer="sourceId" class="admin-knowledge-control">
+                            <option value="">Pilih source</option>
+                            @foreach ($sources as $source)
+                                <option value="{{ $source->id }}">{{ $source->name }}</option>
+                            @endforeach
+                        </select>
+                        @error('sourceId') <span class="admin-knowledge-error">{{ $message }}</span> @enderror
+                    </label>
 
-                <label class="admin-filter">
-                    <span class="admin-filter__label">Catatan internal (opsional)</span>
-                    <textarea wire:model.defer="notes"
-                              rows="2"
-                              placeholder="Konteks tambahan untuk admin lain"
-                              class="admin-filter__control"></textarea>
-                    @error('notes') <span class="text-xs text-rose-500">{{ $message }}</span> @enderror
-                </label>
+                    <label class="admin-knowledge-filter">
+                        <span>Atau source baru</span>
+                        <input type="text" wire:model.defer="newSourceName" placeholder="Contoh: Aturan internal" class="admin-knowledge-control" />
+                        @error('newSourceName') <span class="admin-knowledge-error">{{ $message }}</span> @enderror
+                    </label>
 
-                <label class="admin-filter">
-                    <span class="admin-filter__label">File knowledge</span>
-                    <input type="file"
-                           wire:model="file"
-                           accept=".pdf,.docx,.xlsx,.csv"
-                           class="admin-filter__control" />
-                    @error('file') <span class="text-xs text-rose-500">{{ $message }}</span> @enderror
-                </label>
+                    <label class="admin-knowledge-filter">
+                        <span>Catatan internal</span>
+                        <textarea wire:model.defer="notes" rows="2" placeholder="Konteks singkat untuk admin lain" class="admin-knowledge-control admin-knowledge-control--textarea"></textarea>
+                        @error('notes') <span class="admin-knowledge-error">{{ $message }}</span> @enderror
+                    </label>
 
-                <div wire:loading wire:target="file" class="text-xs text-stone-500 dark:text-gray-400">Meng-upload file…</div>
+                    <label class="admin-knowledge-filter">
+                        <span>File knowledge</span>
+                        <input type="file" wire:model="file" accept=".pdf,.docx,.xlsx,.csv" class="admin-knowledge-control admin-knowledge-control--file" />
+                        @error('file') <span class="admin-knowledge-error">{{ $message }}</span> @enderror
+                    </label>
 
-                <button type="submit"
-                        class="inline-flex h-10 w-full items-center justify-center rounded-lg bg-ista-primary px-4 text-xs font-semibold uppercase tracking-wider text-amber-200 transition hover:bg-ista-primary/90 disabled:opacity-50"
-                        wire:loading.attr="disabled"
-                        wire:target="upload,file">
-                    <span wire:loading.remove wire:target="upload">Upload Knowledge</span>
-                    <span wire:loading wire:target="upload">Memproses…</span>
-                </button>
-            </form>
-        </x-admin.section>
-    </div>
+                    <div wire:loading wire:target="file" class="admin-knowledge-upload-note">Meng-upload file...</div>
 
-    <div class="mt-6">
-        <x-admin.section
-            title="Daftar Knowledge Internal"
-            description="Maksimum 100 baris. Status menunjukkan apakah knowledge aktif atau di-archive.">
-            @if ($documents->isEmpty())
-                <x-admin.empty-state title="Belum ada knowledge" description="Belum ada dokumen knowledge yang cocok dengan filter saat ini." />
-            @else
-                <x-admin.table :columns="[
-                    ['key' => 'title', 'label' => 'Judul / File'],
-                    ['key' => 'source', 'label' => 'Source'],
-                    ['key' => 'mime', 'label' => 'Tipe'],
-                    ['key' => 'size', 'label' => 'Ukuran', 'align' => 'right'],
-                    ['key' => 'status', 'label' => 'Status'],
-                    ['key' => 'time', 'label' => 'Dibuat', 'align' => 'right'],
-                    ['key' => 'actions', 'label' => 'Aksi', 'align' => 'right'],
-                ]">
-                    @foreach ($documents as $doc)
-                        @php
-                            $tone = match ($doc->status) {
-                                'active' => 'success',
-                                'draft', 'processing' => 'warning',
-                                'error' => 'danger',
-                                'archived' => 'neutral',
-                                default => 'neutral',
-                            };
-                        @endphp
-                        <tr>
-                            <td class="admin-table__td">
-                                <div class="flex flex-col">
-                                    <span class="text-sm font-semibold text-stone-700 dark:text-gray-200">{{ \Illuminate\Support\Str::limit((string) $doc->title, 60, '…') }}</span>
-                                    <span class="text-[11px] text-stone-400 dark:text-gray-500">{{ \Illuminate\Support\Str::limit((string) $doc->original_name, 60, '…') }}</span>
-                                </div>
-                            </td>
-                            <td class="admin-table__td">
-                                <span class="text-xs text-stone-600 dark:text-gray-300">{{ $doc->source?->name ?? '—' }}</span>
-                            </td>
-                            <td class="admin-table__td">
-                                <span class="font-mono text-[10.5px] uppercase tracking-wider text-stone-500 dark:text-gray-400">{{ $doc->mime_type ?? 'unknown' }}</span>
-                            </td>
-                            <td class="admin-table__td" data-align="right">
-                                <span class="font-mono text-xs text-stone-500 dark:text-gray-400">{{ $doc->formatted_size }}</span>
-                            </td>
-                            <td class="admin-table__td">
-                                <x-admin.badge :tone="$tone">{{ ucfirst($doc->status) }}</x-admin.badge>
-                                @if ($doc->error_code)
-                                    <p class="mt-1 text-[10.5px] text-rose-500 dark:text-rose-300">{{ $doc->error_code }}</p>
-                                @endif
-                            </td>
-                            <td class="admin-table__td" data-align="right">
-                                <span class="text-xs text-stone-500 dark:text-gray-400" title="{{ $doc->created_at?->toDateTimeString() }}">{{ $doc->created_at?->diffForHumans() }}</span>
-                            </td>
-                            <td class="admin-table__td" data-align="right">
-                                <div class="flex flex-wrap items-center justify-end gap-2">
-                                    @if ($doc->status !== 'active')
-                                        <button type="button"
-                                                wire:click="activate({{ $doc->id }})"
-                                                class="text-[11px] font-semibold uppercase tracking-wider text-emerald-600 transition hover:text-emerald-500 dark:text-emerald-300">
-                                            Activate
-                                        </button>
-                                    @endif
-                                    @if ($doc->status !== 'archived')
-                                        <button type="button"
-                                                wire:click="archive({{ $doc->id }})"
-                                                class="text-[11px] font-semibold uppercase tracking-wider text-amber-600 transition hover:text-amber-500 dark:text-amber-300">
-                                            Archive
-                                        </button>
-                                    @endif
-                                    <button type="button"
-                                            wire:click="reprocess({{ $doc->id }})"
-                                            class="text-[11px] font-semibold uppercase tracking-wider text-stone-600 transition hover:text-ista-primary dark:text-gray-300 dark:hover:text-amber-300">
-                                        Reprocess
-                                    </button>
-                                    <button type="button"
-                                            wire:click="delete({{ $doc->id }})"
-                                            wire:confirm="Yakin hapus knowledge ini? Vector akan dihapus juga."
-                                            class="text-[11px] font-semibold uppercase tracking-wider text-rose-600 transition hover:text-rose-500 dark:text-rose-300">
-                                        Delete
-                                    </button>
-                                </div>
-                            </td>
-                        </tr>
-                    @endforeach
-                </x-admin.table>
-            @endif
-        </x-admin.section>
+                    <button type="submit"
+                            class="admin-knowledge-upload-button"
+                            wire:loading.attr="disabled"
+                            wire:target="upload,file">
+                        <span wire:loading.remove wire:target="upload">Upload Knowledge</span>
+                        <span wire:loading wire:target="upload">Memproses...</span>
+                    </button>
+                </form>
+            </section>
+
+            <section class="admin-knowledge-status-panel admin-section">
+                <header class="admin-knowledge-status-panel__header">
+                    <div>
+                        <h3>Status Knowledge</h3>
+                        <p>Berdasarkan seluruh dokumen.</p>
+                    </div>
+                </header>
+
+                <div class="admin-knowledge-status-panel__body">
+                    @if (empty($statusCounts))
+                        <x-admin.empty-state title="Tidak ada status" />
+                    @else
+                        @php $totalStatus = max(1, array_sum($statusCounts)); @endphp
+                        <ul class="admin-documents-status-list" role="list">
+                            @foreach ($statusCounts as $statusName => $count)
+                                @php
+                                    $statusItem = $statusMeta($statusName);
+                                    $pct = (int) round(($count / $totalStatus) * 100);
+                                @endphp
+                                <li>
+                                    <span class="admin-documents-status-dot admin-documents-status-dot--{{ $statusItem['tone'] }}" aria-hidden="true"></span>
+                                    <div>
+                                        <strong>{{ $statusItem['label'] }}</strong>
+                                        <em>{{ $pct }}% dari knowledge</em>
+                                    </div>
+                                    <b>{{ number_format($count) }}</b>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </div>
+            </section>
+        </aside>
     </div>
 </div>

--- a/laravel/tests/Feature/Admin/AdminKnowledgeManagementTest.php
+++ b/laravel/tests/Feature/Admin/AdminKnowledgeManagementTest.php
@@ -28,7 +28,10 @@ class AdminKnowledgeManagementTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('Knowledge Base Internal', false);
-        $response->assertSee('global_internal', false);
+        $response->assertSee('admin-knowledge-kpi-card', false);
+        $response->assertSee('Dokumen Knowledge', false);
+        $response->assertSee('Upload Knowledge', false);
+        $response->assertSee('Admin only', false);
     }
 
     public function test_regular_user_cannot_access_knowledge_page(): void

--- a/laravel/tests/Feature/Admin/AdminMonitoringDashboardTest.php
+++ b/laravel/tests/Feature/Admin/AdminMonitoringDashboardTest.php
@@ -359,11 +359,13 @@ class AdminMonitoringDashboardTest extends TestCase
         $response->assertSee('Dokumen User', false);
         $response->assertSee('admin-documents-kpi-card', false);
         $response->assertSee('admin-documents-kpi-card__icon', false);
-        $response->assertSee('Menampilkan 10 dokumen per halaman', false);
+        $response->assertSee('Maksimum 10 baris', false);
         $response->assertSee('Distribusi Tipe', false);
         $response->assertSee('Status Pipeline', false);
         $response->assertSee('PDF', false);
-        $response->assertSee('Pipeline Dokumen', false);
+        $response->assertSee('Dokumen Terbaru', false);
+        $response->assertSee('Chunks', false);
+        $response->assertDontSee('Pipeline Dokumen', false);
         $response->assertSee('Detail', false);
         $response->assertSee('a.pdf', false);
         $response->assertSee('b.pdf', false);
@@ -442,7 +444,7 @@ class AdminMonitoringDashboardTest extends TestCase
         Carbon::setTestNow();
     }
 
-    public function test_admin_documents_detail_drawer_shows_pipeline_metadata(): void
+    public function test_admin_documents_detail_modal_shows_compact_metadata(): void
     {
         $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
         $owner = User::factory()->create(['role' => User::ROLE_USER]);
@@ -476,9 +478,10 @@ class AdminMonitoringDashboardTest extends TestCase
 
         Livewire::test(AdminDocuments::class)
             ->call('showDetail', $document->id)
-            ->assertSee('Document Pipeline')
-            ->assertSee('AI Index Metadata')
-            ->assertSee('Chunk Count')
+            ->assertSee('Document Detail')
+            ->assertSee('Status AI')
+            ->assertSee('Metadata ringkas')
+            ->assertSee('Chunks')
             ->assertSee('2')
             ->assertSee('Indexed')
             ->assertSee('GOOGLE DRIVE', false)
@@ -513,7 +516,7 @@ class AdminMonitoringDashboardTest extends TestCase
         $this->actingAs($admin);
 
         Livewire::test(AdminDocuments::class)
-            ->assertSee('Menampilkan 10 dokumen per halaman')
+            ->assertSee('Maksimum 10 baris')
             ->assertSee('document-row-1.pdf', false)
             ->assertDontSee('document-row-11.pdf', false)
             ->call('gotoPage', 2)


### PR DESCRIPTION
## Summary
- update admin documents table to match the requested compact file/user/type/size/status/chunks/time/action layout
- replace the noisy document detail drawer with a compact modal aligned with the error detail modal
- restyle admin knowledge with consistent hero, KPI cards, filters, table, upload panel, and status panel

## Verification
- cd laravel && php artisan test tests/Feature/Admin/AdminMonitoringDashboardTest.php tests/Feature/Admin/AdminKnowledgeManagementTest.php tests/Feature/Admin/AdminLayoutTest.php
- cd laravel && npm run build
- git diff --check
- cd laravel && php artisan test
- cd python-ai && source venv/bin/activate && pytest