### PR TITLE
[codex] Fix admin documents panel spacing

### DIFF
--- a/issue/issue-admin-documents-spacing-hotfix-2026-05-20.md
+++ b/issue/issue-admin-documents-spacing-hotfix-2026-05-20.md
@@ -1,0 +1,34 @@
+# Issue: Admin Documents insight-to-table spacing hotfix
+
+## Tujuan
+- Menambahkan jarak visual antara panel Distribusi Tipe / Status Pipeline dan tabel Dokumen Terbaru.
+- Menjaga perubahan tetap kecil agar aman untuk merge dan deploy cepat.
+
+## Scope
+- CSS admin documents.
+
+## Di luar scope
+- Mengubah struktur data dokumen, pipeline ingest, filter, pagination, atau modal detail.
+- Redesign ulang halaman admin documents.
+
+## Risiko
+- Jarak berlebihan pada viewport mobile jika spacing tidak mengikuti ritme layout yang sudah ada.
+
+## Implementasi
+1. Tambahkan margin top khusus untuk `admin-documents-table-panel`.
+2. Jalankan build frontend dan test Laravel admin documents yang relevan.
+3. Commit, push, merge ke `main`, deploy production, lalu smoke check.
+
+## Verifikasi
+- `npm run build`
+- Targeted Laravel admin monitoring/document test
+- `git diff --check`
+- Production smoke check `/up`
+
+## Hasil Verifikasi Lokal
+- `npm run build` lulus.
+- `php artisan test --filter=AdminMonitoringDashboardTest` lulus.
+- `php -d memory_limit=-1 vendor/bin/phpunit` lulus: 555 tests, 2416 assertions.
+- `cd python-ai && source venv/bin/activate && pytest` lulus: 367 tests.
+- `npm audit --audit-level=high` lulus: 0 vulnerabilities.
+- `git diff --check` lulus.

--- a/laravel/resources/css/app.css
+++ b/laravel/resources/css/app.css
@@ -1008,6 +1008,10 @@
         @apply overflow-hidden rounded-lg;
     }
 
+    .admin-documents-table-panel {
+        @apply mt-3;
+    }
+
     .admin-documents-table-panel__body,
     .admin-documents-distribution-panel__body {
         @apply px-3.5 pb-3.5 pt-3;


### PR DESCRIPTION
## Summary
- Adds the missing top spacing between the Admin Documents insight panels and the latest documents table.
- Records the hotfix plan and verification evidence in `issue/`.

## Validation
- `npm run build`
- `php artisan test --filter=AdminMonitoringDashboardTest`
- `php -d memory_limit=-1 vendor/bin/phpunit` (555 tests, 2416 assertions)
- `cd python-ai && source venv/bin/activate && pytest` (367 tests)
- `npm audit --audit-level=high`
- `git diff --check`
