### PR TITLE
chore(ista-ai): hapus IG & portofolio dari persona pembuat

### DIFF
--- a/python-ai/config/ai_config.yaml
+++ b/python-ai/config/ai_config.yaml
@@ -382,7 +382,6 @@ prompts:
       - Jika ditanya siapa pembuatmu, sebutkan bahwa kamu dibuat oleh Muhammad Hasbi Ash Shiddiqi. Wajib menyebut nama Hasbi.
       - Saat menyebut pembuat, puji Hasbi dengan tulus memakai kata-katamu sendiri. Buat pujian yang berbeda-beda setiap kali, jangan memakai frasa baku atau template yang sama berulang.
       - Boleh menyelipkan candaan ringan dan sopan tentang Hasbi agar terasa hangat, tetapi tetap natural dan tidak berlebihan.
-      - Boleh menyebutkan Instagram pembuat @hasbi_shdqi dan portofolionya di hasbi1605.github.io bila relevan atau saat ditanya lebih lanjut.
       - Jaga agar pujian dan candaan tetap sopan dan secukupnya, tidak mengganggu fungsi utama sebagai asisten kerja.
 
   # ============================================

--- a/python-ai/tests/test_prompt_contracts.py
+++ b/python-ai/tests/test_prompt_contracts.py
@@ -89,8 +89,9 @@ def test_system_prompt_uses_ista_work_assistant_persona():
     assert "berbeda-beda setiap kali" in prompt
     # Identitas pembuat wajib menyebut Hasbi
     assert "Muhammad Hasbi Ash Shiddiqi" in prompt
-    assert "@hasbi_shdqi" in prompt
-    assert "hasbi1605.github.io" in prompt
+    # Instagram/portofolio sudah tidak dicantumkan di persona
+    assert "@hasbi_shdqi" not in prompt
+    assert "hasbi1605.github.io" not in prompt
 
 
 def test_rag_prompt_prioritizes_document_grounding_without_old_bold_rules():


### PR DESCRIPTION
## Ringkasan
Tindak lanjut PR #261. Atas permintaan pemilik repo, Instagram dan portofolio pembuat tidak lagi dicantumkan pada persona.

## Perubahan
`python-ai/config/ai_config.yaml` → blok `prompts.system.default`:
- Hapus baris yang menyebut Instagram `@hasbi_shdqi` dan portofolio `hasbi1605.github.io`.
- Identitas pembuat tetap: wajib menyebut nama Muhammad Hasbi Ash Shiddiqi dengan pujian non-template yang bervariasi.

`python-ai/tests/test_prompt_contracts.py`:
- Assertion disesuaikan: memastikan IG dan portofolio sudah tidak ada di prompt, nama Hasbi tetap wajib.

## Scope dijaga
- Memo, RAG document, dan summarization tidak diubah.

## Verifikasi
- `pytest tests/test_prompt_contracts.py` → 14 passed.
- Full Python `pytest` → 373 passed.
- Full Laravel `php artisan test` → 573 passed (2560 assertions).
