### PR TITLE
Polish admin tables and pagination

### DIFF
--- a/issue/issue-admin-ui-consistency-actions-pagination-2026-05-19.md
+++ b/issue/issue-admin-ui-consistency-actions-pagination-2026-05-19.md
@@ -1,0 +1,59 @@
+# Admin UI Consistency, Actions, and Pagination Hotfix
+
+Tanggal: 2026-05-19
+
+## Tujuan
+
+Merapikan lanjutan halaman admin production agar konsisten di tab Users, Documents, Account Management, dan pagination semua tabel. Perubahan juga menambahkan aksi hapus akun regular user oleh super admin dengan guard agar akun admin/super admin tidak bisa ikut terhapus dari tab Users.
+
+## Scope
+
+- Users:
+  - `/admin/users` hanya menampilkan regular user.
+  - Hilangkan filter/kolom role serta kolom event hari ini dan event 7 hari.
+  - Tambahkan aksi delete akun user untuk super admin saja.
+  - Guard backend: hanya super admin aktif yang boleh menghapus regular user; target admin/super admin harus ditolak.
+- KPI:
+  - Persentase di kartu admin dibulatkan ke integer: `0%`, `11%`, bukan `0.0%`.
+- Account Management:
+  - Tombol `Tambah Akun` dipindah dari hero ke header tabel `Daftar Akun Admin`.
+- Documents:
+  - Icon file mengikuti warna/type icon di sidebar dokumen chat.
+  - Hilangkan kolom `Tipe` dari tabel `Dokumen Terbaru`.
+  - Status chip dokumen memakai style standar yang sama dengan tabel admin lain.
+  - Modal detail dokumen dibuat lebih ringkas dan fokus: status, owner, size, chunks, source, uploaded, status AI, metadata penting.
+- Pagination:
+  - Buat pagination admin standar berbahasa Indonesia.
+  - Terapkan ke tabel Users, Usage, Errors, Documents, dan Account Management.
+
+## Risiko
+
+- Delete akun user menyentuh data berelasi. Untuk dokumen, cleanup harus melewati `DocumentLifecycleService` agar file, preview, dan vector ikut dibersihkan sebelum user dihapus.
+- Perubahan Blade/CSS harus tetap aman di dark mode dan tidak memunculkan scrollbar horizontal.
+- Pagination custom harus tetap kompatibel dengan Livewire paginator.
+
+## Rencana Implementasi
+
+1. Tambah service method untuk delete regular user dengan audit dan cleanup dokumen.
+2. Update Livewire Users agar listing dan summary selalu regular-user only, serta expose aksi delete untuk super admin.
+3. Update Blade/CSS Users, Documents, Accounts, dan pagination shared.
+4. Update format persentase admin ke integer di tab terkait.
+5. Tambahkan/update test untuk guard delete, regular-only users, documents table, modal documents, dan pagination Indonesia.
+6. Jalankan test Laravel relevan, build asset, lalu full verification sebelum merge/deploy.
+7. Deploy ke production dan QA end-to-end. Jika ada mismatch, patch-deploy-QA ulang.
+
+## Verifikasi
+
+- Targeted Laravel tests:
+  - `php artisan test tests/Feature/Admin/AdminMonitoringDashboardTest.php tests/Feature/Admin/AdminAccountManagementTest.php tests/Unit/Services/Admin/AdminMetricsServiceTest.php`
+- Build frontend:
+  - `npm run build`
+- Full Laravel test sebelum merge/deploy:
+  - `php artisan test`
+- Full Python test sebelum merge/deploy:
+  - `cd python-ai && source venv/bin/activate && pytest`
+- Production QA:
+  - Health check.
+  - Smoke auth/admin routes.
+  - Screenshot/check UI admin untuk Users, Documents, Account Management, pagination, dan modal detail dokumen.
+  - Cek log container setelah deploy.

--- a/laravel/app/Livewire/Admin/AdminUsers.php
+++ b/laravel/app/Livewire/Admin/AdminUsers.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Admin;
 
 use App\Models\User;
 use App\Services\Admin\AdminMetricsService;
+use App\Services\Admin\AdminUserManagementService;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -19,7 +20,7 @@ class AdminUsers extends Component
 
     public string $status = '';
 
-    public string $role = '';
+    public ?string $flashMessage = null;
 
     /**
      * @var array<string, array<int, string>>
@@ -27,7 +28,6 @@ class AdminUsers extends Component
     protected $queryString = [
         'search' => ['except' => ''],
         'status' => ['except' => ''],
-        'role' => ['except' => ''],
     ];
 
     public function updatingSearch(): void
@@ -40,15 +40,25 @@ class AdminUsers extends Component
         $this->resetPage();
     }
 
-    public function updatingRole(): void
+    public function resetFilters(): void
     {
+        $this->reset(['search', 'status']);
         $this->resetPage();
     }
 
-    public function resetFilters(): void
+    public function deleteUser(int $userId, AdminUserManagementService $service): void
     {
-        $this->reset(['search', 'status', 'role']);
+        $target = User::query()->findOrFail($userId);
+
+        $service->deleteRegularUser(auth()->user(), $target, request());
+
+        $this->flashMessage = sprintf('Akun "%s" berhasil dihapus.', $target->email);
         $this->resetPage();
+    }
+
+    public function clearFlash(): void
+    {
+        $this->flashMessage = null;
     }
 
     public function render(AdminMetricsService $metrics)
@@ -56,7 +66,7 @@ class AdminUsers extends Component
         $users = $metrics->userPresenceListing(
             [
                 'status' => $this->normalizedStatus(),
-                'role' => $this->normalizedRole(),
+                'role' => User::ROLE_USER,
                 'search' => $this->search,
             ],
             self::USERS_PER_PAGE,
@@ -67,17 +77,13 @@ class AdminUsers extends Component
         return view('livewire.admin.admin-users', [
             'users' => $users,
             'usersPerPage' => self::USERS_PER_PAGE,
-            'presenceSummary' => $metrics->userPresenceSummary(),
+            'presenceSummary' => $metrics->userPresenceSummary(role: User::ROLE_USER),
             'statusOptions' => [
                 'online' => 'Online',
                 'idle' => 'Idle',
                 'offline' => 'Offline',
             ],
-            'roleOptions' => [
-                User::ROLE_USER => 'User',
-                User::ROLE_ADMIN => 'Admin',
-                User::ROLE_SUPER_ADMIN => 'Super Admin',
-            ],
+            'canDeleteUsers' => auth()->user()?->isSuperAdmin() && auth()->user()?->isActive(),
         ]);
     }
 
@@ -86,8 +92,4 @@ class AdminUsers extends Component
         return in_array($this->status, ['online', 'idle', 'offline'], true) ? $this->status : null;
     }
 
-    private function normalizedRole(): ?string
-    {
-        return in_array($this->role, User::ROLES, true) ? $this->role : null;
-    }
 }

--- a/laravel/app/Models/AdminAccountAudit.php
+++ b/laravel/app/Models/AdminAccountAudit.php
@@ -28,6 +28,8 @@ class AdminAccountAudit extends Model
 
     public const ACTION_ROLE_CHANGED = 'admin_role_changed';
 
+    public const ACTION_REGULAR_USER_DELETED = 'regular_user_deleted';
+
     protected $fillable = [
         'actor_id',
         'target_user_id',

--- a/laravel/app/Services/Admin/AdminMetricsService.php
+++ b/laravel/app/Services/Admin/AdminMetricsService.php
@@ -130,17 +130,23 @@ class AdminMetricsService
      *
      * @return array{total: int, online: int, idle: int, offline: int}
      */
