### PR TITLE
feat(ista-ai): persona chat lebih hidup (pujian non-template, emoji, markdown)

### DIFF
--- a/python-ai/config/ai_config.yaml
+++ b/python-ai/config/ai_config.yaml
@@ -363,12 +363,12 @@ prompts:
       Anda adalah ISTA AI, asisten kerja internal untuk pegawai Istana Kepresidenan Yogyakarta.
 
       GAYA RESPONS:
-      - Gunakan Bahasa Indonesia yang luwes, hangat, dan nyaman dibaca.
+      - Gunakan Bahasa Indonesia yang luwes, hangat, dan nyaman dibaca, seperti rekan kerja yang asik diajak ngobrol.
       - Bersikap ramah, santai, dan suportif, tetapi tetap fokus dan membantu.
-      - Boleh menggunakan emoji secukupnya untuk membuat percakapan lebih hidup, tetapi jangan berlebihan. Cukup sesekali dan kontekstual, jangan di setiap kalimat.
+      - Gunakan emoji yang relevan sesekali agar percakapan terasa hidup, tetap secukupnya dan profesional. Jangan menaruh emoji di setiap kalimat.
+      - Gunakan format markdown ringan bila membantu keterbacaan: tebalkan istilah atau poin penting, dan pakai daftar saat memang lebih jelas. Jangan berlebihan.
       - Jawab inti persoalan terlebih dahulu. Tambahkan detail hanya bila membantu.
-      - Gunakan struktur seperlunya. Jangan memaksa daftar poin jika bentuk naratif lebih nyaman.
-      - Hindari jargon model, pembuka repetitif, pujian berlebihan, dan nada menggurui.
+      - Hindari jargon model, pembuka repetitif, dan nada menggurui.
       - Tetap terdengar profesional dan ramah, jangan kaku atau birokratis.
 
       ATURAN KERJA:
@@ -380,9 +380,10 @@ prompts:
       IDENTITAS DAN PEMBUAT:
       - Jika ditanya siapa kamu, perkenalkan diri sebagai ISTA AI, asisten kerja internal untuk pegawai Istana Kepresidenan Yogyakarta.
       - Jika ditanya siapa pembuatmu, sebutkan bahwa kamu dibuat oleh Muhammad Hasbi Ash Shiddiqi. Wajib menyebut nama Hasbi.
-      - Boleh memvariasikan jawaban tentang pembuat dengan gaya santai dan sedikit jenaka, misalnya menyebut Hasbi sebagai orang baik, keren, dan calon CEO masa depan (wkwk). Buat variasi sendiri, jangan kaku atau selalu sama.
+      - Saat menyebut pembuat, puji Hasbi dengan tulus memakai kata-katamu sendiri. Buat pujian yang berbeda-beda setiap kali, jangan memakai frasa baku atau template yang sama berulang.
+      - Boleh menyelipkan candaan ringan dan sopan tentang Hasbi agar terasa hangat, tetapi tetap natural dan tidak berlebihan.
       - Boleh menyebutkan Instagram pembuat @hasbi_shdqi dan portofolionya di hasbi1605.github.io bila relevan atau saat ditanya lebih lanjut.
-      - Jaga agar bumbu jenaka tetap sopan dan secukupnya, tidak mengganggu fungsi utama sebagai asisten kerja.
+      - Jaga agar pujian dan candaan tetap sopan dan secukupnya, tidak mengganggu fungsi utama sebagai asisten kerja.
 
   # ============================================
   # RAG PROMPT - Untuk chat dengan dokumen

--- a/python-ai/tests/test_prompt_contracts.py
+++ b/python-ai/tests/test_prompt_contracts.py
@@ -81,9 +81,12 @@ def test_system_prompt_uses_ista_work_assistant_persona():
     assert "ISTA AI" in prompt
     assert "Istana Kepresidenan Yogyakarta" in prompt
     assert "Jawab inti persoalan terlebih dahulu" in prompt
-    # Persona baru: gaya lebih santai dan boleh emoji secukupnya
-    assert "emoji secukupnya" in prompt
-    assert "jangan berlebihan" in prompt
+    # Persona baru: gaya santai, emoji relevan sesekali, dan format markdown ringan
+    assert "emoji yang relevan sesekali" in prompt
+    assert "markdown ringan" in prompt
+    # Pujian pembuat tidak boleh template (harus bervariasi, tanpa frasa baku)
+    assert "kata-katamu sendiri" in prompt
+    assert "berbeda-beda setiap kali" in prompt
     # Identitas pembuat wajib menyebut Hasbi
     assert "Muhammad Hasbi Ash Shiddiqi" in prompt
     assert "@hasbi_shdqi" in prompt


### PR DESCRIPTION
## Ringkasan
Tindak lanjut PR #259. Setelah uji di produksi, jawaban chat masih terasa kaku: pujian ke pembuat terbaca seperti template, tidak ada emoji, dan tidak ada format (bold/list) padahal frontend sudah mendukung markdown. PR ini menyetel ulang persona chat umum agar lebih hidup namun tetap profesional.

## Perubahan
`python-ai/config/ai_config.yaml` → blok `prompts.system.default`:
- **Pujian non-template**: hapus contoh kata pujian yang didikte. Model wajib menyebut Muhammad Hasbi Ash Shiddiqi dan memujinya dengan kata-katanya sendiri, bervariasi tiap jawaban (tidak ada frasa baku berulang).
- **Emoji aktif**: dari pasif "boleh" menjadi arahan "gunakan emoji relevan sesekali", tetap secukupnya dan profesional (tidak tiap kalimat).
- **Markdown ringan**: izinkan bold untuk istilah/poin penting dan list bila membantu; hapus rem "jangan memaksa daftar" yang membuat output datar.
- **Nada lebih luwes**: gaya seperti rekan kerja yang asik diajak ngobrol.

`python-ai/tests/test_prompt_contracts.py`: assertion `test_system_prompt_uses_ista_work_assistant_persona` disesuaikan dengan wording baru.

## Konteks teknis
- Frontend chat sudah render markdown penuh: `resources/js/chat-page.js` (`marked` + `DOMPurify`) dan `chat-messages.blade.php` (`SafeAssistantMarkdown->toHtml` + kelas `prose`). Jadi bold/list akan tampil tanpa perubahan frontend.

## Scope dijaga
- Memo (`prompts.memo_generation`) tetap ketat tanpa markdown/emoji.
- `prompts.rag.document` dan `prompts.summarization.*` tidak diubah.

## Verifikasi
- `pytest tests/test_prompt_contracts.py` → 14 passed.
- Full Python `pytest` → 373 passed.
- Full Laravel `php artisan test` → 573 passed (2560 assertions).
