### PR TITLE
Fix memo configuration loading labels

### DIFF
--- a/issue/issue-memo-config-loading-hotfix-2026-05-20.md
+++ b/issue/issue-memo-config-loading-hotfix-2026-05-20.md
@@ -1,0 +1,37 @@
+# Issue: Memo configuration loading label hotfix
+
+## Tujuan
+- Menghilangkan loading ganda pada tombol konfigurasi memo.
+- Menjaga label loading sesuai konteks:
+  - Memo baru menampilkan "Memproses...".
+  - Revisi dari konfigurasi menampilkan "Menyimpan perubahan...".
+
+## Scope
+- Markup tombol konfigurasi memo di workspace memo.
+- Test render tombol agar label loading tidak tercampur antar konteks.
+
+## Di luar scope
+- Mengubah alur generate memo, force-save OnlyOffice, revisi chat, atau struktur data memo.
+- Redesign panel konfigurasi memo.
+
+## Risiko
+- State loading menjadi kosong jika markup tombol tidak lagi cocok dengan Livewire atau Alpine.
+
+## Implementasi
+1. Pisahkan label loading tombol berdasarkan konteks memo baru atau memo aktif.
+2. Tambahkan test render untuk memastikan memo baru hanya membawa label proses dan memo aktif hanya membawa label simpan.
+3. Jalankan test Laravel memo, build frontend, dan verifikasi sebelum merge/deploy.
+
+## Verifikasi
+- `php artisan test --filter=MemoWorkspaceTest`
+- `npm run build`
+- `git diff --check`
+- Full test akhir sebelum merge.
+
+## Hasil Verifikasi Lokal
+- `php artisan test --filter=MemoWorkspaceTest` lulus: 32 tests, 242 assertions.
+- `npm run build` lulus.
+- `npm audit --audit-level=high` lulus: 0 vulnerabilities.
+- `git diff --check` lulus.
+- `php -d memory_limit=-1 vendor/bin/phpunit` lulus: 556 tests, 2422 assertions.
+- `cd python-ai && source venv/bin/activate && pytest` lulus: 367 tests.

--- a/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
+++ b/laravel/resources/views/livewire/memos/partials/memo-chat.blade.php
@@ -330,15 +330,19 @@
                         wire:target="generateConfiguredMemo,generateFromChat"
                         :disabled="memoSyncLoading || $wire.isGenerating"
                         class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-ista-primary px-4 text-[13px] font-semibold text-white shadow-sm transition hover:bg-ista-dark active:translate-y-px disabled:cursor-not-allowed disabled:opacity-50">
-                    <span x-show="memoSyncLoading" x-cloak class="inline-flex items-center gap-2">
-                        <span class="h-3.5 w-3.5 rounded-full border-2 border-white/70 border-t-transparent animate-spin" aria-hidden="true"></span>
-                        <span>Menyimpan perubahan...</span>
-                    </span>
-                    <span x-show="!memoSyncLoading" wire:loading.remove wire:target="generateConfiguredMemo,generateFromChat">{{ $activeMemoId ? 'Buat ulang dari konfigurasi' : 'Buat memo' }}</span>
-                    <span x-show="!memoSyncLoading" wire:loading.inline-flex wire:target="generateConfiguredMemo,generateFromChat" class="items-center gap-2">
-                        <span class="h-3.5 w-3.5 rounded-full border-2 border-white/70 border-t-transparent animate-spin" aria-hidden="true"></span>
-                        <span>Memproses...</span>
-                    </span>
+                    @if ($activeMemoId)
+                        <span data-memo-config-saving-label x-show="memoSyncLoading" x-cloak class="inline-flex items-center gap-2">
+                            <span class="h-3.5 w-3.5 rounded-full border-2 border-white/70 border-t-transparent animate-spin" aria-hidden="true"></span>
+                            <span>Menyimpan perubahan...</span>
+                        </span>
+                        <span data-memo-config-idle-label x-show="!memoSyncLoading">Buat ulang dari konfigurasi</span>
+                    @else
+                        <span data-memo-config-idle-label wire:loading.remove wire:target="generateConfiguredMemo,generateFromChat">Buat memo</span>
+                        <span data-memo-config-processing-label wire:loading.inline-flex wire:target="generateConfiguredMemo,generateFromChat" class="items-center gap-2">
+                            <span class="h-3.5 w-3.5 rounded-full border-2 border-white/70 border-t-transparent animate-spin" aria-hidden="true"></span>
+                            <span>Memproses...</span>
+                        </span>
+                    @endif
                 </button>
             </div>
         @elseif ($activeMemoId)

--- a/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
+++ b/laravel/tests/Feature/Memos/MemoWorkspaceTest.php
@@ -312,6 +312,44 @@ class MemoWorkspaceTest extends TestCase
             ->assertDontSee('wire:click="generateConfiguredMemo"', false);
     }
 
+    public function test_configuration_generate_button_uses_context_specific_loading_label(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        Livewire::actingAs($user)
+            ->test(MemoWorkspace::class)
+            ->assertSee('data-memo-config-processing-label', false)
+            ->assertSee('Memproses...', false)
+            ->assertDontSee('data-memo-config-saving-label', false);
+
+        $memo = Memo::create([
+            'user_id' => $user->id,
+            'title' => 'Memo Revisi Konfigurasi',
+            'memo_type' => 'memo_internal',
+            'file_path' => 'memos/'.$user->id.'/memo-revisi-konfigurasi.docx',
+            'status' => Memo::STATUS_GENERATED,
+            'configuration' => [
+                'number' => 'EVAL-26/IST/YK/05/2026',
+                'recipient' => 'Kepala Unit Layanan',
+                'sender' => 'Kepala Istana Kepresidenan Yogyakarta',
+                'subject' => 'Memo Revisi Konfigurasi',
+                'date' => '20 Mei 2026',
+                'content' => 'Isi memo revisi.',
+                'signatory' => 'Deni Mulyana',
+                'page_size' => 'auto',
+                'page_size_mode' => 'auto',
+            ],
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(MemoWorkspace::class)
+            ->call('loadMemo', $memo->id)
+            ->set('showMemoConfiguration', true)
+            ->assertSee('data-memo-config-saving-label', false)
+            ->assertSee('Menyimpan perubahan...', false)
+            ->assertDontSee('data-memo-config-processing-label', false);
+    }
+
     public function test_generated_memo_chat_thread_is_restored_when_loading_memo_history(): void
     {
         Storage::fake('local');


### PR DESCRIPTION
## Summary
- Split memo configuration button loading labels by context so new memo generation only renders "Memproses...".
- Keep active memo regeneration on the editor-save loading label "Menyimpan perubahan..." and prevent Livewire processing label from rendering in that mode.
- Add Livewire render coverage for both button states.

## Verification
- php artisan test --filter=MemoWorkspaceTest
- npm run build
- npm audit --audit-level=high
- git diff --check
- php -d memory_limit=-1 vendor/bin/phpunit
- cd python-ai && source venv/bin/activate && pytest