-    public function userPresenceSummary(?CarbonInterface $now = null): array
+    public function userPresenceSummary(?CarbonInterface $now = null, ?string $role = null): array
     {
         $now = $now ? $now->copy() : now();
-        $total = User::query()->count();
+        $baseQuery = User::query();
 
-        $online = User::query()
+        if ($role !== null && in_array($role, User::ROLES, true)) {
+            $baseQuery->where('role', $role);
+        }
+
+        $total = (clone $baseQuery)->count();
+
+        $online = (clone $baseQuery)
             ->whereNotNull('last_seen_at')
             ->where('last_seen_at', '>=', $now->copy()->subMinutes(self::PRESENCE_ONLINE_MINUTES))
             ->count();
 
-        $idle = User::query()
+        $idle = (clone $baseQuery)
             ->whereNotNull('last_seen_at')
             ->where('last_seen_at', '<', $now->copy()->subMinutes(self::PRESENCE_ONLINE_MINUTES))
             ->where('last_seen_at', '>=', $now->copy()->subMinutes(self::PRESENCE_IDLE_MINUTES))

--- a/laravel/app/Services/Admin/AdminUserManagementService.php
+++ b/laravel/app/Services/Admin/AdminUserManagementService.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Services\Admin;
+
+use App\Models\AdminAccountAudit;
+use App\Models\Conversation;
+use App\Models\Document;
+use App\Models\Memo;
+use App\Models\User;
+use App\Services\DocumentLifecycleService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class AdminUserManagementService
+{
+    public function __construct(
+        private readonly AdminAccountAuditService $audit,
+        private readonly DocumentLifecycleService $documentLifecycle,
+    ) {
+    }
+
+    /**
+     * Delete a regular user account and clean user-owned document artifacts.
+     */
+    public function deleteRegularUser(User $actor, User $target, ?Request $request = null): bool
+    {
+        $this->guardActorIsSuperAdmin($actor);
+        $this->guardTargetIsRegularUser($target);
+
+        $metadata = [
+            'conversation_count' => Conversation::query()->where('user_id', $target->id)->count(),
+            'document_count' => Document::query()->where('user_id', $target->id)->count(),
+            'memo_count' => Memo::query()->where('user_id', $target->id)->count(),
+        ];
+
+        Document::query()
+            ->where('user_id', $target->id)
+            ->orderBy('id')
+            ->get()
+            ->each(fn (Document $document) => $this->documentLifecycle->deleteDocument($document));
+
+        return DB::transaction(function () use ($actor, $target, $metadata, $request) {
+            $before = $this->audit->snapshot($target);
+
+            $this->audit->record(
+                AdminAccountAudit::ACTION_REGULAR_USER_DELETED,
+                actor: $actor,
+                target: $target,
+                before: $before,
+                metadata: $metadata,
+                request: $request,
+            );
+
+            DB::table('sessions')->where('user_id', $target->id)->delete();
+
+            return (bool) $target->delete();
+        });
+    }
+
+    private function guardActorIsSuperAdmin(User $actor): void
+    {
+        if (! $actor->isSuperAdmin() || ! $actor->isActive()) {
+            Log::warning('Non super admin attempted regular user deletion', [
+                'actor_id' => $actor->id,
+                'role' => $actor->role,
+            ]);
+
+            abort(403, 'Hanya super admin aktif yang dapat menghapus akun user.');
+        }
+    }
+
+    private function guardTargetIsRegularUser(User $target): void
+    {
+        if ($target->role !== User::ROLE_USER) {
+            Log::warning('Regular user deletion attempted on admin-family target', [
+                'target_id' => $target->id,
+                'role' => $target->role,
+            ]);
+
+            abort(404, 'Akun target bukan user regular.');
+        }
+    }
+}

--- a/laravel/resources/css/app.css
+++ b/laravel/resources/css/app.css
@@ -294,6 +294,69 @@
     .admin-badge--gold { @apply border-amber-300 bg-amber-100/70 text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/15 dark:text-amber-300; }
     .admin-badge--primary { @apply border-ista-primary/30 bg-ista-primary/10 text-ista-primary dark:border-ista-primary/40 dark:bg-ista-primary/20 dark:text-amber-300; }
 
+    .admin-status-chip {
+        @apply inline-flex min-w-[4.8rem] items-center justify-center gap-1.5 rounded-full px-2.5 py-1 text-[0.64rem] font-bold ring-1;
+        letter-spacing: 0;
+    }
+
+    .admin-status-chip > span {
+        @apply h-1.5 w-1.5 rounded-full;
+    }
+
+    .admin-status-chip--success {
+        @apply bg-emerald-50 text-emerald-700 ring-emerald-100 dark:bg-emerald-400/10 dark:text-emerald-300 dark:ring-emerald-300/20;
+    }
+
+    .admin-status-chip--success > span { @apply bg-emerald-500; }
+
+    .admin-status-chip--warning {
+        @apply bg-amber-50 text-amber-700 ring-amber-100 dark:bg-amber-400/10 dark:text-amber-300 dark:ring-amber-300/20;
+    }
+
+    .admin-status-chip--warning > span { @apply bg-amber-500; }
+
+    .admin-status-chip--danger {
+        @apply bg-rose-50 text-rose-700 ring-rose-100 dark:bg-rose-500/10 dark:text-rose-300 dark:ring-rose-400/20;
+    }
+
+    .admin-status-chip--danger > span { @apply bg-rose-500; }
+
+    .admin-status-chip--neutral {
+        @apply bg-stone-100 text-stone-600 ring-stone-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700;
+    }
+
+    .admin-status-chip--neutral > span { @apply bg-stone-400 dark:bg-gray-500; }
+
+    .admin-pagination {
+        @apply flex w-full flex-wrap items-center justify-between gap-3 text-[0.72rem] text-stone-500 dark:text-gray-400;
+    }
+
+    .admin-pagination__summary {
+        @apply font-medium;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-pagination__nav {
+        @apply flex flex-wrap items-center justify-end gap-1.5;
+    }
+
+    .admin-pagination__button {
+        @apply inline-flex h-7 min-w-7 items-center justify-center rounded-md border border-stone-200 bg-white px-2 text-[0.68rem] font-semibold text-stone-600 transition hover:border-ista-primary/40 hover:bg-ista-primary/5 hover:text-ista-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-300 dark:hover:border-amber-300/40 dark:hover:bg-amber-300/10 dark:hover:text-amber-300;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .admin-pagination__button--active {
+        @apply border-ista-primary bg-ista-primary text-white shadow-[0_8px_18px_rgba(139,8,54,0.16)] dark:border-amber-300 dark:bg-amber-300 dark:text-gray-950;
+    }
+
+    .admin-pagination__button--disabled {
+        @apply cursor-not-allowed bg-stone-50 text-stone-300 dark:bg-gray-900 dark:text-gray-600;
+    }
+
+    .admin-pagination__ellipsis {
+        @apply inline-flex h-7 min-w-7 items-center justify-center text-stone-400 dark:text-gray-500;
+    }
+
     .admin-empty-state {
         @apply flex flex-col items-center justify-center rounded-xl border border-dashed border-stone-200 bg-stone-50/40 px-6 py-10 text-center dark:border-gray-800 dark:bg-gray-900/40;
     }
@@ -454,6 +517,10 @@
         @apply grid gap-3 px-4 pb-3.5 pt-3 md:grid-cols-[minmax(15rem,1fr)_minmax(10rem,0.7fr)_minmax(10rem,0.85fr)_minmax(5rem,0.25fr)];
     }
 
+    .admin-users-filter-grid--compact {
+        @apply md:grid-cols-[minmax(15rem,1fr)_minmax(10rem,0.42fr)];
+    }
+
     .admin-users-filter {
         @apply flex flex-col gap-1.5;
     }
@@ -569,6 +636,22 @@
 
     .admin-users-total-cell__meta {
         @apply whitespace-nowrap;
+    }
+
+    .admin-users-alert {
+        @apply mx-4 mt-3 flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-[0.74rem] font-medium;
+    }
+
+    .admin-users-alert--success {
+        @apply border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300;
+    }
+
+    .admin-users-alert button {
+        @apply inline-flex h-7 w-7 flex-none items-center justify-center rounded-md transition hover:bg-black/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:hover:bg-white/10;
+    }
+
+    .admin-users-delete-button {
+        @apply inline-flex h-7 items-center justify-center rounded-md border border-rose-200 bg-rose-50 px-2.5 text-[0.68rem] font-semibold text-rose-700 transition hover:border-ista-primary/40 hover:bg-ista-primary hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ista-primary/25 dark:border-rose-400/20 dark:bg-rose-500/10 dark:text-rose-300 dark:hover:border-amber-300/40 dark:hover:bg-amber-300 dark:hover:text-gray-950;
     }
 
     .admin-users-pagination {
@@ -964,58 +1047,28 @@
     }
 
     .admin-documents-file-icon {
-        @apply relative inline-flex h-9 w-8 flex-none items-center justify-center font-mono text-[0.52rem] font-black;
-        letter-spacing: 0;
+        @apply inline-flex h-[34px] w-[34px] flex-none items-center justify-center rounded-lg border border-stone-200/60 bg-white/80 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800;
     }
 
     .admin-documents-file-icon svg {
-        @apply absolute inset-0 h-full w-full;
+        @apply h-[18px] w-[18px] shrink-0;
     }
 
-    .admin-documents-file-icon > span {
-        @apply absolute bottom-1 left-1/2 z-10 -translate-x-1/2 rounded-[0.16rem] px-0.5 py-px text-[0.43rem] font-black leading-none text-white shadow-sm;
-        letter-spacing: 0;
+    .admin-documents-file-icon--modal {
+        @apply h-10 w-10;
     }
 
-    .admin-documents-file-icon--pdf {
-        @apply text-red-500 dark:text-red-300;
+    .admin-documents-file-icon--modal svg {
+        @apply h-[21px] w-[21px];
     }
 
-    .admin-documents-file-icon--pdf > span {
-        @apply bg-red-600 dark:bg-red-500;
-    }
-
-    .admin-documents-file-icon--csv {
-        @apply text-emerald-600 dark:text-emerald-300;
-    }
-
-    .admin-documents-file-icon--csv > span {
-        @apply bg-emerald-700 dark:bg-emerald-500;
-    }
-
-    .admin-documents-file-icon--xlsx {
-        @apply text-green-700 dark:text-green-300;
-    }
-
-    .admin-documents-file-icon--xlsx > span {
-        @apply bg-green-700 dark:bg-green-500;
-    }
-
-    .admin-documents-file-icon--docx {
-        @apply text-sky-600 dark:text-sky-300;
-    }
-
-    .admin-documents-file-icon--docx > span {
-        @apply bg-sky-600 dark:bg-sky-500;
-    }
-
-    .admin-documents-file-icon--file {
-        @apply text-stone-500 dark:text-gray-300;
-    }
-
-    .admin-documents-file-icon--file > span {
-        @apply bg-stone-600 dark:bg-gray-500;
-    }
+    .admin-documents-file-icon--pdf { color: #FF2056; }
+    .admin-documents-file-icon--csv,
+    .admin-documents-file-icon--xlsx { color: #32CD32; }
+    .admin-documents-file-icon--docx { color: #2B7FFF; }
+    .admin-documents-file-icon--txt,
+    .admin-documents-file-icon--file { color: #62748E; }
+    .admin-documents-file-icon--image { color: #FD9A00; }
 
     .admin-documents-file-cell__name,
     .admin-documents-user-cell__name {
@@ -1108,7 +1161,7 @@
     }
 
     .admin-documents-table-footer {
-        @apply flex flex-wrap items-center justify-center gap-3 border-t border-stone-100 px-3 py-3 text-center text-[0.74rem] text-stone-500 dark:border-gray-800 dark:text-gray-400;
+        @apply border-t border-stone-100 px-3 py-3 text-[0.74rem] text-stone-500 dark:border-gray-800 dark:text-gray-400;
     }
 
     .admin-documents-pagination {
@@ -1240,7 +1293,8 @@
         @apply mt-1 block truncate text-xs font-semibold text-stone-900 dark:text-gray-100;
     }
 
-    .admin-documents-modal__summary-grid strong.admin-documents-status-chip {
+    .admin-documents-modal__summary-grid strong.admin-documents-status-chip,
+    .admin-documents-modal__summary-grid strong.admin-status-chip {
         @apply inline-flex;
     }
 
@@ -1336,7 +1390,8 @@
         @apply mt-1 block truncate text-xs font-semibold text-stone-900 dark:text-gray-100;
     }
 
-    .admin-documents-drawer__summary strong.admin-documents-status-chip {
+    .admin-documents-drawer__summary strong.admin-documents-status-chip,
+    .admin-documents-drawer__summary strong.admin-status-chip {
         @apply inline-flex;
     }
 
@@ -1649,6 +1704,10 @@
 
     .admin-accounts-primary-button {
         @apply bg-ista-primary text-white shadow-[0_8px_20px_rgba(139,8,54,0.18)] hover:bg-rose-900 focus-visible:ring-ista-primary/30 dark:bg-amber-300 dark:text-gray-950 dark:hover:bg-amber-200;
+    }
+
+    .admin-accounts-table-add-button {
+        @apply h-8 px-3 text-[0.72rem];
     }
 
     .admin-accounts-secondary-button {

--- a/laravel/resources/views/admin/pagination.blade.php
+++ b/laravel/resources/views/admin/pagination.blade.php
@@ -1,0 +1,63 @@
+@if ($paginator->hasPages())
+    <nav class="admin-pagination" role="navigation" aria-label="Pagination">
+        <p class="admin-pagination__summary">
+            Menampilkan {{ number_format($paginator->firstItem() ?? 0) }}-{{ number_format($paginator->lastItem() ?? 0) }}
+            dari {{ number_format($paginator->total()) }}
+        </p>
+
+        <div class="admin-pagination__nav">
+            @if ($paginator->onFirstPage())
+                <span class="admin-pagination__button admin-pagination__button--disabled" aria-disabled="true" aria-label="Halaman sebelumnya">‹</span>
+            @else
+                <button type="button"
+                        class="admin-pagination__button"
+                        wire:click="previousPage('{{ $paginator->getPageName() }}')"
+                        wire:loading.attr="disabled"
+                        rel="prev"
+                        aria-label="Halaman sebelumnya">
+                    ‹
+                </button>
+            @endif
+
+            @foreach ($elements as $element)
+                @if (is_string($element))
+                    <span class="admin-pagination__ellipsis" aria-hidden="true">{{ $element }}</span>
+                @endif
+
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <span class="admin-pagination__button admin-pagination__button--active" aria-current="page">{{ $page }}</span>
+                        @else
+                            <button type="button"
+                                    class="admin-pagination__button"
+                                    wire:click="gotoPage({{ $page }}, '{{ $paginator->getPageName() }}')"
+                                    wire:loading.attr="disabled">
+                                {{ $page }}
+                            </button>
+                        @endif
+                    @endforeach
+                @endif
+            @endforeach
+
+            @if ($paginator->hasMorePages())
+                <button type="button"
+                        class="admin-pagination__button"
+                        wire:click="nextPage('{{ $paginator->getPageName() }}')"
+                        wire:loading.attr="disabled"
+                        rel="next"
+                        aria-label="Halaman berikutnya">
+                    ›
+                </button>
+            @else
+                <span class="admin-pagination__button admin-pagination__button--disabled" aria-disabled="true" aria-label="Halaman berikutnya">›</span>
+            @endif
+        </div>
+    </nav>
+@else
+    <div class="admin-pagination admin-pagination--single">
+        <p class="admin-pagination__summary">
+            Menampilkan {{ number_format($paginator->total()) }} dari {{ number_format($paginator->total()) }}
+        </p>
+    </div>
+@endif

--- a/laravel/resources/views/components/admin/document-icon.blade.php
+++ b/laravel/resources/views/components/admin/document-icon.blade.php
@@ -1,0 +1,28 @@
+@props([
+    'type' => 'file',
+    'label' => 'File',
+])
+
+@php
+    $type = in_array($type, ['pdf', 'csv', 'xlsx', 'docx', 'txt', 'image', 'file'], true) ? $type : 'file';
+@endphp
+
+<span {{ $attributes->merge(['class' => 'admin-documents-file-icon admin-documents-file-icon--' . $type]) }} aria-label="{{ $label }}" role="img">
+    @if ($type === 'pdf')
+        <svg fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd" />
+        </svg>
+    @elseif ($type === 'image')
+        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 5h16a1 1 0 011 1v12a1 1 0 01-1 1H4a1 1 0 01-1-1V6a1 1 0 011-1zm4 4h.01M21 15l-5-5-7 7-3-3-3 3" />
+        </svg>
+    @else
+        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            @if ($type === 'txt')
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M7 3h7l5 5v13a1 1 0 01-1 1H7a1 1 0 01-1-1V4a1 1 0 011-1zm7 1v4h4M8 13h8M8 17h6" />
+            @else
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M7 3h7l5 5v13a1 1 0 01-1 1H7a1 1 0 01-1-1V4a1 1 0 011-1zm7 1v4h4M8 13h8M8 17h8" />
+            @endif
+        </svg>
+    @endif
+</span>

--- a/laravel/resources/views/livewire/admin/admin-accounts.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-accounts.blade.php
@@ -63,12 +63,6 @@
                 <span></span>
                 Akses terbatas
             </span>
-            <button type="button" wire:click="openCreateModal" class="admin-accounts-primary-button">
-                <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M12 4v16m8-8H4"/>
-                </svg>
-                Tambah Akun
-            </button>
         </div>
     </div>
 
@@ -175,6 +169,12 @@
                     <h3>Daftar Akun Admin</h3>
                     <p>Menampilkan {{ $accountsPerPage }} akun per halaman pada filter aktif.</p>
                 </div>
+                <button type="button" wire:click="openCreateModal" class="admin-accounts-primary-button admin-accounts-table-add-button">
+                    <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M12 4v16m8-8H4"/>
+                    </svg>
+                    Tambah Akun
+                </button>
             </header>
 
             <div class="admin-accounts-table-panel__body">
@@ -269,7 +269,7 @@
 
                 @if ($accounts->hasPages())
                     <div class="admin-accounts-pagination">
-                        {{ $accounts->links() }}
+                        {{ $accounts->links('admin.pagination') }}
                     </div>
                 @endif
             </div>

--- a/laravel/resources/views/livewire/admin/admin-dashboard.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-dashboard.blade.php
@@ -1,6 +1,6 @@
 @php
     $formatInt = fn ($value): string => number_format((float) $value, 0, ',', '.');
-    $formatPct = fn ($value): string => number_format((float) $value, 1, ',', '.') . '%';
+    $formatPct = fn ($value): string => number_format((float) $value, 0, ',', '.') . '%';
     $formatSeconds = fn ($milliseconds): string => number_format(((float) $milliseconds) / 1000, 2, ',', '.') . 's';
     $trendClass = function (?array $trend): string {
         return match ($trend['tone'] ?? 'neutral') {
@@ -23,7 +23,7 @@
         $unit = $trend['unit'] ?? 'percent';
 
         $value = match ($unit) {
-            'percentage_points' => number_format($delta, 1, ',', '.') . ' poin',
+            'percentage_points' => number_format($delta, 0, ',', '.') . ' poin',
             'milliseconds' => $formatSeconds($delta),
             default => $formatPct(abs((float) ($trend['delta_percent'] ?? 0))),
         };

--- a/laravel/resources/views/livewire/admin/admin-documents.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-documents.blade.php
@@ -2,10 +2,10 @@
     $formatInt = fn ($value): string => number_format((float) $value, 0, ',', '.');
     $formatPct = function (int $value, int $total): string {
         if ($total <= 0) {
-            return '0.0%';
+            return '0%';
         }
 
-        return number_format(($value / $total) * 100, 1, '.', '') . '%';
+        return ((int) round(($value / $total) * 100)) . '%';
     };
     $formatBytes = function (int $bytes): string {
         if ($bytes >= 1073741824) {
@@ -30,6 +30,8 @@
             in_array($mime, ['text/csv', 'text/plain', 'application/csv'], true) || $extension === 'csv' => 'csv',
             in_array($mime, ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel'], true) || in_array($extension, ['xls', 'xlsx'], true) => 'xlsx',
             $mime === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' || $extension === 'docx' => 'docx',
+            $extension === 'txt' => 'txt',
+            in_array($extension, ['png', 'jpg', 'jpeg', 'gif', 'webp', 'img'], true) => 'image',
             default => 'file',
         };
 
@@ -40,6 +42,8 @@
                 'csv' => 'CSV',
                 'xlsx' => 'XLSX',
                 'docx' => 'DOCX',
+                'txt' => 'TXT',
+                'image' => 'IMG',
                 default => strtoupper($extension ?: 'FILE'),
             },
             'type_label' => match ($type) {
@@ -71,12 +75,12 @@
         return match ($status) {
             'ready' => ['label' => 'Ready', 'tone' => 'success'],
             'processing' => ['label' => 'Processing', 'tone' => 'warning'],
-            'pending' => ['label' => 'Pending', 'tone' => 'neutral'],
+            'pending' => ['label' => 'Pending', 'tone' => 'warning'],
             'error' => ['label' => 'Failed', 'tone' => 'danger'],
             default => ['label' => ucfirst((string) ($status ?: 'Unknown')), 'tone' => 'neutral'],
         };
     };
-    $stageState = function (string $status, string $previewStatus, string $stage): string {
+    $stageState = function (string $status, string $previewStatus, string $stage, int $chunks = 0): string {
         if ($stage === 'uploaded') {
             return 'done';
         }
@@ -94,7 +98,7 @@
         }
 
         if ($stage === 'indexed') {
-            if ($status === 'ready') {
+            if ($status === 'ready' && $chunks > 0) {
                 return 'done';
             }
 
@@ -124,11 +128,17 @@
             $status === 'processing' => 'Parsing',
             default => 'Queued',
         };
-        $embeddingStatus = match ($status) {
-            'ready' => 'Indexed',
-            'processing' => 'Indexing',
-            'error' => 'Failed',
+        $embeddingStatus = match (true) {
+            $status === 'ready' && $chunks > 0 => 'Indexed',
+            $status === 'ready' && $chunks === 0 => 'Index kosong',
+            $status === 'processing' => 'Indexing',
+            $status === 'error' => 'Failed',
             default => 'Waiting',
+        };
+        $chunkStatus = match (true) {
+            $chunks > 0 => number_format($chunks) . ' chunk siap',
+            $status === 'error' => 'Belum ada chunk',
+            default => 'Index kosong',
         };
 
         return [
@@ -136,12 +146,13 @@
             'tone' => $status === 'error' ? 'danger' : ($status === 'ready' ? 'success' : 'warning'),
             'parse_status' => $parseStatus,
             'embedding_status' => $embeddingStatus,
+            'chunk_status' => $chunkStatus,
             'chunk_count' => $chunks,
             'stages' => [
-                ['key' => 'uploaded', 'label' => 'Uploaded', 'state' => $stageState($status, $previewStatus, 'uploaded')],
-                ['key' => 'parsed', 'label' => 'Parsed', 'state' => $stageState($status, $previewStatus, 'parsed')],
-                ['key' => 'indexed', 'label' => 'Indexed', 'state' => $stageState($status, $previewStatus, 'indexed')],
-                ['key' => 'ready', 'label' => 'Ready', 'state' => $stageState($status, $previewStatus, 'ready')],
+                ['key' => 'uploaded', 'label' => 'Uploaded', 'state' => $stageState($status, $previewStatus, 'uploaded', $chunks)],
+                ['key' => 'parsed', 'label' => 'Parsed', 'state' => $stageState($status, $previewStatus, 'parsed', $chunks)],
+                ['key' => 'indexed', 'label' => 'Indexed', 'state' => $stageState($status, $previewStatus, 'indexed', $chunks)],
+                ['key' => 'ready', 'label' => 'Ready', 'state' => $stageState($status, $previewStatus, 'ready', $chunks)],
             ],
         ];
     };
@@ -297,14 +308,13 @@
                     <x-admin.table
                         class="admin-documents-table"
                         :columns="[
-                            ['key' => 'file', 'label' => 'File', 'width' => '26%'],
-                            ['key' => 'owner', 'label' => 'User', 'width' => '18%'],
-                            ['key' => 'type', 'label' => 'Tipe', 'width' => '12%'],
-                            ['key' => 'size', 'label' => 'Size', 'align' => 'right', 'width' => '9%'],
-                            ['key' => 'status', 'label' => 'Status', 'width' => '11%'],
+                            ['key' => 'file', 'label' => 'File', 'width' => '34%'],
+                            ['key' => 'owner', 'label' => 'User', 'width' => '21%'],
+                            ['key' => 'size', 'label' => 'Size', 'align' => 'right', 'width' => '10%'],
+                            ['key' => 'status', 'label' => 'Status', 'width' => '12%'],
                             ['key' => 'chunks', 'label' => 'Chunks', 'align' => 'center', 'width' => '8%'],
                             ['key' => 'uploaded', 'label' => 'Waktu', 'align' => 'right', 'width' => '9%'],
-                            ['key' => 'action', 'label' => 'Aksi', 'align' => 'right', 'width' => '7%'],
+                            ['key' => 'action', 'label' => 'Aksi', 'align' => 'right', 'width' => '6%'],
                         ]">
                         @foreach ($documents as $doc)
                             @php
@@ -314,13 +324,7 @@
                             <tr>
                                 <td class="admin-table__td">
                                     <div class="admin-documents-file-cell">
-                                        <span class="admin-documents-file-icon admin-documents-file-icon--{{ $typeMeta['key'] }}" aria-hidden="true">
-                                            <svg viewBox="0 0 32 38" fill="none" aria-hidden="true">
-                                                <path d="M7 1.75h12.6L29.25 11.4V33A3.25 3.25 0 0 1 26 36.25H7A3.25 3.25 0 0 1 3.75 33V5A3.25 3.25 0 0 1 7 1.75Z" stroke="currentColor" stroke-width="2"/>
-                                                <path d="M19.5 2.5V10a2 2 0 0 0 2 2H29" stroke="currentColor" stroke-width="2"/>
-                                            </svg>
-                                            <span>{{ $typeMeta['label'] }}</span>
-                                        </span>
+                                        <x-admin.document-icon :type="$typeMeta['key']" :label="$typeMeta['label']" />
                                         <div class="min-w-0">
                                             <span class="admin-documents-file-cell__name" title="{{ $doc->original_name }}">
                                                 {{ \Illuminate\Support\Str::limit((string) $doc->original_name, 54, '...') }}
@@ -337,14 +341,11 @@
                                         </div>
                                     </div>
                                 </td>
-                                <td class="admin-table__td">
-                                    <span class="admin-documents-type-label">{{ $typeMeta['type_label'] }}</span>
-                                </td>
                                 <td class="admin-table__td" data-align="right">
                                     <span class="admin-documents-number">{{ $doc->formatted_size }}</span>
                                 </td>
                                 <td class="admin-table__td">
-                                    <span class="admin-documents-status-chip admin-documents-status-chip--{{ $status['tone'] }}">
+                                    <span class="admin-status-chip admin-status-chip--{{ $status['tone'] }}">
                                         <span aria-hidden="true"></span>
                                         {{ $status['label'] }}
                                     </span>
@@ -369,11 +370,12 @@
                     </x-admin.table>
 
                     <div class="admin-documents-table-footer">
-                        <span>Menampilkan {{ number_format($documents->firstItem() ?? 0) }}-{{ number_format($documents->lastItem() ?? 0) }} dari {{ number_format($documents->total()) }} dokumen</span>
                         @if ($documents->hasPages())
                             <div class="admin-documents-pagination">
-                                {{ $documents->links() }}
+                                {{ $documents->links('admin.pagination') }}
                             </div>
+                        @else
+                            {{ $documents->links('admin.pagination') }}
                         @endif
                     </div>
                 @endif
@@ -467,19 +469,12 @@
             <section class="admin-documents-modal__panel">
                 <header class="admin-documents-modal__header">
                     <div class="admin-documents-modal__title-row">
-                        <span class="admin-documents-file-icon admin-documents-file-icon--{{ $selectedType['key'] }}" aria-hidden="true">
-                            <svg viewBox="0 0 32 38" fill="none" aria-hidden="true">
-                                <path d="M7 1.75h12.6L29.25 11.4V33A3.25 3.25 0 0 1 26 36.25H7A3.25 3.25 0 0 1 3.75 33V5A3.25 3.25 0 0 1 7 1.75Z" stroke="currentColor" stroke-width="2"/>
-                                <path d="M19.5 2.5V10a2 2 0 0 0 2 2H29" stroke="currentColor" stroke-width="2"/>
-                            </svg>
-                            <span>{{ $selectedType['label'] }}</span>
-                        </span>
+                        <x-admin.document-icon :type="$selectedType['key']" :label="$selectedType['label']" class="admin-documents-file-icon--modal" />
                         <div class="min-w-0">
                             <p class="admin-documents-modal__eyebrow">Document Detail</p>
                             <h3 id="admin-document-detail-title" title="{{ $selectedDocument->original_name }}">
                                 {{ \Illuminate\Support\Str::limit((string) $selectedDocument->original_name, 64, '...') }}
                             </h3>
-                            <span class="admin-documents-modal__code">{{ $selectedType['type_label'] }}</span>
                         </div>
                     </div>
                     <button type="button" wire:click="closeDetail" class="admin-documents-modal__close" aria-label="Tutup detail dokumen">
@@ -493,7 +488,7 @@
                     <div class="admin-documents-modal__summary-grid">
                         <div>
                             <span>Status</span>
-                            <strong class="admin-documents-status-chip admin-documents-status-chip--{{ $selectedStatus['tone'] }}">
+                            <strong class="admin-status-chip admin-status-chip--{{ $selectedStatus['tone'] }}">
                                 <span aria-hidden="true"></span>
                                 {{ $selectedStatus['label'] }}
                             </strong>
@@ -511,7 +506,7 @@
                         <div>
                             <span>Chunks</span>
                             <strong>{{ number_format((int) ($selectedDocument->chunks_count ?? 0)) }}</strong>
-                            <em>{{ $selectedPipeline['embedding_status'] }}</em>
+                            <em>{{ $selectedPipeline['chunk_status'] }}</em>
                         </div>
                         <div>
                             <span>Uploaded</span>
@@ -535,23 +530,35 @@
                                 <span class="admin-documents-pipeline__bar admin-documents-pipeline__bar--{{ $selectedPipeline['tone'] }}" style="width: {{ $selectedPipeline['progress'] }}%"></span>
                             </div>
                         </div>
-                        <p>{{ $selectedPipeline['parse_status'] }} · {{ $selectedPipeline['embedding_status'] }} · preview {{ ucfirst((string) ($selectedDocument->preview_status ?? 'pending')) }}.</p>
+                        <ul class="admin-documents-stage-list" role="list">
+                            @foreach ($selectedPipeline['stages'] as $stage)
+                                <li class="admin-documents-stage-list__item admin-documents-stage-list__item--{{ $stage['state'] }}">
+                                    <span aria-hidden="true"></span>
+                                    <strong>{{ $stage['label'] }}</strong>
+                                </li>
+                            @endforeach
+                        </ul>
+                        <p>{{ $selectedPipeline['parse_status'] }} · {{ $selectedPipeline['embedding_status'] }} · {{ $selectedPipeline['chunk_status'] }} · preview {{ ucfirst((string) ($selectedDocument->preview_status ?? 'pending')) }}.</p>
                     </section>
 
                     <section class="admin-documents-modal__section">
                         <h4>Metadata ringkas</h4>
                         <dl class="admin-documents-modal__metadata">
                             <div>
-                                <dt>Stored file</dt>
-                                <dd>{{ $selectedDocument->filename ?? '-' }}</dd>
-                            </div>
-                            <div>
                                 <dt>Original file</dt>
                                 <dd>{{ $selectedDocument->original_name ?? '-' }}</dd>
                             </div>
+                            <div>
+                                <dt>Uploaded</dt>
+                                <dd>{{ $selectedDocument->created_at?->toDateTimeString() ?? '-' }}</dd>
+                            </div>
+                            <div>
+                                <dt>Source</dt>
+                                <dd>{{ $selectedSource }}</dd>
+                            </div>
                             @if ($selectedDocument->source_external_id)
                                 <div>
-                                    <dt>External ID</dt>
+                                    <dt>Source ID</dt>
                                     <dd>{{ $selectedDocument->source_external_id }}</dd>
                                 </div>
                             @endif

--- a/laravel/resources/views/livewire/admin/admin-errors.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-errors.blade.php
@@ -2,10 +2,10 @@
     $formatInt = fn ($value): string => number_format((float) $value, 0, ',', '.');
     $formatPct = function (int $value, int $total): string {
         if ($total <= 0) {
-            return '0.0%';
+            return '0%';
         }
 
-        return number_format(($value / $total) * 100, 1, '.', '') . '%';
+        return ((int) round(($value / $total) * 100)) . '%';
     };
 
     $totalErrors = (int) ($errorSummary['total'] ?? 0);
@@ -208,7 +208,7 @@
 
                     @if ($errors->hasPages())
                         <div class="admin-errors-pagination">
-                            {{ $errors->links() }}
+                            {{ $errors->links('admin.pagination') }}
                         </div>
                     @endif
                 @endif

--- a/laravel/resources/views/livewire/admin/admin-knowledge.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-knowledge.blade.php
@@ -2,10 +2,10 @@
     $formatInt = fn ($value): string => number_format((float) $value, 0, ',', '.');
     $formatPct = function (int $value, int $total): string {
         if ($total <= 0) {
-            return '0.0%';
+            return '0%';
         }
 
-        return number_format(($value / $total) * 100, 1, '.', '') . '%';
+        return ((int) round(($value / $total) * 100)) . '%';
     };
     $fileTypeMeta = function ($doc): array {
         $mime = (string) ($doc?->mime_type ?? '');
@@ -15,6 +15,8 @@
             in_array($mime, ['text/csv', 'text/plain', 'application/csv'], true) || $extension === 'csv' => 'csv',
             in_array($mime, ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel'], true) || in_array($extension, ['xls', 'xlsx'], true) => 'xlsx',
             $mime === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' || $extension === 'docx' => 'docx',
+            $extension === 'txt' => 'txt',
+            in_array($extension, ['png', 'jpg', 'jpeg', 'gif', 'webp', 'img'], true) => 'image',
             default => 'file',
         };
 
@@ -25,6 +27,8 @@
                 'csv' => 'CSV',
                 'xlsx' => 'XLSX',
                 'docx' => 'DOCX',
+                'txt' => 'TXT',
+                'image' => 'IMG',
                 default => strtoupper($extension ?: 'FILE'),
             },
             'type_label' => match ($type) {
@@ -209,13 +213,7 @@
                                 <tr>
                                     <td class="admin-table__td">
                                         <div class="admin-documents-file-cell">
-                                            <span class="admin-documents-file-icon admin-documents-file-icon--{{ $typeMeta['key'] }}" aria-hidden="true">
-                                                <svg viewBox="0 0 32 38" fill="none" aria-hidden="true">
-                                                    <path d="M7 1.75h12.6L29.25 11.4V33A3.25 3.25 0 0 1 26 36.25H7A3.25 3.25 0 0 1 3.75 33V5A3.25 3.25 0 0 1 7 1.75Z" stroke="currentColor" stroke-width="2"/>
-                                                    <path d="M19.5 2.5V10a2 2 0 0 0 2 2H29" stroke="currentColor" stroke-width="2"/>
-                                                </svg>
-                                                <span>{{ $typeMeta['label'] }}</span>
-                                            </span>
+                                            <x-admin.document-icon :type="$typeMeta['key']" :label="$typeMeta['label']" />
                                             <div class="min-w-0">
                                                 <span class="admin-knowledge-file-name" title="{{ $doc->title }}">{{ \Illuminate\Support\Str::limit((string) $doc->title, 52, '...') }}</span>
                                                 <span class="admin-knowledge-file-meta">{{ \Illuminate\Support\Str::limit((string) $doc->original_name, 52, '...') }}</span>
@@ -241,7 +239,7 @@
                                         <span class="admin-documents-number">{{ $doc->formatted_size }}</span>
                                     </td>
                                     <td class="admin-table__td">
-                                        <span class="admin-documents-status-chip admin-documents-status-chip--{{ $status['tone'] }}">
+                                        <span class="admin-status-chip admin-status-chip--{{ $status['tone'] }}">
                                             <span aria-hidden="true"></span>
                                             {{ $status['label'] }}
                                         </span>

--- a/laravel/resources/views/livewire/admin/admin-usage.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-usage.blade.php
@@ -2,10 +2,10 @@
     $formatInt = fn ($value): string => number_format((float) $value, 0, ',', '.');
     $formatPct = function (int $value, int $total): string {
         if ($total <= 0) {
-            return '0.0%';
+            return '0%';
         }
 
-        return number_format(($value / $total) * 100, 1, '.', '') . '%';
+        return ((int) round(($value / $total) * 100)) . '%';
     };
 
     $totalEvents = (int) ($totals['total'] ?? 0);
@@ -224,7 +224,7 @@
 
                     @if ($events->hasPages())
                         <div class="admin-usage-pagination">
-                            {{ $events->links() }}
+                            {{ $events->links('admin.pagination') }}
                         </div>
                     @endif
                 @endif

--- a/laravel/resources/views/livewire/admin/admin-users.blade.php
+++ b/laravel/resources/views/livewire/admin/admin-users.blade.php
@@ -2,10 +2,10 @@
     $formatInt = fn ($value): string => number_format((float) $value, 0, ',', '.');
     $formatPct = function (int $value, int $total): string {
         if ($total <= 0) {
-            return '0.0%';
+            return '0%';
         }
 
-        return number_format(($value / $total) * 100, 1, '.', '') . '%';
+        return ((int) round(($value / $total) * 100)) . '%';
     };
 
     $totalUsers = (int) ($presenceSummary['total'] ?? 0);
@@ -112,7 +112,18 @@
             </div>
         </div>
 
-        <div class="admin-users-filter-grid">
+        @if ($flashMessage)
+            <div class="admin-users-alert admin-users-alert--success">
+                <span>{{ $flashMessage }}</span>
+                <button type="button" wire:click="clearFlash" aria-label="Tutup pesan">
+                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" d="M6 6l12 12M18 6L6 18"/>
+                    </svg>
+                </button>
+            </div>
+        @endif
+
+        <div class="admin-users-filter-grid admin-users-filter-grid--compact">
             <label class="admin-users-filter">
                 <span>Cari</span>
                 <div class="admin-users-search-control">
@@ -131,16 +142,6 @@
                 <select wire:model.live="status" class="admin-users-control">
                     <option value="">Semua</option>
                     @foreach ($statusOptions as $key => $label)
-                        <option value="{{ $key }}">{{ $label }}</option>
-                    @endforeach
-                </select>
-            </label>
-
-            <label class="admin-users-filter">
-                <span>Role</span>
-                <select wire:model.live="role" class="admin-users-control">
-                    <option value="">Semua</option>
-                    @foreach ($roleOptions as $key => $label)
                         <option value="{{ $key }}">{{ $label }}</option>
                     @endforeach
                 </select>
@@ -165,14 +166,12 @@
                 <x-admin.table
                     class="admin-users-table"
                     :columns="[
-                        ['key' => 'user', 'label' => 'User', 'width' => '21%'],
-                        ['key' => 'role', 'label' => 'Role', 'width' => '9%'],
-                        ['key' => 'status', 'label' => 'Status', 'width' => '10%'],
-                        ['key' => 'last_seen', 'label' => 'Last Seen', 'width' => '11%'],
+                        ['key' => 'user', 'label' => 'User', 'width' => '30%'],
+                        ['key' => 'status', 'label' => 'Status', 'width' => '13%'],
+                        ['key' => 'last_seen', 'label' => 'Last Seen', 'width' => '15%'],
                         ['key' => 'last_feature', 'label' => 'Aktivitas Terakhir', 'width' => '20%'],
-                        ['key' => 'events_today', 'label' => 'Event Hari Ini', 'align' => 'right', 'width' => '9%'],
-                        ['key' => 'events_week', 'label' => 'Event 7 Hari', 'align' => 'right', 'width' => '9%'],
-                        ['key' => 'totals', 'label' => 'Total', 'align' => 'right', 'width' => '11%'],
+                        ['key' => 'totals', 'label' => 'Total', 'align' => 'right', 'width' => '13%'],
+                        ['key' => 'actions', 'label' => 'Aksi', 'align' => 'right', 'width' => '9%'],
                     ]">
                     @foreach ($users as $user)
                         @php
@@ -180,11 +179,6 @@
                             $statusTone = match ($statusKey) {
                                 'online' => 'success',
                                 'idle' => 'warning',
-                                default => 'neutral',
-                            };
-                            $roleTone = match ($user->role) {
-                                \App\Models\User::ROLE_SUPER_ADMIN => 'gold',
-                                \App\Models\User::ROLE_ADMIN => 'primary',
                                 default => 'neutral',
                             };
                             $lastFeature = $user->last_active_feature
@@ -200,11 +194,6 @@
                                         <span class="admin-users-user-cell__email">{{ $user->email }}</span>
                                     </div>
                                 </div>
-                            </td>
-                            <td class="admin-table__td">
-                                <x-admin.badge :tone="$roleTone">
-                                    {{ $roleOptions[$user->role] ?? $user->role }}
-                                </x-admin.badge>
                             </td>
                             <td class="admin-table__td">
                                 <x-admin.badge :tone="$statusTone" class="admin-users-status-badge">
@@ -226,17 +215,23 @@
                                 <span class="admin-users-feature">{{ $lastFeature }}</span>
                             </td>
                             <td class="admin-table__td" data-align="right">
-                                <span class="admin-users-number">{{ number_format($user->getAttribute('events_today') ?? 0) }}</span>
-                            </td>
-                            <td class="admin-table__td" data-align="right">
-                                <span class="admin-users-number">{{ number_format($user->getAttribute('events_week') ?? 0) }}</span>
-                            </td>
-                            <td class="admin-table__td" data-align="right">
                                 <div class="admin-users-total-cell">
                                     <span class="admin-users-total-cell__primary">{{ number_format($user->getAttribute('conversation_count') ?? 0) }} conv</span>
                                     <span class="admin-users-total-cell__meta">{{ number_format($user->getAttribute('document_count') ?? 0) }} doc</span>
                                     <span class="admin-users-total-cell__meta">{{ number_format($user->getAttribute('memo_count') ?? 0) }} memo</span>
                                 </div>
+                            </td>
+                            <td class="admin-table__td" data-align="right">
+                                @if ($canDeleteUsers)
+                                    <button type="button"
+                                            wire:click="deleteUser({{ $user->id }})"
+                                            wire:confirm="Hapus akun user {{ $user->email }}? Percakapan, memo, dokumen, file, dan vector dokumen milik user ini akan ikut dibersihkan."
+                                            class="admin-users-delete-button">
+                                        Delete
+                                    </button>
+                                @else
+                                    <span class="admin-users-muted">-</span>
+                                @endif
                             </td>
                         </tr>
                     @endforeach
@@ -244,7 +239,7 @@
 
                 @if ($users->hasPages())
                     <div class="admin-users-pagination">
-                        {{ $users->links() }}
+                        {{ $users->links('admin.pagination') }}
                     </div>
                 @endif
             @endif

--- a/laravel/tests/Feature/Admin/AdminAccountManagementTest.php
+++ b/laravel/tests/Feature/Admin/AdminAccountManagementTest.php
@@ -31,6 +31,7 @@ class AdminAccountManagementTest extends TestCase
         $response->assertDontSee('Ringkasan Keamanan');
         $response->assertSee('Reset Password');
         $response->assertSee('Menampilkan 15 akun per halaman');
+        $response->assertSee('admin-accounts-table-add-button', false);
     }
 
     public function test_admin_cannot_access_account_management_page(): void

--- a/laravel/tests/Feature/Admin/AdminMonitoringDashboardTest.php
+++ b/laravel/tests/Feature/Admin/AdminMonitoringDashboardTest.php
@@ -73,6 +73,12 @@ class AdminMonitoringDashboardTest extends TestCase
 
         User::factory()->create([
             'role' => User::ROLE_USER,
+            'name' => 'User Online',
+            'last_seen_at' => $now->copy()->subSeconds(30),
+        ]);
+
+        User::factory()->create([
+            'role' => User::ROLE_USER,
             'name' => 'User Idle',
             'last_seen_at' => $now->copy()->subMinutes(8),
         ]);
@@ -95,12 +101,14 @@ class AdminMonitoringDashboardTest extends TestCase
         $response->assertSee('admin-users-kpi-card', false);
         $response->assertSee('admin-users-kpi-card__icon', false);
         $response->assertSee('admin-user-avatar', false);
-        $response->assertSee('Admin Aktif', false);
+        $response->assertSee('User Online', false);
         $response->assertSee('User Idle', false);
         $response->assertSee('User Offline', false);
         $response->assertSee('Online', false);
         $response->assertSee('Idle', false);
         $response->assertSee('Offline', false);
+        $response->assertDontSee('Event Hari Ini', false);
+        $response->assertDontSee('Event 7 Hari', false);
 
         Carbon::setTestNow();
     }
@@ -118,6 +126,12 @@ class AdminMonitoringDashboardTest extends TestCase
 
         User::factory()->create([
             'role' => User::ROLE_USER,
+            'name' => 'Online Person',
+            'last_seen_at' => $now->copy()->subSeconds(30),
+        ]);
+
+        User::factory()->create([
+            'role' => User::ROLE_USER,
             'name' => 'Idle Person',
             'last_seen_at' => $now->copy()->subMinutes(8),
         ]);
@@ -126,10 +140,51 @@ class AdminMonitoringDashboardTest extends TestCase
 
         Livewire::test(AdminUsers::class)
             ->set('status', 'online')
-            ->assertSee('Admin Aktif')
+            ->assertSee('Online Person')
+            ->assertDontSee('Admin Aktif')
             ->assertDontSee('Idle Person');
 
         Carbon::setTestNow();
+    }
+
+    public function test_super_admin_can_delete_regular_user_from_users_page(): void
+    {
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $regular = User::factory()->create([
+            'role' => User::ROLE_USER,
+            'email' => 'delete-me@example.test',
+        ]);
+
+        $this->actingAs($superAdmin);
+
+        Livewire::test(AdminUsers::class)
+            ->assertSee('delete-me@example.test', false)
+            ->assertSee('admin-users-delete-button', false)
+            ->call('deleteUser', $regular->id)
+            ->assertSee('berhasil dihapus');
+
+        $this->assertDatabaseMissing('users', ['id' => $regular->id]);
+    }
+
+    public function test_users_page_delete_action_refuses_admin_family_targets(): void
+    {
+        $superAdmin = User::factory()->create([
+            'role' => User::ROLE_SUPER_ADMIN,
+            'is_active' => true,
+        ]);
+        $adminTarget = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($superAdmin);
+
+        Livewire::test(AdminUsers::class)
+            ->call('deleteUser', $adminTarget->id)
+            ->assertStatus(404);
     }
 
     public function test_admin_usage_filter_by_feature(): void
@@ -366,6 +421,10 @@ class AdminMonitoringDashboardTest extends TestCase
         $response->assertSee('Dokumen Terbaru', false);
         $response->assertSee('Chunks', false);
         $response->assertDontSee('Pipeline Dokumen', false);
+        $response->assertDontSee('admin-documents-type-label', false);
+        $response->assertSee('admin-documents-file-icon--pdf', false);
+        $response->assertSee('admin-status-chip--success', false);
+        $response->assertSee('admin-status-chip--danger', false);
         $response->assertSee('Detail', false);
         $response->assertSee('a.pdf', false);
         $response->assertSee('b.pdf', false);
@@ -480,12 +539,42 @@ class AdminMonitoringDashboardTest extends TestCase
             ->call('showDetail', $document->id)
             ->assertSee('Document Detail')
             ->assertSee('Status AI')
+            ->assertSee('admin-documents-stage-list', false)
             ->assertSee('Metadata ringkas')
+            ->assertSee('Original file')
+            ->assertSee('Uploaded')
+            ->assertSee('Source')
+            ->assertSee('Updated')
             ->assertSee('Chunks')
             ->assertSee('2')
             ->assertSee('Indexed')
             ->assertSee('GOOGLE DRIVE', false)
+            ->assertDontSee('Stored file')
             ->assertDontSee('Hidden chunk content must not be rendered.', false);
+    }
+
+    public function test_admin_documents_detail_marks_empty_index_when_ready_document_has_no_chunks(): void
+    {
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+        $owner = User::factory()->create(['role' => User::ROLE_USER]);
+
+        $document = Document::create([
+            'user_id' => $owner->id,
+            'filename' => 'empty-index.pdf',
+            'original_name' => 'empty-index.pdf',
+            'file_path' => 'docs/empty-index.pdf',
+            'status' => 'ready',
+            'preview_status' => Document::PREVIEW_STATUS_READY,
+            'mime_type' => 'application/pdf',
+            'file_size_bytes' => 4096,
+        ]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(AdminDocuments::class)
+            ->call('showDetail', $document->id)
+            ->assertSee('Index kosong')
+            ->assertDontSee('chunk siap');
     }
 
     public function test_admin_documents_paginates_document_table_at_ten_rows(): void
@@ -517,6 +606,10 @@ class AdminMonitoringDashboardTest extends TestCase
 
         Livewire::test(AdminDocuments::class)
             ->assertSee('Maksimum 10 baris')
+            ->assertSee('Menampilkan', false)
+            ->assertSee('dari 11', false)
+            ->assertSee('admin-pagination__button--active', false)
+            ->assertDontSee('Showing', false)
             ->assertSee('document-row-1.pdf', false)
             ->assertDontSee('document-row-11.pdf', false)
             ->call('gotoPage', 2)

--- a/laravel/tests/Unit/Services/Admin/AdminMetricsServiceTest.php
+++ b/laravel/tests/Unit/Services/Admin/AdminMetricsServiceTest.php
@@ -125,6 +125,36 @@ class AdminMetricsServiceTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_user_presence_summary_can_be_scoped_to_regular_users(): void
+    {
+        $now = Carbon::parse('2026-05-18 12:00:00');
+        Carbon::setTestNow($now);
+
+        User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'last_seen_at' => $now->copy()->subSeconds(30),
+        ]);
+        User::factory()->create([
+            'role' => User::ROLE_USER,
+            'last_seen_at' => $now->copy()->subSeconds(30),
+        ]);
+        User::factory()->create([
+            'role' => User::ROLE_USER,
+            'last_seen_at' => $now->copy()->subMinutes(8),
+        ]);
+
+        $summary = $this->metrics->userPresenceSummary($now, User::ROLE_USER);
+
+        $this->assertSame([
+            'total' => 2,
+            'online' => 1,
+            'idle' => 1,
+            'offline' => 0,
+        ], $summary);
+
+        Carbon::setTestNow();
+    }
+
     public function test_overview_comparisons_use_real_previous_periods(): void
     {
         $now = Carbon::parse('2026-05-18 12:00:00');


### PR DESCRIPTION
## Summary
- Scope /admin/users to regular users, remove noisy columns, and add guarded super-admin-only delete for regular user accounts.
- Standardize admin pagination, integer KPI percentages, document file icons/status chips, and document detail modal metadata.
- Move Account Management create action into the admin-account table header.

## Verification
- php artisan test tests/Feature/Admin/AdminMonitoringDashboardTest.php tests/Feature/Admin/AdminAccountManagementTest.php tests/Unit/Services/Admin/AdminMetricsServiceTest.php
- npm run build
- source python-ai/venv/bin/activate && pytest
- php -d memory_limit=512M vendor/bin/phpunit --stop-on-failure

Note: plain `php artisan test` hit the local 128MB CLI memory limit in Symfony Fileinfo; full PHPUnit passed with 512M.